### PR TITLE
fix(ci): tolerate CRLF in generated table check

### DIFF
--- a/scripts/generate-node-distribution.ts
+++ b/scripts/generate-node-distribution.ts
@@ -7,7 +7,7 @@
 
 import { readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
-import { fail, ok, readManifest, repoRoot } from "./lib/common.ts";
+import { fail, normalizeLineEndings, ok, readManifest, repoRoot } from "./lib/common.ts";
 
 const VERSION_RE = /^(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)$/;
 const outputPath = join(repoRoot, "scripts", "lib", "node-distribution.ts");
@@ -55,7 +55,7 @@ if (process.argv.includes("--check")) {
   } catch (error) {
     fail(`could not read generated node distribution: ${(error as Error).message}`);
   }
-  if (actual !== expected) {
+  if (normalizeLineEndings(actual) !== expected) {
     fail("generated node distribution is stale; run pnpm runtime:node:generate and commit the result");
   }
   ok(`generated node distribution aligned: ${version}`);

--- a/scripts/lib/common.ts
+++ b/scripts/lib/common.ts
@@ -47,6 +47,13 @@ export function info(message: string): void {
   console.log(`  ${message}`);
 }
 
+// Git for Windows may materialize a repository file with CRLF even when the
+// generated source is committed with LF. Use this only for content equality
+// checks; generators should continue emitting LF for a stable repository form.
+export function normalizeLineEndings(text: string): string {
+  return text.replace(/\r\n/g, "\n");
+}
+
 // npm version gate shared by every script that runs `npm ci` in runtime/.
 // runtime/.npmrc relies on strict-allow-scripts/allow-scripts, an npm 11
 // feature: OLDER npm silently ignores unknown config keys (fail open — every

--- a/scripts/lib/lib.test.ts
+++ b/scripts/lib/lib.test.ts
@@ -8,7 +8,7 @@ import { quarantinePresent, parseSltListing } from "./bundle-checks.ts";
 import { isParseableReadyLine } from "./heartbeat-sim.ts";
 import { isPackageRoot } from "./licenses.ts";
 import { nodeRelease } from "./node-distribution.ts";
-import { readManifest } from "./common.ts";
+import { normalizeLineEndings, readManifest } from "./common.ts";
 
 test("node release allowlist stays aligned with the runtime manifest", () => {
   const manifest = readManifest();
@@ -22,6 +22,12 @@ test("node release allowlist stays aligned with the runtime manifest", () => {
     "win32-arm64",
     "win32-x64",
   ]);
+});
+
+test("normalizeLineEndings: generated-file comparisons tolerate Windows checkout CRLF", () => {
+  assert.equal(normalizeLineEndings("one\r\ntwo\r\n"), "one\ntwo\n");
+  assert.equal(normalizeLineEndings("one\ntwo\n"), "one\ntwo\n");
+  assert.equal(normalizeLineEndings("one\rtwo"), "one\rtwo");
 });
 
 test("expectedSigned: platform secret presence decides", () => {


### PR DESCRIPTION
Windows Release jobs checked out the generated Node distribution table with CRLF, while the generator renders LF. Normalize only CRLF during the stale-file equality check, retain LF output, and cover the behavior with a unit test.