### PR TITLE
fix(security): close code-scanning alerts — GITHUB_TOKEN permissions + manifest URL validation

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -7,6 +7,11 @@ name: Quality
 on:
   workflow_call:
 
+# Reusable workflow: callers (test.yml / release.yml) do not escalate the
+# GITHUB_TOKEN, and the gate suite only ever reads the checkout.
+permissions:
+  contents: read
+
 jobs:
   quality:
     name: Quality gates (Linux)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,11 @@ on:
         required: false
         description: "Tag/branch to build & verify (defaults to the default branch). Does not publish."
 
+# Least privilege baseline for every job; only the `release` job escalates
+# (contents: write) to publish the GitHub Release.
+permissions:
+  contents: read
+
 jobs:
   quality:
     name: Quality gates
@@ -347,7 +352,7 @@ jobs:
           "$lsregister" -dump > /tmp/lsregister-dump.txt
           grep -q 'claimed schemes:.*dsharness' /tmp/lsregister-dump.txt
           grep -q 'claim id:.*com.yeagoo.dsh-desktop dsharness' /tmp/lsregister-dump.txt
-          cat /tmp/lsregister-dump.txt | grep -A4 -B2 dsharness || true
+          grep -A4 -B2 dsharness /tmp/lsregister-dump.txt || true
           pkill -f "deepseek-harness-desktop" 2>/dev/null || true
           open "dsharness://plugin/install?v=1&name=is-odd&source=https%3A%2F%2Fcordis.run%2Fplugins%2Fis-odd"
           sleep 20
@@ -358,7 +363,6 @@ jobs:
 
       - name: Warm open keeps single process
         run: |
-          app="$HOME/Applications/DeepSeek Harness Desktop.app"
           before=$(pgrep -f "DeepSeek Harness Desktop.app/Contents/MacOS/deepseek-harness-desktop" | head -1)
           [ -n "$before" ] || { echo "app not running before warm link"; exit 1; }
           open "dsharness://plugin/install?v=1&name=is-odd&source=https%3A%2F%2Fcordis.run%2Fen%2Fplugins%2Fis-odd"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,11 @@ on:
     tags: ["v*"]
   pull_request:
 
+# Least privilege: every job here only reads the checkout (quality.yml brings
+# its own block); nothing in this workflow needs write access to the repo.
+permissions:
+  contents: read
+
 jobs:
   quality:
     name: Quality gates

--- a/scripts/download-node.ts
+++ b/scripts/download-node.ts
@@ -17,8 +17,7 @@ interface Dist {
   bin: string; // path of the binary inside the archive
 }
 
-function distFor(): Dist {
-  const v = readManifest().nodeVersion;
+function distFor(v: string): Dist {
   const base = `node-v${v}`;
   const map: Record<string, Dist> = {
     "win32-x64": { file: `${base}-win-x64.zip`, bin: `${base}-win-x64/node.exe` },
@@ -104,8 +103,15 @@ function run(cmd: string, args: string[]): void {
 
 const manifest = readManifest();
 const platformKey = `${process.platform}-${process.arch}`;
-const dist = distFor();
 const v = manifest.nodeVersion;
+// The URL below is built from manifest data (CodeQL js/file-access-to-http):
+// constrain it to a strict semver triple before it can reach fetch(). The
+// SHA-256 pin below is the primary integrity anchor; this just prevents a
+// tampered manifest from redirecting the download to an arbitrary path.
+if (!/^(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)$/.test(v)) {
+  fail(`runtime-manifest.json nodeVersion "${v}" is not a semver triple like 24.18.0`);
+}
+const dist = distFor(v);
 // Scratch stays OUTSIDE src-tauri/resources/runtime — everything in there
 // gets bundled into the app. Only the final binary is copied in.
 const scratch = join(tmpDir, "node-dist");

--- a/scripts/gen-icon.ts
+++ b/scripts/gen-icon.ts
@@ -137,8 +137,6 @@ function genTrayTemplate(): void {
   const rgba = Buffer.alloc(S * S * 4);
   for (let y = 0; y < S; y++) {
     for (let x = 0; x < S; x++) {
-      const d = Math.hypot(x - cx, y - cy);
-      const hit = d <= CORE || (d >= R_IN && d <= R_OUT);
       const i = (y * S + x) * 4;
       // 2×2 supersample for smooth edges.
       let a = 0;

--- a/scripts/prepare-harness.ts
+++ b/scripts/prepare-harness.ts
@@ -25,7 +25,6 @@ import { join } from "node:path";
 import { spawnSync } from "node:child_process";
 import {
   repoRoot,
-  runtimeDir,
   harnessDir,
   readManifest,
   fail,

--- a/scripts/verify-preset.ts
+++ b/scripts/verify-preset.ts
@@ -10,7 +10,7 @@
 import { spawn } from "node:child_process";
 import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
-import { harnessDir, tmpDir, nodePath, fail, ok, info } from "./lib/common.ts";
+import { harnessDir, tmpDir, nodePath, fail, ok } from "./lib/common.ts";
 
 const dshHome = join(tmpDir, "preset-e2e-home");
 const id = "e2e-demo";


### PR DESCRIPTION
## Summary

Closes 14 of the 15 open CodeQL code-scanning alerts (all 12 warnings + 3 unused-symbol notes; `codeql.yml` advanced-config note #8 is intentionally kept — languages are split into parallel analyze jobs).

### Workflow permissions (11 × `actions/missing-workflow-permissions`)
- `test.yml`, `quality.yml` (reusable), `release.yml`: top-level `permissions: contents: read`
- `release.yml` `release` job keeps its job-level `contents: write` (publish via softprops/action-gh-release + `gh release upload --clobber`)
- Audited every job/step: checkout/toolchain/cache/setup-node/artifact transfer/cargo vet/npm audit need only read; the cache API is not permission-gated.

### scripts (3 × `js/unused-local-variable` + 1 × `js/file-access-to-http`)
- `download-node.ts`: validate `manifest.nodeVersion` as a strict semver triple (rejects leading zeros / prerelease / path) **before** it flows into the nodejs.org fetch URL; `distFor()` now derives everything from the single validated value. SHA-256 pin remains the primary integrity anchor.
- `gen-icon.ts` / `prepare-harness.ts` / `verify-preset.ts`: drop dead `d`/`hit` variables and unused `runtimeDir`/`info` imports (behavior-verified: tray alpha math unchanged).
- Bonus: two actionlint shellcheck nits in the macos smoke job (useless `cat`, unused var).

## Testing
- `actionlint` clean on all three workflows
- `tsc -p tsconfig.scripts.json` (strict) pass; `node --test scripts/lib/*.test.ts` 7/7
- Reviewed by Codex (full-auto): verdict safe-to-merge, with the `distFor` validation-order fix and shellcheck nits applied by the reviewer.