### PR TITLE
feat: migrate Desktop marketplace to Cordis v4

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -11,16 +11,21 @@ on:
 permissions:
   security-events: write
 
+concurrency:
+  group: codeql-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   analyze:
     name: Analyze
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
         language: ["javascript-typescript", "actions"]
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4 (SHA-pinned)
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1 (SHA-pinned)
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@f3712979fa5f215279b101dd0a2e3bdfb4353324  # v3 (SHA-pinned, peeled commit)
@@ -37,8 +42,9 @@ jobs:
   analyze-rust:
     name: Analyze (Rust)
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4 (SHA-pinned)
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1 (SHA-pinned)
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@f3712979fa5f215279b101dd0a2e3bdfb4353324  # v3 (SHA-pinned, peeled commit)

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -7,12 +7,17 @@ permissions:
   contents: read
   pull-requests: write
 
+concurrency:
+  group: dependency-review-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   dependency-review:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Checkout
-        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4 (SHA-pinned)
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1 (SHA-pinned)
 
       # Blocks PRs that introduce vulnerable dependencies (any severity) or
       # GPL/AGPL/LGPL licenses. NOTE: requires the repo's Dependency graph to

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -22,16 +22,16 @@ jobs:
     # Keep a wedged hosted runner from holding a PR/release indefinitely.
     timeout-minutes: 45
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4 (SHA-pinned)
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1 (SHA-pinned)
 
       - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c  # stable (version via rust-toolchain.toml)
 
-      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1  # v4 (SHA-pinned, peeled commit)
+      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86  # v6.0.10 (SHA-pinned)
       # Version source of truth: packageManager in package.json (action-setup
-      # v4 reads it when `version` is omitted; mismatches fail loudly).
+      # v6 reads it when `version` is omitted; mismatches fail loudly).
       # MUST precede setup-node: its cache step needs `pnpm store path`.
 
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4 (SHA-pinned)
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v7.0.0 (SHA-pinned)
         with:
           node-version-file: .nvmrc
 
@@ -161,8 +161,9 @@ jobs:
   quality-windows:
     name: Quality gates (Windows host)
     runs-on: windows-latest
+    timeout-minutes: 30
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4 (SHA-pinned)
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1 (SHA-pinned)
 
       - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c  # stable (version via rust-toolchain.toml)
 

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -16,6 +16,9 @@ jobs:
   quality:
     name: Quality gates (Linux)
     runs-on: ubuntu-latest
+    # A healthy full gate has historically completed well below this bound.
+    # Keep a wedged hosted runner from holding a PR/release indefinitely.
+    timeout-minutes: 45
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4 (SHA-pinned)
 
@@ -32,6 +35,9 @@ jobs:
 
       # Tauri shell system deps (compiling src-tauri requires webkit2gtk-4.1).
       - name: Install Tauri system dependencies
+        # Hosted apt mirrors occasionally stall; fail with a specific step
+        # rather than consuming the full job timeout.
+        timeout-minutes: 15
         run: |
           sudo apt-get update
           sudo apt-get install -y libwebkit2gtk-4.1-dev libayatana-appindicator3-dev librsvg2-dev patchelf
@@ -68,6 +74,9 @@ jobs:
           cargo clippy --target aarch64-apple-darwin --manifest-path crates/dsh-sidecar/Cargo.toml --all-targets -- -D warnings
 
       - name: "Tauri shell tests (nextest: state machine + proptests)"
+        # Unit/property tests are normally short after the preceding builds.
+        # A step bound makes a wedged test process diagnosable from the log.
+        timeout-minutes: 15
         run: |
           # tauri-build asserts the bundle resources path exists; the smoke
           # job stages the real runtime — the unit job only needs the dir.

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -15,7 +15,9 @@ permissions:
 jobs:
   quality:
     name: Quality gates (Linux)
-    runs-on: ubuntu-latest
+    # Keep the Tauri system-package contract stable across runner image
+    # migrations; update this pin deliberately after validating apt sources.
+    runs-on: ubuntu-24.04
     # A healthy full gate has historically completed well below this bound.
     # Keep a wedged hosted runner from holding a PR/release indefinitely.
     timeout-minutes: 45
@@ -35,12 +37,31 @@ jobs:
 
       # Tauri shell system deps (compiling src-tauri requires webkit2gtk-4.1).
       - name: Install Tauri system dependencies
-        # Hosted apt mirrors occasionally stall; fail with a specific step
-        # rather than consuming the full job timeout.
+        # GitHub's Ubuntu image prefers azure.archive.ubuntu.com through a
+        # mirror list. That endpoint has intermittently accepted connections
+        # without serving indexes, so prefer the runner image's official
+        # archive/security fallbacks and bound every network attempt.
         timeout-minutes: 15
         run: |
-          sudo apt-get update
-          sudo apt-get install -y libwebkit2gtk-4.1-dev libayatana-appindicator3-dev librsvg2-dev patchelf
+          test -f /etc/apt/apt-mirrors.txt
+          grep -q '^http://azure\.archive\.ubuntu\.com/ubuntu/' /etc/apt/apt-mirrors.txt
+          grep -q '^https://archive\.ubuntu\.com/ubuntu/' /etc/apt/apt-mirrors.txt
+          sudo sed -i '\|^http://azure\.archive\.ubuntu\.com/ubuntu/|d' /etc/apt/apt-mirrors.txt
+          if grep -q '^http://azure\.archive\.ubuntu\.com/ubuntu/' /etc/apt/apt-mirrors.txt; then
+            echo 'Azure apt mirror remained enabled after sanitization' >&2
+            exit 1
+          fi
+
+          apt_options=(
+            -o Acquire::Retries=3
+            -o Acquire::http::Timeout=20
+            -o Acquire::https::Timeout=20
+            -o Acquire::Languages=none
+            -o Dpkg::Use-Pty=0
+          )
+          sudo apt-get "${apt_options[@]}" update
+          sudo DEBIAN_FRONTEND=noninteractive apt-get "${apt_options[@]}" install -y \
+            libwebkit2gtk-4.1-dev libayatana-appindicator3-dev librsvg2-dev patchelf
 
       - name: Install cargo tools (nextest, llvm-cov, deny, vet)
         uses: taiki-e/install-action@82cd3e7658a6f96c86c0234aeeda1748937cb0a1  # v2 (SHA-pinned)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,12 @@ on:
 permissions:
   contents: read
 
+# Never run two expensive release builds for the same ref concurrently. A
+# queued manual verification must not cancel an in-flight signed tag build.
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   # The desktop deliberately refuses CDN redirects for remote preset archives.
   # Keep this independent of native builds: a backend contract regression must
@@ -31,11 +37,11 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 2
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4 (SHA-pinned)
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1 (SHA-pinned)
         with:
           ref: ${{ github.event.inputs.tag || github.ref }}
 
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4 (SHA-pinned)
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v7.0.0 (SHA-pinned)
         with:
           node-version-file: .nvmrc
 
@@ -62,8 +68,9 @@ jobs:
     name: Tag gate (tag must be on main)
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4 (SHA-pinned)
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1 (SHA-pinned)
         with:
           ref: ${{ github.ref }}
 
@@ -83,10 +90,11 @@ jobs:
     name: Heartbeat load soak (Linux, 5min)
     needs: quality
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4 (SHA-pinned)
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1 (SHA-pinned)
 
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4 (SHA-pinned)
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v7.0.0 (SHA-pinned)
         with:
           node-version-file: .nvmrc
           cache: npm
@@ -146,8 +154,9 @@ jobs:
             # the macOS build and forces a conscious decision.
             updaterGlob: target/release/bundle/macos/*.app.tar.gz.sig
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 120
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4 (SHA-pinned)
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1 (SHA-pinned)
         with:
           ref: ${{ github.event.inputs.tag || github.ref }}
 
@@ -160,12 +169,12 @@ jobs:
           # step stays cold.
           cache-directories: crates/dsh-sidecar/target
 
-      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1  # v4 (SHA-pinned, peeled commit)
+      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86  # v6.0.10 (SHA-pinned)
       # Version source of truth: packageManager in package.json (action-setup
-      # v4 reads it when `version` is omitted; mismatches fail loudly).
+      # v6 reads it when `version` is omitted; mismatches fail loudly).
       # MUST precede setup-node: its cache step needs `pnpm store path`.
 
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4 (SHA-pinned)
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v7.0.0 (SHA-pinned)
         with:
           node-version-file: .nvmrc
           # One cache per job: the runtime npm ci (prepare-harness) is the
@@ -262,7 +271,7 @@ jobs:
       STORE_BUILD: "1"
       CARGO_TARGET_DIR: ${{ github.workspace }}/target
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4 (SHA-pinned)
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1 (SHA-pinned)
         with:
           ref: ${{ github.event.inputs.tag || github.ref }}
 
@@ -276,9 +285,9 @@ jobs:
             src-tauri -> target
           cache-directories: crates/dsh-sidecar/target
 
-      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1  # v4 (SHA-pinned, peeled commit)
+      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86  # v6.0.10 (SHA-pinned)
 
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4 (SHA-pinned)
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v7.0.0 (SHA-pinned)
         with:
           node-version-file: .nvmrc
           cache: npm
@@ -506,14 +515,15 @@ jobs:
     # builds, so waiting on it adds no wall time.
     needs: [build, soak, tag-gate, windows-deep-link-smoke, macos-deep-link-smoke, preset-download-contract]
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4 (SHA-pinned)
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1 (SHA-pinned)
         with:
           ref: ${{ github.ref }}
 
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4 (SHA-pinned)
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v7.0.0 (SHA-pinned)
         with:
           node-version-file: .nvmrc
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,11 @@ on:
         type: string
         required: false
         description: "Tag/branch to build & verify (defaults to the default branch). Does not publish."
+      preset_slug:
+        type: string
+        required: false
+        default: code
+        description: "Public Cordis preset slug that must return a direct ZIP response."
 
 # Least privilege baseline for every job; only the `release` job escalates
 # (contents: write) to publish the GitHub Release. Also covers the new
@@ -17,6 +22,28 @@ permissions:
   contents: read
 
 jobs:
+  # The desktop deliberately refuses CDN redirects for remote preset archives.
+  # Keep this independent of native builds: a backend contract regression must
+  # block tag publication, while workflow_dispatch can still collect Windows
+  # build and installer evidence for diagnosis.
+  preset-download-contract:
+    name: Cordis preset direct ZIP contract
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4 (SHA-pinned)
+        with:
+          ref: ${{ github.event.inputs.tag || github.ref }}
+
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4 (SHA-pinned)
+        with:
+          node-version-file: .nvmrc
+
+      - name: Require direct HTTP 200 application/zip
+        run: node scripts/verify-cordis-preset-download.ts
+        env:
+          CORDIS_PRESET_SLUG: ${{ github.event.inputs.preset_slug || 'code' }}
+
   quality:
     name: Quality gates
     uses: ./.github/workflows/quality.yml
@@ -477,7 +504,7 @@ jobs:
     # soak is a publish gate: a heartbeat regression must surface before
     # release, and the 5-minute soak overlaps the (much longer) platform
     # builds, so waiting on it adds no wall time.
-    needs: [build, soak, tag-gate, windows-deep-link-smoke, macos-deep-link-smoke]
+    needs: [build, soak, tag-gate, windows-deep-link-smoke, macos-deep-link-smoke, preset-download-contract]
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,6 +11,12 @@ on:
 permissions:
   contents: read
 
+# A newer commit supersedes every check from the previous PR revision. Avoid
+# keeping obsolete cross-platform builds alive for hours.
+concurrency:
+  group: test-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   quality:
     name: Quality gates
@@ -23,17 +29,18 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-14]
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 20
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4 (SHA-pinned)
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1 (SHA-pinned)
 
       - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c  # stable (version via rust-toolchain.toml)
 
-      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1  # v4 (SHA-pinned, peeled commit)
+      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86  # v6.0.10 (SHA-pinned)
       # Version source of truth: packageManager in package.json (action-setup
-      # v4 reads it when `version` is omitted; mismatches fail loudly).
+      # v6 reads it when `version` is omitted; mismatches fail loudly).
       # MUST precede setup-node: its cache step needs `pnpm store path`.
 
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4 (SHA-pinned)
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v7.0.0 (SHA-pinned)
         with:
           node-version-file: .nvmrc
           # The smoke job never runs pnpm — caching its store dir would fail

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -731,6 +731,7 @@ dependencies = [
  "getrandom 0.2.17",
  "proptest",
  "reqwest 0.12.28",
+ "semver",
  "serde",
  "serde_json",
  "tauri",
@@ -742,6 +743,7 @@ dependencies = [
  "tauri-plugin-updater",
  "tauri-plugin-window-state",
  "url",
+ "windows-sys 0.61.2",
  "zip 2.4.2",
 ]
 

--- a/README.en.md
+++ b/README.en.md
@@ -48,10 +48,11 @@ pnpm bundled (**no system pnpm needed**), live install logs, and cancel
 
 On a cordis.run plugin page, "Install in desktop app" opens
 `dsharness://plugin/install?v=1&name=<package>&source=<plugin-page>`. The
-desktop shell validates the URL strictly in Rust, asks for confirmation, and
-only then starts the install. Older desktop builds and market pages without
-the deep-link button can still use copy-paste package names. Command-line
-equivalent (for power users):
+desktop shell validates the URL strictly in Rust, uses it only to locate the
+canonical marketplace slug, refetches the detail and current `entryRevision`,
+and then asks for installation confirmation. Older desktop builds and market
+pages without the deep-link button can still use copy-paste package names.
+Command-line equivalent (for power users):
 
 ```bash
 # macOS

--- a/README.md
+++ b/README.md
@@ -97,6 +97,26 @@ CORDIS_RUN_API=http://127.0.0.1:<port>/api/v1 pnpm tauri dev
 禁用构建脚本、校验 lockfile integrity，并将插件保持为“待激活”。安装不会自动
 启用，需在插件列表中显式点击 **Activate**，随后重启 Harness。
 
+### cordis.run 生产发布 smoke（只读）
+
+每次 Cordis 后端部署或 Desktop 发版前，运行以下无 mutation 的验证：
+
+```bash
+pnpm verify:cordis-preset
+pnpm verify:cordis-market
+```
+
+第二个命令固定请求 `platform=desktop`，要求直接 JSON、ETag/304 和 JSON 404。
+在有已审核公开条目后，可额外验证它的嵌套 source / integrity / engine wire
+shape（仍不安装）：
+
+```bash
+CORDIS_MARKET_PROBE_SLUG=<reviewed-public-slug> pnpm verify:cordis-market
+```
+
+Microsoft Store 构建仍只允许 `src-tauri/store-curated-plugins.json` 的审核快照；
+通过生产 probe 不等于获得 Store allowlist 权限。
+
 > `~/.cargo` 不可写时：`export CARGO_HOME=<repo>/.tmp/cargo-home`。
 
 ### 质量门

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Harness 的技能、工具、模型路由、MCP、预设——**全部是 Cordis
 
 **安装**：设置页「插件（用户安装）」输入 npm 包名即装即卸——桌面层调用官方 `dsh plugin --profile web add/remove`，pinned CLI 与 pnpm 均随包携带（**无需系统 pnpm**），带实时安装日志与取消（整棵 node → dsh → pnpm 进程树一并清理）。
 
-从 cordis.run 插件详情页点「安装到桌面版」会用 `dsharness://plugin/install?v=1&name=<包名>&source=<插件页>` 唤起桌面版；桌面版在 Rust 侧严格校验协议后弹出确认框，用户确认后才开始安装（旧版本桌面版或不支持的市场页仍可复制包名粘贴安装）。命令行等价路径（高级用法）：
+从 cordis.run 插件详情页点「安装到桌面版」会用 `dsharness://plugin/install?v=1&name=<包名>&source=<插件页>` 唤起桌面版；桌面版在 Rust 侧严格校验协议后，仅将链接定位到对应市场 slug，并重新拉取详情、核对当前 `entryRevision` 与嵌套 source，再由用户确认安装（旧版本桌面版或不支持的市场页仍可复制包名粘贴安装）。命令行等价路径（高级用法）：
 
 ```bash
 # macOS
@@ -85,13 +85,17 @@ pnpm tauri dev                                    # 桌面开发模式
 
 ### cordis.run 本地 fixture（市场联调）
 
-真 API 上线前，可用仓库内置 fixture 联调市场功能（数据契约与真实 API 一致：嵌套 `source`、`{zh,en}` 描述、cursor 分页字段 `page.cursor/hasMore/limit` + `count`）：
+真 API 上线前，可用仓库内置 fixture 联调市场功能（数据契约与真实 API 一致：嵌套 `source`、`{zh,en}` 描述、cursor 分页字段 `page.cursor/hasMore/limit` + `count`、ETag/304 与 JSON 404 错误）：
 
 ```bash
 node tools/cordis-fixture/fixture-server.mjs
 # 输出端口后，在另一个终端设置后启动桌面调试构建：
 CORDIS_RUN_API=http://127.0.0.1:<port>/api/v1 pnpm tauri dev
 ```
+
+市场安装只接受可验证的 npm 嵌套 source；Desktop 会重新核对详情修订、
+禁用构建脚本、校验 lockfile integrity，并将插件保持为“待激活”。安装不会自动
+启用，需在插件列表中显式点击 **Activate**，随后重启 Harness。
 
 > `~/.cargo` 不可写时：`export CARGO_HOME=<repo>/.tmp/cargo-home`。
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -13,6 +13,7 @@
 ```bash
 pnpm release:preflight     # 版本对齐 + lock + checksum 表 + npm 边界 + tag 绑定演练
 pnpm check && pnpm check:scripts
+CORDIS_PRESET_SLUG=code pnpm verify:cordis-preset
 cargo clippy --workspace --all-targets -- -D warnings
 cargo nextest run --workspace  # 或按 crate 分别跑
 cargo vet --locked && cargo deny check
@@ -45,6 +46,19 @@ git push origin v0.2.1
 4. `release`：tag 绑定 preflight（`--expect-tag`）→ 下载制品 →
    **draft** GitHub Release（`files: artifacts/**/*`）。
 
+### 3a. cordis.run preset 直返 ZIP 契约
+
+`preset-download-contract` 在每次 tag 发布和手动演练时，对
+`https://cordis.run/api/presets/<slug>/download` 发起不跟随重定向的请求。
+它只接受 **HTTP 200**、无 `Location`、且 `Content-Type` 为
+`application/zip`（允许 MIME 参数）；3xx/CDN 跳转、HTML 错页或其他内容类型
+都会失败。该 job 是 tag 发布门禁，但刻意不作为原生构建的依赖：后端回归时仍可
+用 `workflow_dispatch` 留存 Windows/MSIX 的构建和安装验证证据。
+
+探针不写入或安装任何归档；真正的 Desktop 下载仍需经过 Rust 侧的无重定向、大小、
+归档检查与用户确认。默认公开样本是 `code`；在手动演练中可通过
+`preset_slug` 输入（或本地 `CORDIS_PRESET_SLUG`）选择另一个合法 slug。
+
 ### 3b. Microsoft Store MSIX 构建
 
 `build-msix` job 与双平台 build 并行，仅发布/演练时运行：
@@ -60,6 +74,21 @@ git push origin v0.2.1
 - Store 产品身份固定在
   `src-tauri/gen/windows/AppxManifest.xml.template` 与 `bundle.config.json`；
   如 Partner Center 重建产品，必须同步这两处。
+
+### 3c. npm 发布所有权边界
+
+根 `package.json` 必须保持 `private: true`，它是 Desktop 构建工作区，不是 npm
+发布通道；`release:preflight` 会拒绝移除此保护。已确认的组织决策是：若将来确有
+独立的公开 npm 制品，所有权必须归 `web-casa`，并使用一个经单独评审的
+`@web-casa/<package>` 名称。
+
+首次发布前，负责人必须完成并记录以下事项：确认准确的 scoped 名称与 npm 组织
+成员关系；为发布者启用 npm 2FA；将 GitHub 仓库配置为 npm Trusted Publishing
+（OIDC，优先）或使用仅限该包、短期且最小权限的 granular token；以实际发布身份
+复核 `npm owner ls`/包访问权限。Trusted Publishing 的专用发布 workflow 必须在
+GitHub-hosted runner 上运行、申请 `id-token: write`，且其仓库和 workflow 文件名
+与 npm 设置精确一致。不得假定当前未 scoped 的根包名可用或可转移，更不得把本
+Desktop 工作区直接改为公开发布。
 
 ## 4. 签名状态（verify-signing 语义）
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -41,8 +41,11 @@ DSH Desktop 是社区桌面打包层：Tauri 2 壳 + Rust `dsh-sidecar`
 - **Deep link 边界**：`dsharness://plugin/install` 与
   `dsharness://preset/install` 都是外部输入。Rust 侧对
   scheme/host/path/协议版本/包名或下载 URL/来源页逐项重校验后才生成「待确认
-  安装请求」；未确认前不会 spawn 任何进程或下载预设，非法链接直接丢弃且不会弹窗。
-- **CSP 与桌面 IPC**：`withGlobalTauri: false`；32 个桌面命令经 AppManifest
+  安装请求」；插件链接只定位经 Rust 校验的市场 slug，仍须重新拉取详情并确认
+  `entryRevision` 后才能进入受控安装；预设链接只接受直出
+  `https://cordis.run/api/presets/<slug>/download` 的 200 zip 响应且不跟随重定向。
+  未确认前不会 spawn 任何进程或下载预设，非法链接直接丢弃且不会弹窗。
+- **CSP 与桌面 IPC**：`withGlobalTauri: false`；35 个桌面命令经 AppManifest
   ACL 仅授权 bootstrap 窗口。
 
 ## 已知边界（请如实预期）

--- a/STORE.md
+++ b/STORE.md
@@ -47,9 +47,9 @@ installed in the Store build are restricted to the reviewed cordis.run list.
 
 **Search terms:** deepseek harness, dsh, cordis, ai agent, desktop harness
 
-**Support contact:** contact@dsharness.app
-**Website:** https://dsharness.app
-**Privacy policy:** https://dsharness.app/privacy
+**Support contact:** https://dsharness.app/support/
+**Website:** https://dsharness.app/windows/
+**Privacy policy:** https://dsharness.app/privacy/
 
 ### 简体中文
 
@@ -96,12 +96,16 @@ Microsoft Store 版通过 Microsoft Store 更新；插件安装仅允许 cordis.
 
 ## Package upload
 
-1. Run the `Release` workflow (`workflow_dispatch` or `v*` tag).
-2. Download artifacts:
+1. Verify the public Store URLs return HTML successfully:
+   - `https://dsharness.app/windows/`
+   - `https://dsharness.app/privacy/`
+   - `https://dsharness.app/support/`
+2. Run the `Release` workflow (`workflow_dispatch` or `v*` tag).
+3. Download artifacts:
    - `dsh-desktop-store-msix-x64`
    - `dsh-desktop-store-msix-arm64`
-3. Extract and upload the two `.msix` packages on the Packages page.
-4. Do **not** upload the MSIX files to GitHub Releases; they are Store-only.
+4. Extract and upload the two `.msix` packages on the Packages page.
+5. Do **not** upload the MSIX files to GitHub Releases; they are Store-only.
 
 ## Post-publish updates
 

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "icons": "node scripts/gen-icon.ts && tauri icon src-tauri/icons/icon-source.png --output src-tauri/icons",
     "test:scripts": "node --test \"scripts/lib/*.test.ts\"",
     "verify:cordis-preset": "node scripts/verify-cordis-preset-download.ts",
+    "verify:cordis-market": "node scripts/verify-cordis-market-api.ts",
     "tauri:windows:build": "tauri-windows-bundle build --runner pnpm",
     "verify:sideload": "node scripts/verify-sideload.ts"
   },

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "release:preflight": "node scripts/release-preflight.ts",
     "icons": "node scripts/gen-icon.ts && tauri icon src-tauri/icons/icon-source.png --output src-tauri/icons",
     "test:scripts": "node --test \"scripts/lib/*.test.ts\"",
+    "verify:cordis-preset": "node scripts/verify-cordis-preset-download.ts",
     "tauri:windows:build": "tauri-windows-bundle build --runner pnpm",
     "verify:sideload": "node scripts/verify-sideload.ts"
   },

--- a/scripts/lib/cordis-market-contract.test.ts
+++ b/scripts/lib/cordis-market-contract.test.ts
@@ -1,0 +1,139 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import {
+  CORDIS_MARKET_API_ORIGIN,
+  DEFAULT_MISSING_MARKET_SLUG,
+  desktopInstallWireProblem,
+  directJsonErrorResponseProblem,
+  directJsonResponseProblem,
+  isJsonContentType,
+  isValidCordisMarketSlug,
+  marketDetailUrl,
+  marketErrorResponseProblem,
+  marketListResponseProblem,
+  marketListUrl,
+  notModifiedResponseProblem,
+} from "./cordis-market-contract.ts";
+
+const INTEGRITY = `sha512-${Buffer.alloc(64).toString("base64")}`;
+const CANDIDATE_DSH_ENGINE = ">=0.1.0-rc.7 <0.2.0";
+
+function validDetail(): Record<string, unknown> {
+  return {
+    slug: "cordis-market",
+    name: "Cordis Market",
+    entryRevision: "2026-08-19T00:00:00.000Z-deadbeef",
+    description: { zh: "中文说明", en: "English description" },
+    source: {
+      type: "npm",
+      packageName: "@cordis-mp/web",
+      version: "0.1.0",
+      integrity: INTEGRITY,
+      registry: "https://registry.npmjs.org",
+      tarball: "https://registry.npmjs.org/@cordis-mp/web/-/web-0.1.0.tgz",
+    },
+    platforms: ["web", "desktop"],
+    engines: { dsh: CANDIDATE_DSH_ENGINE },
+    blocked: false,
+    deprecated: false,
+  };
+}
+
+test("Cordis market URLs remain constrained to desktop production API", () => {
+  assert.equal(isValidCordisMarketSlug("cordis-market"), true);
+  assert.equal(isValidCordisMarketSlug(DEFAULT_MISSING_MARKET_SLUG), true);
+  assert.equal(isValidCordisMarketSlug("../escape"), false);
+  assert.equal(isValidCordisMarketSlug("Cordis"), false);
+  assert.equal(isValidCordisMarketSlug("a?b"), false);
+  assert.equal(
+    marketListUrl(1).toString(),
+    `${CORDIS_MARKET_API_ORIGIN}/plugins?platform=desktop&limit=1`,
+  );
+  assert.equal(
+    marketDetailUrl("cordis-market").toString(),
+    `${CORDIS_MARKET_API_ORIGIN}/plugins/cordis-market`,
+  );
+  assert.throws(() => marketListUrl(0), /1\.\.100/);
+  assert.throws(() => marketDetailUrl("../escape"), /invalid Cordis market slug/);
+});
+
+test("Cordis market response headers reject redirects and non-JSON bodies", () => {
+  const endpoint = marketListUrl(1);
+  assert.equal(isJsonContentType("application/json; charset=utf-8"), true);
+  assert.equal(isJsonContentType("text/html"), false);
+  assert.equal(
+    directJsonResponseProblem({
+      endpoint,
+      status: 200,
+      statusText: "OK",
+      contentType: "application/json; charset=utf-8",
+      location: null,
+    }),
+    null,
+  );
+  assert.match(
+    directJsonResponseProblem({
+      endpoint,
+      status: 307,
+      statusText: "Temporary Redirect",
+      contentType: null,
+      location: "https://cdn.example/catalog",
+    }) ?? "",
+    /got 307.*Location/,
+  );
+  assert.match(
+    directJsonErrorResponseProblem({
+      endpoint: marketDetailUrl(DEFAULT_MISSING_MARKET_SLUG),
+      status: 404,
+      statusText: "Not Found",
+      contentType: "application/json",
+      location: null,
+      expectedStatus: 404,
+    }) ?? "",
+    /^$/,
+  );
+  assert.equal(
+    notModifiedResponseProblem({ endpoint, status: 304, statusText: "Not Modified", location: null }),
+    null,
+  );
+});
+
+test("Cordis list and JSON 404 retain the v4 response shape", () => {
+  const body = {
+    schemaVersion: 1,
+    catalogRevision: "revision-1",
+    updated: "2026-08-19T00:00:00.000Z",
+    count: 0,
+    categories: {},
+    items: [],
+    page: { cursor: null, hasMore: false, limit: 1 },
+  };
+  assert.equal(marketListResponseProblem(body), null);
+  assert.equal(marketListResponseProblem({ ...body, page: { ...body.page, limit: 101 } }), "market list page.limit must be an integer in 1..100");
+  assert.equal(marketErrorResponseProblem({ error: { code: "NOT_FOUND", message: "missing" } }, "NOT_FOUND"), null);
+  assert.match(marketErrorResponseProblem({ error: { code: "OTHER", message: "missing" } }, "NOT_FOUND") ?? "", /NOT_FOUND/);
+});
+
+test("optional real-plugin probe shape matches Desktop's strict nested-source boundary", () => {
+  assert.equal(desktopInstallWireProblem(validDetail()), null);
+  assert.equal(
+    desktopInstallWireProblem({ ...validDetail(), engines: { dsh: ">=0.1.0-rc.6 <0.2.0" } }),
+    null,
+  );
+  const malformedIntegrity = validDetail();
+  assert.match(
+    desktopInstallWireProblem({
+      ...malformedIntegrity,
+      source: { ...(malformedIntegrity.source as Record<string, unknown>), integrity: "sha256-bad" },
+    }) ?? "",
+    /canonical sha512/,
+  );
+  assert.match(
+    desktopInstallWireProblem({ ...validDetail(), platforms: ["web"] }) ?? "",
+    /include desktop/,
+  );
+  assert.match(
+    desktopInstallWireProblem({ ...validDetail(), engines: { dsh: "^0.2.0" } }) ?? "",
+    /engines\.dsh must be a standard/,
+  );
+});

--- a/scripts/lib/cordis-market-contract.test.ts
+++ b/scripts/lib/cordis-market-contract.test.ts
@@ -2,7 +2,7 @@ import assert from "node:assert/strict";
 import { test } from "node:test";
 import {
   CORDIS_MARKET_API_ORIGIN,
-  DEFAULT_MISSING_MARKET_SLUG,
+  MISSING_MARKET_SLUG_PREFIX,
   desktopInstallWireProblem,
   directJsonErrorResponseProblem,
   directJsonResponseProblem,
@@ -41,7 +41,11 @@ function validDetail(): Record<string, unknown> {
 
 test("Cordis market URLs remain constrained to desktop production API", () => {
   assert.equal(isValidCordisMarketSlug("cordis-market"), true);
-  assert.equal(isValidCordisMarketSlug(DEFAULT_MISSING_MARKET_SLUG), true);
+  assert.equal(isValidCordisMarketSlug(MISSING_MARKET_SLUG_PREFIX), true);
+  assert.equal(
+    isValidCordisMarketSlug(`${MISSING_MARKET_SLUG_PREFIX}-00000000-0000-4000-8000-000000000000`),
+    true,
+  );
   assert.equal(isValidCordisMarketSlug("../escape"), false);
   assert.equal(isValidCordisMarketSlug("Cordis"), false);
   assert.equal(isValidCordisMarketSlug("a?b"), false);
@@ -83,7 +87,7 @@ test("Cordis market response headers reject redirects and non-JSON bodies", () =
   );
   assert.match(
     directJsonErrorResponseProblem({
-      endpoint: marketDetailUrl(DEFAULT_MISSING_MARKET_SLUG),
+      endpoint: marketDetailUrl(`${MISSING_MARKET_SLUG_PREFIX}-missing`),
       status: 404,
       statusText: "Not Found",
       contentType: "application/json",

--- a/scripts/lib/cordis-market-contract.ts
+++ b/scripts/lib/cordis-market-contract.ts
@@ -5,7 +5,7 @@
 // Desktop gate for source, integrity, engine, and activation safety.
 
 export const CORDIS_MARKET_API_ORIGIN = "https://cordis.run/api/v1";
-export const DEFAULT_MISSING_MARKET_SLUG = "cordis-production-probe-missing";
+export const MISSING_MARKET_SLUG_PREFIX = "cordis-production-probe-missing";
 
 const MARKET_SLUG_RE = /^[a-z0-9][a-z0-9-]{0,127}$/;
 const PACKAGE_NAME_RE = /^(@[a-z0-9-~][a-z0-9-._~]*\/)?[a-z0-9-~][a-z0-9-._~]*$/;

--- a/scripts/lib/cordis-market-contract.ts
+++ b/scripts/lib/cordis-market-contract.ts
@@ -1,0 +1,187 @@
+// Pure contract helpers for the public Cordis market API release probe.
+//
+// These helpers observe the production wire contract only. They do not make
+// an installation decision; src-tauri/src/market.rs remains the authoritative
+// Desktop gate for source, integrity, engine, and activation safety.
+
+export const CORDIS_MARKET_API_ORIGIN = "https://cordis.run/api/v1";
+export const DEFAULT_MISSING_MARKET_SLUG = "cordis-production-probe-missing";
+
+const MARKET_SLUG_RE = /^[a-z0-9][a-z0-9-]{0,127}$/;
+const PACKAGE_NAME_RE = /^(@[a-z0-9-~][a-z0-9-._~]*\/)?[a-z0-9-~][a-z0-9-._~]*$/;
+const EXACT_SEMVER_RE = /^(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)(?:-[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$/;
+const SHA512_INTEGRITY_RE = /^sha512-[A-Za-z0-9+/]{86}==$/;
+const DSH_ENGINE_RE = /^>=\s*(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)(?:-[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?(?:\s+(?:<|<=)\s*(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)(?:-[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?)?$/;
+
+type JsonRecord = Record<string, unknown>;
+
+function isRecord(value: unknown): value is JsonRecord {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function nonEmptyString(value: unknown): value is string {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+function directResponseProblem(args: {
+  endpoint: URL;
+  status: number;
+  statusText: string;
+  contentType: string | null;
+  location: string | null;
+  expectedStatus: number;
+}): string | null {
+  const { endpoint, status, statusText, contentType, location, expectedStatus } = args;
+  if (status !== expectedStatus) {
+    const redirectHint = location === null ? "" : ` (Location: ${JSON.stringify(location)})`;
+    return `expected direct HTTP ${expectedStatus} JSON from ${endpoint}, got ${status}` +
+      `${statusText ? ` ${statusText}` : ""}${redirectHint}`;
+  }
+  if (location !== null) {
+    return `expected no redirect Location from ${endpoint}, got ${JSON.stringify(location)}`;
+  }
+  if (!isJsonContentType(contentType)) {
+    return `expected Content-Type application/json from ${endpoint}, got ${JSON.stringify(contentType)}`;
+  }
+  return null;
+}
+
+export function isValidCordisMarketSlug(value: string): boolean {
+  return MARKET_SLUG_RE.test(value);
+}
+
+export function marketListUrl(limit = 1): URL {
+  if (!Number.isSafeInteger(limit) || limit < 1 || limit > 100) {
+    throw new Error(`market limit must be an integer in 1..100: ${JSON.stringify(limit)}`);
+  }
+  const url = new URL(`${CORDIS_MARKET_API_ORIGIN}/plugins`);
+  url.searchParams.set("platform", "desktop");
+  url.searchParams.set("limit", String(limit));
+  return url;
+}
+
+export function marketDetailUrl(slug: string): URL {
+  if (!isValidCordisMarketSlug(slug)) {
+    throw new Error(`invalid Cordis market slug: ${JSON.stringify(slug)}`);
+  }
+  return new URL(`${CORDIS_MARKET_API_ORIGIN}/plugins/${slug}`);
+}
+
+export function isJsonContentType(contentType: string | null): boolean {
+  return contentType?.split(";", 1)[0]?.trim().toLowerCase() === "application/json";
+}
+
+export function directJsonResponseProblem(args: {
+  endpoint: URL;
+  status: number;
+  statusText: string;
+  contentType: string | null;
+  location: string | null;
+}): string | null {
+  return directResponseProblem({ ...args, expectedStatus: 200 });
+}
+
+export function directJsonErrorResponseProblem(args: {
+  endpoint: URL;
+  status: number;
+  statusText: string;
+  contentType: string | null;
+  location: string | null;
+  expectedStatus: number;
+}): string | null {
+  return directResponseProblem(args);
+}
+
+export function notModifiedResponseProblem(args: {
+  endpoint: URL;
+  status: number;
+  statusText: string;
+  location: string | null;
+}): string | null {
+  const { endpoint, status, statusText, location } = args;
+  if (status !== 304) {
+    const redirectHint = location === null ? "" : ` (Location: ${JSON.stringify(location)})`;
+    return `expected HTTP 304 after If-None-Match from ${endpoint}, got ${status}` +
+      `${statusText ? ` ${statusText}` : ""}${redirectHint}`;
+  }
+  if (location !== null) {
+    return `expected no redirect Location from 304 ${endpoint}, got ${JSON.stringify(location)}`;
+  }
+  return null;
+}
+
+export function marketListResponseProblem(value: unknown): string | null {
+  if (!isRecord(value)) return "market list body must be an object";
+  if (value.schemaVersion !== 1) return "market list schemaVersion must be 1";
+  if (!nonEmptyString(value.catalogRevision)) return "market list catalogRevision is required";
+  if (!nonEmptyString(value.updated)) return "market list updated is required";
+  if (!Number.isSafeInteger(value.count) || (value.count as number) < 0) {
+    return "market list count must be a non-negative safe integer";
+  }
+  if (!Array.isArray(value.items)) return "market list items must be an array";
+  if (!isRecord(value.categories)) return "market list categories must be an object";
+  if (!isRecord(value.page)) return "market list page must be an object";
+  if (value.page.cursor !== null && typeof value.page.cursor !== "string") {
+    return "market list page.cursor must be string or null";
+  }
+  if (typeof value.page.hasMore !== "boolean") return "market list page.hasMore must be boolean";
+  if (!Number.isSafeInteger(value.page.limit) || (value.page.limit as number) < 1 || (value.page.limit as number) > 100) {
+    return "market list page.limit must be an integer in 1..100";
+  }
+  return null;
+}
+
+export function marketErrorResponseProblem(value: unknown, expectedCode: string): string | null {
+  if (!isRecord(value) || !isRecord(value.error)) return "market error body must contain error object";
+  if (value.error.code !== expectedCode) {
+    return `market error code must be ${expectedCode}, got ${JSON.stringify(value.error.code)}`;
+  }
+  if (!nonEmptyString(value.error.message)) return "market error message is required";
+  return null;
+}
+
+/**
+ * Validate the strictly nested source shape that the Rust Desktop gate expects
+ * before an explicitly requested release probe names a real plugin. It is
+ * deliberately read-only and does not replace candidate_from_entry in Rust.
+ */
+export function desktopInstallWireProblem(value: unknown): string | null {
+  if (!isRecord(value)) return "market detail body must be an object";
+  if (!isValidCordisMarketSlug(String(value.slug ?? ""))) return "detail slug is invalid";
+  if (!nonEmptyString(value.entryRevision)) return "detail entryRevision is required";
+  if (!isRecord(value.description) || !nonEmptyString(value.description.zh) || !nonEmptyString(value.description.en)) {
+    return "detail description.zh and description.en are required";
+  }
+  if (value.blocked !== false) return "detail must be explicitly unblocked";
+  if (value.deprecated !== false) return "detail must be explicitly non-deprecated";
+  if (!Array.isArray(value.platforms) || !value.platforms.includes("desktop")) {
+    return "detail platforms must include desktop";
+  }
+  if (!isRecord(value.engines) || !nonEmptyString(value.engines.dsh) || !DSH_ENGINE_RE.test(value.engines.dsh)) {
+    return "detail engines.dsh must be a standard >= DSH range";
+  }
+  if (!isRecord(value.source)) return "detail source is required";
+  if (value.source.type !== "npm") return "detail source.type must be npm";
+  if (!nonEmptyString(value.source.packageName) || !PACKAGE_NAME_RE.test(value.source.packageName)) {
+    return "detail source.packageName is invalid";
+  }
+  if (!nonEmptyString(value.source.version) || !EXACT_SEMVER_RE.test(value.source.version)) {
+    return "detail source.version must be an exact semver";
+  }
+  if (!nonEmptyString(value.source.integrity) || !SHA512_INTEGRITY_RE.test(value.source.integrity)) {
+    return "detail source.integrity must be canonical sha512";
+  }
+  if (value.source.registry !== "https://registry.npmjs.org") {
+    return "detail source.registry must be https://registry.npmjs.org";
+  }
+  if (!nonEmptyString(value.source.tarball)) return "detail source.tarball is required";
+  try {
+    const tarball = new URL(value.source.tarball);
+    if (tarball.protocol !== "https:" || tarball.hostname !== "registry.npmjs.org" || tarball.port || tarball.username || tarball.password || tarball.search || tarball.hash || !tarball.pathname.endsWith(".tgz")) {
+      return "detail source.tarball must be a direct https registry.npmjs.org .tgz URL";
+    }
+  } catch {
+    return "detail source.tarball is invalid";
+  }
+  return null;
+}

--- a/scripts/lib/cordis-preset-contract.test.ts
+++ b/scripts/lib/cordis-preset-contract.test.ts
@@ -1,0 +1,73 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import {
+  CORDIS_PRESET_ORIGIN,
+  directZipResponseProblem,
+  isValidCordisPresetSlug,
+  isZipContentType,
+  presetDownloadUrl,
+} from "./cordis-preset-contract.ts";
+
+test("Cordis preset slug and canonical download URL stay constrained", () => {
+  assert.equal(isValidCordisPresetSlug("code"), true);
+  assert.equal(isValidCordisPresetSlug("v2-demo"), true);
+  assert.equal(isValidCordisPresetSlug("-code"), false);
+  assert.equal(isValidCordisPresetSlug("Code"), false);
+  assert.equal(isValidCordisPresetSlug("code/payload"), false);
+  assert.equal(isValidCordisPresetSlug("code?next=x"), false);
+
+  assert.equal(
+    presetDownloadUrl("v2-demo").toString(),
+    `${CORDIS_PRESET_ORIGIN}/api/presets/v2-demo/download`,
+  );
+  assert.throws(() => presetDownloadUrl("../other"), /invalid Cordis preset slug/);
+});
+
+test("Cordis preset response requires direct ZIP semantics", () => {
+  const endpoint = presetDownloadUrl("code");
+  assert.equal(isZipContentType("application/zip"), true);
+  assert.equal(isZipContentType("Application/Zip; charset=binary"), true);
+  assert.equal(isZipContentType("application/octet-stream"), false);
+  assert.equal(isZipContentType(null), false);
+
+  assert.equal(
+    directZipResponseProblem({
+      endpoint,
+      status: 200,
+      statusText: "OK",
+      contentType: "application/zip",
+      location: null,
+    }),
+    null,
+  );
+  assert.match(
+    directZipResponseProblem({
+      endpoint,
+      status: 307,
+      statusText: "Temporary Redirect",
+      contentType: null,
+      location: "https://cdn.example/preset.dshpreset",
+    }) ?? "",
+    /redirects are rejected/,
+  );
+  assert.match(
+    directZipResponseProblem({
+      endpoint,
+      status: 200,
+      statusText: "OK",
+      contentType: "text/html",
+      location: null,
+    }) ?? "",
+    /Content-Type application\/zip/,
+  );
+  assert.match(
+    directZipResponseProblem({
+      endpoint,
+      status: 200,
+      statusText: "OK",
+      contentType: "application/zip",
+      location: "https://cdn.example/preset.dshpreset",
+    }) ?? "",
+    /no redirect Location/,
+  );
+});

--- a/scripts/lib/cordis-preset-contract.ts
+++ b/scripts/lib/cordis-preset-contract.ts
@@ -1,0 +1,49 @@
+// Pure contract helpers for the public Cordis preset download endpoint.
+//
+// The Desktop deep-link boundary accepts only this canonical HTTPS route and
+// rejects redirects. Keep this independent of market DTOs so a release can
+// verify the production endpoint without installing a preset.
+
+export const CORDIS_PRESET_ORIGIN = "https://cordis.run";
+export const DEFAULT_CORDIS_PRESET_SLUG = "code";
+
+const PRESET_SLUG_RE = /^[a-z0-9][a-z0-9-]*$/;
+
+export function isValidCordisPresetSlug(value: string): boolean {
+  return PRESET_SLUG_RE.test(value);
+}
+
+export function presetDownloadUrl(slug: string): URL {
+  if (!isValidCordisPresetSlug(slug)) {
+    throw new Error(`invalid Cordis preset slug: ${JSON.stringify(slug)}`);
+  }
+  return new URL(`/api/presets/${slug}/download`, CORDIS_PRESET_ORIGIN);
+}
+
+export function isZipContentType(contentType: string | null): boolean {
+  return contentType?.split(";", 1)[0]?.trim().toLowerCase() === "application/zip";
+}
+
+export function directZipResponseProblem(args: {
+  endpoint: URL;
+  status: number;
+  statusText: string;
+  contentType: string | null;
+  location: string | null;
+}): string | null {
+  const { endpoint, status, statusText, contentType, location } = args;
+  if (status !== 200) {
+    const redirectHint = location === null ? "" : ` (Location: ${JSON.stringify(location)})`;
+    return (
+      `expected direct HTTP 200 from ${endpoint}, got ${status}` +
+      `${statusText ? ` ${statusText}` : ""}${redirectHint}; redirects are rejected by the Desktop preset contract`
+    );
+  }
+  if (location !== null) {
+    return `expected no redirect Location from ${endpoint}, got ${JSON.stringify(location)}`;
+  }
+  if (!isZipContentType(contentType)) {
+    return `expected Content-Type application/zip from ${endpoint}, got ${JSON.stringify(contentType)}`;
+  }
+  return null;
+}

--- a/scripts/release-preflight.ts
+++ b/scripts/release-preflight.ts
@@ -51,7 +51,7 @@ const manifest = readManifest();
 
 // --- deny: version alignment ---------------------------------------------
 const desktopVersion = manifest.desktopVersion;
-const rootPkg = readJson("package.json") as { version?: string };
+const rootPkg = readJson("package.json") as { private?: boolean; version?: string };
 const tauriConf = readJson("src-tauri/tauri.conf.json") as { version?: string };
 const tauriCargo = cargoVersion("src-tauri/Cargo.toml");
 const sidecarCargo = cargoVersion("crates/dsh-sidecar/Cargo.toml");
@@ -71,6 +71,14 @@ for (const [file, version] of versionFiles) {
   }
 }
 ok(`desktop version aligned: ${desktopVersion} (manifest/package.json/Cargo.toml/tauri.conf.json)`);
+
+// The root package is the Desktop build workspace, not an npm distribution.
+// Public npm artifacts, if approved later, must use a separately reviewed
+// @web-casa scoped package rather than accidentally publishing this workspace.
+if (rootPkg.private !== true) {
+  fail("package.json must remain private; do not publish the Desktop workspace to npm");
+}
+ok("root npm workspace remains private (public npm artifacts require @web-casa review)");
 
 if (sidecarCargo !== manifest.sidecarVersion) {
   fail(`sidecar version drift: Cargo.toml ${sidecarCargo} != manifest ${manifest.sidecarVersion}`);

--- a/scripts/verify-cordis-market-api.ts
+++ b/scripts/verify-cordis-market-api.ts
@@ -1,0 +1,141 @@
+// Production release-contract probe for Cordis market API.
+//
+// This performs no mutation and never downloads or installs a plugin. It
+// verifies the exact direct JSON, ETag/304, and JSON-404 behavior that the
+// Desktop Rust client consumes. Set CORDIS_MARKET_PROBE_SLUG only after a
+// reviewed public catalog entry exists to inspect its install wire shape.
+
+import {
+  DEFAULT_MISSING_MARKET_SLUG,
+  desktopInstallWireProblem,
+  directJsonErrorResponseProblem,
+  directJsonResponseProblem,
+  isValidCordisMarketSlug,
+  marketDetailUrl,
+  marketErrorResponseProblem,
+  marketListResponseProblem,
+  marketListUrl,
+  notModifiedResponseProblem,
+} from "./lib/cordis-market-contract.ts";
+import { fail, info, ok } from "./lib/common.ts";
+
+const REQUEST_TIMEOUT_MS = 30_000;
+const JSON_HEADERS = { accept: "application/json" };
+
+function requestedProbeSlug(): string | null {
+  const slug = process.env.CORDIS_MARKET_PROBE_SLUG;
+  if (slug === undefined || slug === "") return null;
+  if (!isValidCordisMarketSlug(slug)) {
+    throw new Error(`CORDIS_MARKET_PROBE_SLUG is invalid: ${JSON.stringify(slug)}`);
+  }
+  return slug;
+}
+
+async function fetchJson(endpoint: URL): Promise<{ body: unknown; etag: string }> {
+  const response = await fetch(endpoint, {
+    redirect: "manual",
+    signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+    headers: JSON_HEADERS,
+  });
+  const problem = directJsonResponseProblem({
+    endpoint,
+    status: response.status,
+    statusText: response.statusText,
+    contentType: response.headers.get("content-type"),
+    location: response.headers.get("location"),
+  });
+  if (problem !== null) {
+    await response.body?.cancel().catch(() => undefined);
+    throw new Error(problem);
+  }
+  const etag = response.headers.get("etag");
+  if (etag === null || etag.trim().length === 0) {
+    await response.body?.cancel().catch(() => undefined);
+    throw new Error(`expected ETag from ${endpoint}`);
+  }
+  let body: unknown;
+  try {
+    body = await response.json();
+  } catch (error) {
+    throw new Error(`could not parse JSON from ${endpoint}: ${error instanceof Error ? error.message : String(error)}`);
+  }
+  return { body, etag };
+}
+
+async function assertNotModified(endpoint: URL, etag: string): Promise<void> {
+  const response = await fetch(endpoint, {
+    redirect: "manual",
+    signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+    headers: { ...JSON_HEADERS, "if-none-match": etag },
+  });
+  try {
+    const problem = notModifiedResponseProblem({
+      endpoint,
+      status: response.status,
+      statusText: response.statusText,
+      location: response.headers.get("location"),
+    });
+    if (problem !== null) throw new Error(problem);
+  } finally {
+    await response.body?.cancel().catch(() => undefined);
+  }
+}
+
+async function assertJson404(): Promise<void> {
+  const endpoint = marketDetailUrl(DEFAULT_MISSING_MARKET_SLUG);
+  const response = await fetch(endpoint, {
+    redirect: "manual",
+    signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+    headers: JSON_HEADERS,
+  });
+  const problem = directJsonErrorResponseProblem({
+    endpoint,
+    status: response.status,
+    statusText: response.statusText,
+    contentType: response.headers.get("content-type"),
+    location: response.headers.get("location"),
+    expectedStatus: 404,
+  });
+  if (problem !== null) {
+    await response.body?.cancel().catch(() => undefined);
+    throw new Error(problem);
+  }
+  let body: unknown;
+  try {
+    body = await response.json();
+  } catch (error) {
+    throw new Error(`could not parse JSON 404 from ${endpoint}: ${error instanceof Error ? error.message : String(error)}`);
+  }
+  const bodyProblem = marketErrorResponseProblem(body, "NOT_FOUND");
+  if (bodyProblem !== null) throw new Error(`${endpoint}: ${bodyProblem}`);
+}
+
+async function main(): Promise<void> {
+  const listEndpoint = marketListUrl(1);
+  info(`probing Cordis Desktop market response: ${listEndpoint}`);
+  const list = await fetchJson(listEndpoint);
+  const listProblem = marketListResponseProblem(list.body);
+  if (listProblem !== null) throw new Error(`${listEndpoint}: ${listProblem}`);
+  await assertNotModified(listEndpoint, list.etag);
+  await assertJson404();
+
+  const probeSlug = requestedProbeSlug();
+  if (probeSlug === null) {
+    const count = (list.body as { count: number }).count;
+    info(`catalog structural probe passed (desktop count=${count}); no CORDIS_MARKET_PROBE_SLUG supplied, so no plugin was inspected or installed`);
+  } else {
+    const endpoint = marketDetailUrl(probeSlug);
+    info(`probing requested Desktop install wire shape: ${endpoint}`);
+    const detail = await fetchJson(endpoint);
+    const detailProblem = desktopInstallWireProblem(detail.body);
+    if (detailProblem !== null) throw new Error(`${endpoint}: ${detailProblem}`);
+    await assertNotModified(endpoint, detail.etag);
+    ok(`Cordis market ${probeSlug} matches the Desktop nested-source compatibility probe; no install was performed`);
+  }
+
+  ok("Cordis Desktop market API returns direct JSON, ETag/304, and JSON 404 as contracted");
+}
+
+main().catch((error: unknown) => {
+  fail(error instanceof Error ? error.message : String(error));
+});

--- a/scripts/verify-cordis-market-api.ts
+++ b/scripts/verify-cordis-market-api.ts
@@ -5,8 +5,9 @@
 // Desktop Rust client consumes. Set CORDIS_MARKET_PROBE_SLUG only after a
 // reviewed public catalog entry exists to inspect its install wire shape.
 
+import { randomUUID } from "node:crypto";
 import {
-  DEFAULT_MISSING_MARKET_SLUG,
+  MISSING_MARKET_SLUG_PREFIX,
   desktopInstallWireProblem,
   directJsonErrorResponseProblem,
   directJsonResponseProblem,
@@ -82,7 +83,12 @@ async function assertNotModified(endpoint: URL, etag: string): Promise<void> {
 }
 
 async function assertJson404(): Promise<void> {
-  const endpoint = marketDetailUrl(DEFAULT_MISSING_MARKET_SLUG);
+  // A fixed sentinel can eventually collide with a real catalog entry and
+  // turn a healthy production API into a false release failure. Keep the
+  // request inside the validated slug grammar while making collision
+  // practically impossible for every probe run.
+  const missingSlug = `${MISSING_MARKET_SLUG_PREFIX}-${randomUUID()}`;
+  const endpoint = marketDetailUrl(missingSlug);
   const response = await fetch(endpoint, {
     redirect: "manual",
     signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),

--- a/scripts/verify-cordis-preset-download.ts
+++ b/scripts/verify-cordis-preset-download.ts
@@ -1,0 +1,57 @@
+// Production release contract probe for Cordis preset deep links.
+//
+// This deliberately inspects only the direct HTTP response headers and
+// immediately cancels the body. It never writes, hashes, executes, or
+// installs archive bytes; the Desktop's real download path performs those
+// security checks after explicit user consent.
+
+import {
+  DEFAULT_CORDIS_PRESET_SLUG,
+  directZipResponseProblem,
+  isValidCordisPresetSlug,
+  presetDownloadUrl,
+} from "./lib/cordis-preset-contract.ts";
+import { fail, info, ok } from "./lib/common.ts";
+
+const REQUEST_TIMEOUT_MS = 30_000;
+
+function requestedSlug(): string {
+  const slug = process.env.CORDIS_PRESET_SLUG ?? DEFAULT_CORDIS_PRESET_SLUG;
+  if (!isValidCordisPresetSlug(slug)) {
+    throw new Error(`CORDIS_PRESET_SLUG is invalid: ${JSON.stringify(slug)}`);
+  }
+  return slug;
+}
+
+async function main(): Promise<void> {
+  const slug = requestedSlug();
+  const endpoint = presetDownloadUrl(slug);
+  info(`probing direct Cordis preset response: ${endpoint}`);
+
+  const response = await fetch(endpoint, {
+    redirect: "manual",
+    signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+    headers: { accept: "application/zip" },
+  });
+  try {
+    const problem = directZipResponseProblem({
+      endpoint,
+      status: response.status,
+      statusText: response.statusText,
+      contentType: response.headers.get("content-type"),
+      location: response.headers.get("location"),
+    });
+    if (problem !== null) throw new Error(problem);
+    ok(`Cordis preset ${slug} returns direct HTTP 200 application/zip`);
+  } finally {
+    // There is no persistent download in this probe; release the stream early.
+    const body = response.body;
+    if (body !== null) {
+      await body.cancel().catch(() => undefined);
+    }
+  }
+}
+
+main().catch((error: unknown) => {
+  fail(error instanceof Error ? error.message : String(error));
+});

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -30,6 +30,7 @@ getrandom = "0.2"
 dsh-sidecar = { path = "../crates/dsh-sidecar", version = "0.2.4" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+semver = "1"
 url = "2"
 
 [lints.clippy]
@@ -42,3 +43,9 @@ dbg_macro = "deny"
 
 [dev-dependencies]
 proptest = "1"
+
+[target.'cfg(windows)'.dependencies]
+# Needed for atomic replacement of Desktop-owned pending state. This is
+# already pinned by dsh-sidecar; declare it directly because Rust crates may
+# not rely on transitive dependencies.
+windows-sys = { version = "0.61", features = ["Win32_Storage_FileSystem"] }

--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -40,6 +40,9 @@ fn main() {
         "market_search",
         "market_plugin",
         "market_image",
+        "market_prepare_install",
+        "market_install_plugin",
+        "activate_market_plugin",
         "sideload_plugin",
     ]);
     let result = tauri_build::try_build(tauri_build::Attributes::new().app_manifest(manifest));

--- a/src-tauri/capabilities/bootstrap.json
+++ b/src-tauri/capabilities/bootstrap.json
@@ -40,6 +40,9 @@
     "allow-market-search",
     "allow-market-plugin",
     "allow-market-image",
+    "allow-market-prepare-install",
+    "allow-market-install-plugin",
+    "allow-activate-market-plugin",
     "allow-sideload-plugin",
     "allow-pick-sideload-file"
   ]

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -365,16 +365,26 @@ pub async fn market_search(
     limit: Option<u32>,
     cursor: Option<String>,
     platform: Option<String>,
+    runtime: State<'_, Runtime>,
     market: State<'_, std::sync::Arc<crate::market::MarketClient>>,
 ) -> Result<Value, String> {
-    let platform = platform.unwrap_or_else(|| "desktop".to_string());
+    if platform.as_deref().is_some_and(|value| value != "desktop") {
+        return Err("Desktop market requests must use platform=desktop".to_string());
+    }
+    let dsh_version = runtime
+        .state
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .versions
+        .harness
+        .clone();
     market
         .search(
             &query,
             category.as_deref(),
             limit,
             cursor.as_deref(),
-            &platform,
+            &dsh_version,
         )
         .await
 }
@@ -382,9 +392,17 @@ pub async fn market_search(
 #[tauri::command]
 pub async fn market_plugin(
     slug: String,
+    runtime: State<'_, Runtime>,
     market: State<'_, std::sync::Arc<crate::market::MarketClient>>,
 ) -> Result<Value, String> {
-    market.detail(&slug).await
+    let dsh_version = runtime
+        .state
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .versions
+        .harness
+        .clone();
+    market.detail(&slug, &dsh_version).await
 }
 
 #[tauri::command]
@@ -395,10 +413,142 @@ pub async fn market_image(
     market.image(&url).await
 }
 
+/// Fetch an installable market entry again and expose the exact current
+/// entryRevision to the confirmation dialog. This command never mutates a
+/// profile; the following market_install_plugin call revalidates it once more
+/// so a stale dialog cannot install a changed entry.
+#[tauri::command]
+pub async fn market_prepare_install(
+    slug: String,
+    runtime: State<'_, Runtime>,
+    market: State<'_, std::sync::Arc<crate::market::MarketClient>>,
+) -> Result<Value, String> {
+    let dsh_version = runtime
+        .state
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .versions
+        .harness
+        .clone();
+    let candidate = market.prepare_install(&slug, &dsh_version).await?;
+    serde_json::to_value(candidate)
+        .map_err(|error| format!("cannot serialize market install preview: {error}"))
+}
+
+/// Begin the reviewed market installation lifecycle:
+/// integrity metadata validation -> pre-disable -> pnpm with scripts disabled
+/// -> local verification -> pending activation. The actual pnpm work runs in
+/// the same cancellable process group/Job Object as normal plugin operations.
+#[tauri::command]
+pub async fn market_install_plugin(
+    app: AppHandle,
+    slug: String,
+    entry_revision: String,
+    runtime: State<'_, Runtime>,
+    plugins: State<'_, Arc<crate::plugins::PluginRunner>>,
+    market: State<'_, std::sync::Arc<crate::market::MarketClient>>,
+) -> Result<(), String> {
+    let plugins = plugins.inner().clone();
+    if plugins.busy.swap(true, Ordering::SeqCst) {
+        return Err("an operation is already running".to_string());
+    }
+    let dsh_version = runtime
+        .state
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .versions
+        .harness
+        .clone();
+    let candidate = match market.prepare_install(&slug, &dsh_version).await {
+        Ok(candidate) => candidate,
+        Err(error) => {
+            plugins.busy.store(false, Ordering::SeqCst);
+            return Err(error);
+        }
+    };
+    if crate::build_info::STORE_BUILD
+        && !crate::curated_plugins::is_allowed(&candidate.package_name)
+    {
+        plugins.busy.store(false, Ordering::SeqCst);
+        return Err("仅允许安装 cordis.run 已审核插件".to_string());
+    }
+    if candidate.entry_revision != entry_revision {
+        plugins.busy.store(false, Ordering::SeqCst);
+        return Err(
+            "market entry changed; review the latest entryRevision before installing".to_string(),
+        );
+    }
+    let Some(paths) = runtime.paths() else {
+        plugins.busy.store(false, Ordering::SeqCst);
+        return Err("runtime paths are not resolved yet".to_string());
+    };
+    if let Err(error) = crate::plugins::pre_disable_market_plugin(&paths.dsh_home, &candidate) {
+        plugins.busy.store(false, Ordering::SeqCst);
+        return Err(error);
+    }
+    std::thread::spawn(move || {
+        run_market_pnpm(app, paths, plugins, candidate);
+    });
+    Ok(())
+}
+
+/// Activate a previously verified pending market package. It refetches and
+/// checks the catalog entry first, so a newly blocked/deprecated/incompatible
+/// package cannot be re-enabled by stale local pending state.
+#[tauri::command]
+pub async fn activate_market_plugin(
+    slug: String,
+    entry_revision: String,
+    runtime: State<'_, Runtime>,
+    plugins: State<'_, Arc<crate::plugins::PluginRunner>>,
+    market: State<'_, std::sync::Arc<crate::market::MarketClient>>,
+) -> Result<(), String> {
+    let plugins = plugins.inner().clone();
+    if plugins.busy.swap(true, Ordering::SeqCst) {
+        return Err("an operation is already running".to_string());
+    }
+    let dsh_version = runtime
+        .state
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .versions
+        .harness
+        .clone();
+    let candidate = match market.prepare_install(&slug, &dsh_version).await {
+        Ok(candidate) => candidate,
+        Err(error) => {
+            plugins.busy.store(false, Ordering::SeqCst);
+            return Err(error);
+        }
+    };
+    if crate::build_info::STORE_BUILD
+        && !crate::curated_plugins::is_allowed(&candidate.package_name)
+    {
+        plugins.busy.store(false, Ordering::SeqCst);
+        return Err("仅允许激活 cordis.run 已审核插件".to_string());
+    }
+    if candidate.entry_revision != entry_revision {
+        plugins.busy.store(false, Ordering::SeqCst);
+        return Err(
+            "market entry changed; install and review the latest revision before activation"
+                .to_string(),
+        );
+    }
+    let result = runtime
+        .paths()
+        .ok_or_else(|| "runtime paths are not resolved yet".to_string())
+        .and_then(|paths| crate::plugins::activate_market_plugin(&paths.dsh_home, &candidate));
+    plugins.busy.store(false, Ordering::SeqCst);
+    result
+}
+
 #[cfg(test)]
 #[allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
 mod tests {
-    use super::{read_installed_plugins, redact, sweep_sideload_dir, sweep_sideloads_root};
+    use super::{
+        is_zip_content_type, read_installed_plugins, redact, sweep_sideload_dir,
+        sweep_sideloads_root,
+    };
 
     #[test]
     fn sideload_sweep_does_not_follow_symlinked_tools_parent() {
@@ -481,6 +631,15 @@ mod tests {
         assert_eq!(redact("Bearer ab-cd_ef", ""), "Bearer ***");
         // 5 chars: below threshold, left untouched.
         assert_eq!(redact("Bearer short", ""), "Bearer short");
+    }
+
+    #[test]
+    fn remote_preset_requires_zip_content_type() {
+        let zip = reqwest::header::HeaderValue::from_static("application/zip; charset=binary");
+        let json = reqwest::header::HeaderValue::from_static("application/json");
+        assert!(is_zip_content_type(Some(&zip)));
+        assert!(!is_zip_content_type(Some(&json)));
+        assert!(!is_zip_content_type(None));
     }
 
     #[test]
@@ -759,6 +918,7 @@ pub async fn export_preset(
 /// node_modules/<pkg>/package.json ("—" when the tree entry is missing).
 /// In-box bundles are not dependencies here, so they never appear — the UI
 /// can therefore offer uninstall on every listed row (plan §P1.4).
+#[cfg(test)]
 fn read_installed_plugins(profile_dir: &std::path::Path) -> Vec<(String, String)> {
     let mut out = Vec::new();
     if let Ok(text) = std::fs::read_to_string(profile_dir.join("package.json")) {
@@ -795,13 +955,10 @@ pub fn list_plugins(
 ) -> Value {
     let entries = runtime
         .paths()
-        .map(|p| read_installed_plugins(&p.dsh_home.join("profiles").join("web")))
+        .map(|paths| crate::plugins::installed_plugins(&paths.dsh_home))
         .unwrap_or_default();
     serde_json::json!({
-        "plugins": entries
-            .into_iter()
-            .map(|(name, version)| serde_json::json!({ "name": name, "version": version }))
-            .collect::<Vec<_>>(),
+        "plugins": entries,
         // The backend busy flag survives webview reloads; the UI must be
         // able to resync instead of showing a stale idle state while an op
         // is still running (single-flight is app-wide).
@@ -1032,6 +1189,212 @@ fn run_plugin_spec(
     );
 }
 
+/// Run the market-only direct pnpm path. The official dsh plugin command
+/// cannot be used here because it reconciles installed bundles into the
+/// active profile automatically. This keeps the same PlatformChild process
+/// tree and logging guarantees as the normal plugin operation, but runs only
+/// pnpm add with lifecycle scripts disabled.
+fn run_market_pnpm(
+    app: AppHandle,
+    paths: crate::paths::RuntimePaths,
+    plugins: Arc<crate::plugins::PluginRunner>,
+    candidate: crate::market::MarketInstallCandidate,
+) {
+    use std::io::{BufRead, BufReader};
+
+    let profile = match crate::plugins::market_profile_dir(&paths.dsh_home) {
+        Ok(profile) => profile,
+        Err(error) => {
+            let _ = app.emit(
+                "plugin-done",
+                serde_json::json!({ "exit": 1, "tail": error }),
+            );
+            plugins.busy.store(false, Ordering::SeqCst);
+            return;
+        }
+    };
+    let pnpm = paths
+        .harness_dir
+        .join("node_modules")
+        .join("pnpm")
+        .join("bin")
+        .join("pnpm.cjs");
+    let spawn_spec = SpawnSpec {
+        node: paths.node.to_string_lossy().to_string(),
+        script: pnpm.to_string_lossy().to_string(),
+        args: vec![
+            "add".to_string(),
+            candidate.tarball.clone(),
+            "--ignore-scripts".to_string(),
+            "--save-exact".to_string(),
+            "--yes".to_string(),
+            "--reporter=append-only".to_string(),
+            format!("--registry={}", candidate.registry),
+        ],
+        cwd: profile.to_string_lossy().to_string(),
+        env: vec![(
+            "DSH_HOME".to_string(),
+            paths.dsh_home.to_string_lossy().to_string(),
+        )],
+    };
+    let inherited = std::env::vars_os().collect::<Vec<_>>();
+    let child = match PlatformChild::spawn(&spawn_spec, &inherited) {
+        Ok(child) => child,
+        Err(error) => {
+            let _ = app.emit(
+                "plugin-done",
+                serde_json::json!({ "exit": 1, "tail": format!("market pnpm spawn failed: {error}") }),
+            );
+            plugins.busy.store(false, Ordering::SeqCst);
+            return;
+        }
+    };
+    if plugins.exiting.load(Ordering::SeqCst) {
+        let _ = child.graceful();
+        child.force();
+        plugins.busy.store(false, Ordering::SeqCst);
+        return;
+    }
+
+    let mut tail: Vec<String> = Vec::new();
+    let mut pending: Vec<(String, String)> = Vec::new();
+    let app_c = app.clone();
+    let mut flush = move |lines: &mut Vec<(String, String)>| {
+        if lines.is_empty() {
+            return;
+        }
+        let payload: Vec<serde_json::Value> = lines
+            .drain(..)
+            .map(|(stream, line)| serde_json::json!({ "stream": stream, "line": line }))
+            .collect();
+        let _ = app_c.emit("plugin-log", serde_json::json!(payload));
+    };
+    let (tx, rx) = std::sync::mpsc::channel::<(String, String)>();
+    let child = {
+        let mut child = child;
+        for (stream, pipe) in [
+            (
+                "stdout",
+                child
+                    .child
+                    .stdout
+                    .take()
+                    .map(|pipe| Box::new(pipe) as Box<dyn std::io::Read + Send>),
+            ),
+            (
+                "stderr",
+                child
+                    .child
+                    .stderr
+                    .take()
+                    .map(|pipe| Box::new(pipe) as Box<dyn std::io::Read + Send>),
+            ),
+        ] {
+            if let Some(pipe) = pipe {
+                let tx = tx.clone();
+                std::thread::spawn(move || {
+                    for line in BufReader::new(pipe).lines().map_while(Result::ok) {
+                        if tx.send((stream.to_string(), line)).is_err() {
+                            break;
+                        }
+                    }
+                });
+            }
+        }
+        child
+    };
+    drop(tx);
+    *plugins
+        .child
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner()) = Some(child);
+    if plugins.exiting.load(Ordering::SeqCst) {
+        if let Some(child) = plugins
+            .child
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .take()
+        {
+            let _ = child.graceful();
+            child.force();
+        }
+        plugins.busy.store(false, Ordering::SeqCst);
+        return;
+    }
+    fn handle_line(
+        tail: &mut Vec<String>,
+        pending: &mut Vec<(String, String)>,
+        flush: &mut impl FnMut(&mut Vec<(String, String)>),
+        stream: String,
+        line: String,
+    ) {
+        tail.push(format!("[{stream}] {line}"));
+        if tail.len() > 300 {
+            tail.remove(0);
+        }
+        pending.push((stream, line));
+        if pending.len() >= 64 {
+            flush(pending);
+        }
+    }
+    let mut exit = loop {
+        match rx.recv_timeout(std::time::Duration::from_millis(100)) {
+            Ok((stream, line)) => handle_line(&mut tail, &mut pending, &mut flush, stream, line),
+            Err(std::sync::mpsc::RecvTimeoutError::Timeout) => flush(&mut pending),
+            Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => {
+                flush(&mut pending);
+                let handle = plugins
+                    .child
+                    .lock()
+                    .unwrap_or_else(|poisoned| poisoned.into_inner())
+                    .take();
+                break handle
+                    .and_then(|mut child| child.child.wait().ok())
+                    .and_then(|status| status.code());
+            }
+        }
+        if let Some(child) = plugins
+            .child
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .as_mut()
+        {
+            if let Some(status) = child.child.try_wait().ok().flatten() {
+                while let Ok((stream, line)) = rx.recv_timeout(std::time::Duration::from_millis(50))
+                {
+                    handle_line(&mut tail, &mut pending, &mut flush, stream, line);
+                }
+                flush(&mut pending);
+                break status.code();
+            }
+        }
+    };
+    *plugins
+        .child
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner()) = None;
+    if exit == Some(0) {
+        if let Err(error) =
+            crate::plugins::verify_and_mark_market_pending(&paths.dsh_home, &candidate)
+        {
+            handle_line(
+                &mut tail,
+                &mut pending,
+                &mut flush,
+                "verify".to_string(),
+                error,
+            );
+            flush(&mut pending);
+            exit = Some(1);
+        }
+    }
+    plugins.busy.store(false, Ordering::SeqCst);
+    let _ = app.emit(
+        "plugin-done",
+        serde_json::json!({ "exit": exit, "tail": tail.join("\n") }),
+    );
+}
+
 fn spawn_plugin_spec(
     app: AppHandle,
     runtime: &Runtime,
@@ -1183,6 +1546,13 @@ fn valid_request_id(request_id: &str) -> bool {
         && request_id
             .bytes()
             .all(|b| b.is_ascii_digit() || (b'a'..=b'f').contains(&b))
+}
+
+fn is_zip_content_type(value: Option<&reqwest::header::HeaderValue>) -> bool {
+    value
+        .and_then(|value| value.to_str().ok())
+        .and_then(|value| value.split(';').next())
+        .is_some_and(|value| value.trim().eq_ignore_ascii_case("application/zip"))
 }
 
 fn ensure_remote_tools_dir(dsh_home: &std::path::Path) -> Result<std::path::PathBuf, String> {
@@ -1481,9 +1851,15 @@ pub async fn confirm_remote_preset_download(
         fail(&pending, &arbiter, &request_id, None);
         format!("download failed: {e}")
     })?;
-    if !resp.status().is_success() {
+    if resp.status() != reqwest::StatusCode::OK {
         fail(&pending, &arbiter, &request_id, None);
         return Err(format!("download failed: HTTP {}", resp.status()));
+    }
+    if !is_zip_content_type(resp.headers().get(reqwest::header::CONTENT_TYPE)) {
+        fail(&pending, &arbiter, &request_id, None);
+        return Err(
+            "preset download must return application/zip directly from cordis.run".to_string(),
+        );
     }
     let max = crate::deep_link::MAX_REMOTE_PRESET_BYTES as usize;
     if resp.content_length().is_some_and(|n| n > max as u64) {

--- a/src-tauri/src/deep_link.rs
+++ b/src-tauri/src/deep_link.rs
@@ -37,6 +37,10 @@ pub const MAX_REMOTE_PRESET_BYTES: u64 = 16 * 1024 * 1024;
 pub struct PluginInstallRequest {
     pub name: String,
     pub source: String,
+    /// Canonical Cordis market slug derived in Rust from `source`. The
+    /// bootstrap uses this instead of the legacy package-name hint when it
+    /// enters the v4 reviewed market-install flow.
+    pub slug: String,
 }
 
 /// Single pending deep-link request. It is stored because a cold start may
@@ -391,11 +395,11 @@ fn query_pairs(url: &Url) -> Vec<(String, String)> {
         .collect()
 }
 
-/// Validate the `source` parameter: an https plugin page on cordis.run with
+/// Validate the `source` parameter: an HTTPS plugin page on cordis.run with
 /// no port, credentials, query string, fragment, or trailing slash after the
-/// slug. It is display-only, but keeping it canonical avoids UI ambiguity
-/// and future abuse as an open-redirect-ish vector.
-fn validate_source(raw: &str) -> Result<String, String> {
+/// slug. Its Rust-derived slug only selects the catalog detail to revalidate;
+/// the link's legacy package-name hint is never an install source.
+fn validate_source(raw: &str) -> Result<(String, String), String> {
     let source = Url::parse(raw).map_err(|e| format!("invalid source URL: {e}"))?;
     if source.scheme() != "https" {
         return Err("source must use https".to_string());
@@ -418,11 +422,11 @@ fn validate_source(raw: &str) -> Result<String, String> {
         .strip_prefix("/plugins/")
         .or_else(|| path.strip_prefix("/en/plugins/"))
         .ok_or_else(|| "source must be a cordis.run plugin page".to_string())?;
-    if slug.is_empty() || slug.contains('/') {
+    if !crate::market::is_valid_market_slug(slug) {
         return Err("source must point to one plugin slug".to_string());
     }
 
-    Ok(source.to_string())
+    Ok((source.to_string(), slug.to_string()))
 }
 
 /// Parse and validate a raw `dsharness://plugin/install?...` URL.
@@ -480,19 +484,19 @@ pub fn parse_install_url(raw: &str) -> Result<PluginInstallRequest, String> {
         return Err(format!("invalid npm package name {name:?}"));
     }
     let source = source.ok_or_else(|| "missing query parameter 'source'".to_string())?;
-    let source = validate_source(source)?;
+    let (source, slug) = validate_source(source)?;
 
     Ok(PluginInstallRequest {
         name: name.clone(),
         source,
+        slug,
     })
 }
 
-/// Validate the preset download URL: an https `cordis.run` endpoint with the
-/// canonical path `/api/presets/<slug>/download` and an optional single
-/// `?v=<versionId>` query. The remote-download state machine disables HTTP
-/// redirects, so this initial cordis.run endpoint remains the only host it
-/// contacts for a deep-link request.
+/// Validate the preset download URL: exactly the HTTPS `cordis.run` endpoint
+/// `/api/presets/<slug>/download`, without a query string. The remote-download
+/// state machine disables redirects and requires its direct 200 zip response,
+/// so this endpoint remains the only host it contacts for a deep-link request.
 pub fn validate_preset_download_url(raw: &str) -> Result<String, String> {
     let u = Url::parse(raw).map_err(|e| format!("invalid download URL: {e}"))?;
     if u.scheme() != "https" {
@@ -504,8 +508,8 @@ pub fn validate_preset_download_url(raw: &str) -> Result<String, String> {
     if !u.username().is_empty() || u.password().is_some() || u.port().is_some() {
         return Err("download URL must not contain credentials or a port".to_string());
     }
-    if u.fragment().is_some() {
-        return Err("download URL must not contain a fragment".to_string());
+    if u.query().is_some() || u.fragment().is_some() {
+        return Err("download URL must not contain a query string or fragment".to_string());
     }
 
     let path = u.path();
@@ -515,18 +519,6 @@ pub fn validate_preset_download_url(raw: &str) -> Result<String, String> {
         .ok_or_else(|| "download URL must be /api/presets/<slug>/download".to_string())?;
     if slug.is_empty() || slug.contains('/') || !crate::preset::is_valid_preset_id(slug) {
         return Err("download URL must point to one preset slug".to_string());
-    }
-
-    // Query: absent, or exactly one `v=<non-empty>` (the version row id).
-    let mut q = u.query_pairs();
-    match q.next() {
-        None => {}
-        Some((key, value)) if key == "v" && !value.is_empty() => {
-            if q.next().is_some() {
-                return Err("download URL query must contain only v=".to_string());
-            }
-        }
-        Some(_) => return Err("download URL query must contain only v=".to_string()),
     }
 
     Ok(u.to_string())
@@ -774,6 +766,7 @@ mod tests {
         );
         assert_eq!(scoped.name, "@cordisjs/plugin-example");
         assert_eq!(scoped.source, "https://cordis.run/plugins/example");
+        assert_eq!(scoped.slug, "example");
 
         let plain = parse(
             "dsharness://plugin/install?v=1&name=is-odd&\
@@ -781,6 +774,7 @@ mod tests {
         );
         assert_eq!(plain.name, "is-odd");
         assert_eq!(plain.source, "https://cordis.run/plugins/is-odd");
+        assert_eq!(plain.slug, "is-odd");
     }
 
     #[test]
@@ -798,10 +792,12 @@ mod tests {
         let first = PluginInstallRequest {
             name: "is-odd".to_string(),
             source: "https://cordis.run/plugins/is-odd".to_string(),
+            slug: "is-odd".to_string(),
         };
         let second = PluginInstallRequest {
             name: "is-even".to_string(),
             source: "https://cordis.run/plugins/is-even".to_string(),
+            slug: "is-even".to_string(),
         };
         pending.replace(first.clone());
         pending.replace(second.clone());
@@ -935,22 +931,13 @@ mod tests {
     }
 
     #[test]
-    fn preset_parses_latest_and_versioned_downloads() {
+    fn preset_parses_canonical_download_without_query() {
         let latest = parse_preset(&preset_raw(
             "https://cordis.run/api/presets/code/download",
             "https://cordis.run/presets/code",
         ));
         assert_eq!(latest.url, "https://cordis.run/api/presets/code/download");
         assert_eq!(latest.source, "https://cordis.run/presets/code");
-
-        let versioned = parse_preset(&preset_raw(
-            "https://cordis.run/api/presets/code/download?v=v1-official-code",
-            "https://cordis.run/presets/code",
-        ));
-        assert_eq!(
-            versioned.url,
-            "https://cordis.run/api/presets/code/download?v=v1-official-code"
-        );
     }
 
     #[test]
@@ -1009,16 +996,12 @@ mod tests {
     }
 
     #[test]
-    fn preset_allows_versioned_download_and_rejects_fragment_and_slug_mismatch() {
-        let versioned = parse_preset(&preset_raw(
-            "https://cordis.run/api/presets/code/download?v=v1-official-code",
-            "https://cordis.run/presets/code",
-        ));
-        assert_eq!(
-            versioned.url,
-            "https://cordis.run/api/presets/code/download?v=v1-official-code"
-        );
+    fn preset_rejects_query_fragment_and_slug_mismatch() {
         for raw in [
+            preset_raw(
+                "https://cordis.run/api/presets/code/download?v=v1-official-code",
+                "https://cordis.run/presets/code",
+            ),
             preset_raw(
                 "https://cordis.run/api/presets/code/download#frag",
                 "https://cordis.run/presets/code",
@@ -1067,6 +1050,7 @@ mod tests {
             "https://cordis.run/api/presets/code/download/extra",
             "https://cordis.run/api/presets/code/download?x=1",
             "https://cordis.run/api/presets/code/download?v=",
+            "https://cordis.run/api/presets/code/download?v=v1-official-code",
             "https://user:pass@cordis.run/api/presets/code/download",
             "https://cordis.run:8443/api/presets/code/download",
         ] {

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -160,6 +160,9 @@ fn main() {
             commands::market_search,
             commands::market_plugin,
             commands::market_image,
+            commands::market_prepare_install,
+            commands::market_install_plugin,
+            commands::activate_market_plugin,
             commands::sideload_plugin
         ]);
 

--- a/src-tauri/src/market.rs
+++ b/src-tauri/src/market.rs
@@ -176,8 +176,22 @@ pub fn is_valid_market_slug(slug: &str) -> bool {
 }
 
 fn base_url_allowed(url: &Url) -> bool {
-    let https_cordis = url.scheme() == "https" && url.host_str() == Some("cordis.run");
+    // CORDIS_RUN_API is a developer-only fixture override, not a general
+    // outbound proxy setting. Keep the production origin and API prefix
+    // exact so an inherited environment variable cannot silently widen the
+    // network trust boundary (for example with credentials, a custom port,
+    // or a same-host non-API route).
+    let structurally_canonical = url.username().is_empty()
+        && url.password().is_none()
+        && url.query().is_none()
+        && url.fragment().is_none()
+        && matches!(url.path(), "/api/v1" | "/api/v1/");
+    let https_cordis = structurally_canonical
+        && url.scheme() == "https"
+        && url.host_str() == Some("cordis.run")
+        && url.port().is_none();
     let debug_loopback = cfg!(debug_assertions)
+        && structurally_canonical
         && url.scheme() == "http"
         && matches!(url.host_str(), Some("127.0.0.1") | Some("localhost"));
     https_cordis || debug_loopback
@@ -219,7 +233,7 @@ impl MarketClient {
             Url::parse(&base_url).map_err(|e| format!("invalid CORDIS_RUN_API URL: {e}"))?;
         if !base_url_allowed(&parsed) {
             return Err(
-                "CORDIS_RUN_API must be https://cordis.run (debug builds may use http://127.0.0.1)"
+                "CORDIS_RUN_API must be https://cordis.run/api/v1 (debug builds may use http://127.0.0.1:<port>/api/v1)"
                     .to_string(),
             );
         }
@@ -1035,6 +1049,38 @@ mod tests {
         assert!(!image_url_allowed(
             &Url::parse("http://127.0.0.1/fixture.png").expect("url")
         ));
+    }
+
+    #[test]
+    fn base_url_is_limited_to_the_canonical_api_boundary() {
+        assert!(base_url_allowed(
+            &Url::parse("https://cordis.run/api/v1").expect("production API URL")
+        ));
+        assert!(base_url_allowed(
+            &Url::parse("https://cordis.run/api/v1/").expect("production API URL")
+        ));
+        assert!(base_url_allowed(
+            &Url::parse("http://127.0.0.1:3210/api/v1").expect("fixture API URL")
+        ));
+        assert!(base_url_allowed(
+            &Url::parse("http://localhost:3210/api/v1/").expect("fixture API URL")
+        ));
+
+        for raw in [
+            "https://cordis.run/",
+            "https://cordis.run/api/v1?fixture=1",
+            "https://cordis.run/api/v1#fragment",
+            "https://user:pass@cordis.run/api/v1",
+            "https://cordis.run:8443/api/v1",
+            "https://evil.example/api/v1",
+            "http://cordis.run/api/v1",
+            "http://127.0.0.1:3210/not-api",
+        ] {
+            assert!(
+                !base_url_allowed(&Url::parse(raw).expect("test URL")),
+                "should reject {raw}"
+            );
+        }
     }
 
     #[test]

--- a/src-tauri/src/market.rs
+++ b/src-tauri/src/market.rs
@@ -1,14 +1,19 @@
-//! cordis.run plugin-market client. The bootstrap webview cannot fetch
-//! external hosts under the app CSP, so every market request is made here.
-//! Results are cached in memory; a failed refresh returns the stale cache
-//! entry (when one exists) instead of dropping an otherwise usable catalog.
+//! cordis.run plugin-market client.
+//!
+//! The bootstrap webview cannot fetch external hosts under the app CSP, so
+//! every catalog request is made here. The wire DTO deliberately remains more
+//! permissive than the installation DTO: incomplete, blocked, deprecated, or
+//! non-npm entries can be displayed, but only a fully validated nested source
+//! can cross the installation boundary.
 
-use reqwest::header::CONTENT_TYPE;
+use reqwest::header::{CONTENT_TYPE, ETAG, IF_NONE_MATCH};
+use semver::{Version, VersionReq};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::sync::Mutex;
 use std::time::{Duration, Instant};
+use url::Url;
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
 struct Source {
@@ -29,6 +34,8 @@ struct Source {
 #[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(untagged)]
 enum Description {
+    // Transitional display-only compatibility. Never use this variant (or
+    // any old flat npm/version field) as an installation source.
     Text(String),
     Localized {
         #[serde(default)]
@@ -39,9 +46,11 @@ enum Description {
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
-struct MarketItem {
+struct MarketEntry {
     slug: String,
     name: String,
+    #[serde(rename = "entryRevision", default)]
+    entry_revision: Option<String>,
     #[serde(default)]
     source: Option<Source>,
     #[serde(default)]
@@ -51,6 +60,8 @@ struct MarketItem {
     #[serde(default)]
     platforms: Vec<String>,
     #[serde(default)]
+    engines: Option<BTreeMap<String, String>>,
+    #[serde(default)]
     stars: Option<u32>,
     #[serde(default)]
     homepage: Option<String>,
@@ -58,6 +69,12 @@ struct MarketItem {
     blocked: Option<bool>,
     #[serde(default)]
     deprecated: Option<bool>,
+    // These two fields are Desktop-derived. They are deliberately skipped
+    // while deserializing so a server cannot advertise an item as installable.
+    #[serde(default, skip_deserializing)]
+    installable: bool,
+    #[serde(rename = "installReason", default, skip_deserializing)]
+    install_reason: Option<String>,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
@@ -69,7 +86,7 @@ struct MarketVersion {
     #[serde(default)]
     platforms: Vec<String>,
     #[serde(default)]
-    engines: Option<serde_json::Value>,
+    engines: Option<BTreeMap<String, String>>,
     #[serde(default)]
     blocked: Option<bool>,
     #[serde(default)]
@@ -80,24 +97,8 @@ struct MarketVersion {
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
 struct MarketDetail {
-    slug: String,
-    name: String,
-    #[serde(default)]
-    source: Option<Source>,
-    #[serde(default)]
-    description: Option<Description>,
-    #[serde(default)]
-    category: Option<String>,
-    #[serde(default)]
-    platforms: Vec<String>,
-    #[serde(default)]
-    stars: Option<u32>,
-    #[serde(default)]
-    homepage: Option<String>,
-    #[serde(default)]
-    blocked: Option<bool>,
-    #[serde(default)]
-    deprecated: Option<bool>,
+    #[serde(flatten)]
+    entry: MarketEntry,
     #[serde(default)]
     screenshots: Vec<String>,
     #[serde(default)]
@@ -116,20 +117,53 @@ struct MarketPage {
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
 struct MarketSearchResponse {
+    #[serde(rename = "schemaVersion", default)]
+    schema_version: Option<u32>,
+    #[serde(rename = "catalogRevision", default)]
+    catalog_revision: Option<String>,
     #[serde(default)]
-    items: Vec<MarketItem>,
+    items: Vec<MarketEntry>,
     #[serde(default)]
     count: u32,
     #[serde(default)]
     page: MarketPage,
 }
 
+#[derive(Debug, Deserialize)]
+struct ApiErrorBody {
+    error: ApiError,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct ApiError {
+    code: String,
+    message: String,
+    request_id: Option<String>,
+}
+
+/// Fully validated, immutable nested source used by the Desktop installation
+/// flow. It intentionally has no legacy flat-field fallback.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct MarketInstallCandidate {
+    pub slug: String,
+    pub entry_revision: String,
+    pub package_name: String,
+    pub version: String,
+    pub integrity: String,
+    pub registry: String,
+    pub tarball: String,
+}
+
 const DEFAULT_BASE_URL: &str = "https://cordis.run/api/v1";
 const SEARCH_TTL: Duration = Duration::from_secs(60);
 const DETAIL_TTL: Duration = Duration::from_secs(300);
+const STALE_MAX_AGE: Duration = Duration::from_secs(24 * 60 * 60);
 const IMAGE_MAX_BYTES: usize = 2 * 1024 * 1024;
 const JSON_MAX_BYTES: usize = 1024 * 1024;
 const CACHE_MAX_ENTRIES: usize = 64;
+const APPROVED_NPM_REGISTRY_HOSTS: &[&str] = &["registry.npmjs.org"];
 
 pub fn is_valid_market_slug(slug: &str) -> bool {
     let bytes = slug.as_bytes();
@@ -141,7 +175,7 @@ pub fn is_valid_market_slug(slug: &str) -> bool {
             .all(|b| b.is_ascii_lowercase() || b.is_ascii_digit() || b == b'-')
 }
 
-fn base_url_allowed(url: &reqwest::Url) -> bool {
+fn base_url_allowed(url: &Url) -> bool {
     let https_cordis = url.scheme() == "https" && url.host_str() == Some("cordis.run");
     let debug_loopback = cfg!(debug_assertions)
         && url.scheme() == "http"
@@ -149,10 +183,20 @@ fn base_url_allowed(url: &reqwest::Url) -> bool {
     https_cordis || debug_loopback
 }
 
+fn image_url_allowed(url: &Url) -> bool {
+    url.scheme() == "https"
+        && url.host_str() == Some("cdn.cordis.run")
+        && url.port().is_none()
+        && url.username().is_empty()
+        && url.password().is_none()
+        && url.fragment().is_none()
+}
+
 #[derive(Debug, Clone)]
 struct Cached {
     at: Instant,
     value: Value,
+    etag: Option<String>,
 }
 
 /// Market client state. Managed once and shared across Tauri commands.
@@ -167,14 +211,18 @@ impl MarketClient {
     pub fn new() -> Result<Self, String> {
         let base_url =
             std::env::var("CORDIS_RUN_API").unwrap_or_else(|_| DEFAULT_BASE_URL.to_string());
-        let base_url = {
-            let parsed = reqwest::Url::parse(&base_url)
-                .map_err(|e| format!("invalid CORDIS_RUN_API URL: {e}"))?;
-            if !base_url_allowed(&parsed) {
-                return Err("CORDIS_RUN_API must be https://cordis.run (debug builds may use http://127.0.0.1)".to_string());
-            }
-            base_url
-        };
+        Self::with_base_url(base_url)
+    }
+
+    fn with_base_url(base_url: String) -> Result<Self, String> {
+        let parsed =
+            Url::parse(&base_url).map_err(|e| format!("invalid CORDIS_RUN_API URL: {e}"))?;
+        if !base_url_allowed(&parsed) {
+            return Err(
+                "CORDIS_RUN_API must be https://cordis.run (debug builds may use http://127.0.0.1)"
+                    .to_string(),
+            );
+        }
         let http = reqwest::Client::builder()
             .timeout(Duration::from_secs(10))
             .redirect(reqwest::redirect::Policy::none())
@@ -189,7 +237,7 @@ impl MarketClient {
         })
     }
 
-    fn cache_get(
+    fn cache_fresh(
         cache: &Mutex<HashMap<String, Cached>>,
         key: &str,
         ttl: Duration,
@@ -206,12 +254,27 @@ impl MarketClient {
         })
     }
 
-    fn cache_put(cache: &Mutex<HashMap<String, Cached>>, key: &str, value: Value) {
+    fn cache_any(cache: &Mutex<HashMap<String, Cached>>, key: &str) -> Option<Cached> {
+        let cache = cache
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        cache
+            .get(key)
+            .filter(|entry| entry.at.elapsed() < STALE_MAX_AGE)
+            .cloned()
+    }
+
+    fn cache_put(
+        cache: &Mutex<HashMap<String, Cached>>,
+        key: &str,
+        value: Value,
+        etag: Option<String>,
+    ) {
         let mut cache = cache
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner());
-        cache.retain(|_, entry| entry.at.elapsed() < Duration::from_secs(24 * 60 * 60));
-        if cache.len() >= CACHE_MAX_ENTRIES {
+        cache.retain(|_, entry| entry.at.elapsed() < STALE_MAX_AGE);
+        if cache.len() >= CACHE_MAX_ENTRIES && !cache.contains_key(key) {
             let oldest = cache
                 .iter()
                 .min_by_key(|(_, entry)| entry.at)
@@ -225,8 +288,82 @@ impl MarketClient {
             Cached {
                 at: Instant::now(),
                 value,
+                etag,
             },
         );
+    }
+
+    fn cache_revalidated(cache: &Mutex<HashMap<String, Cached>>, key: &str) -> Option<Value> {
+        let mut cache = cache
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let entry = cache.get_mut(key)?;
+        if entry.at.elapsed() >= STALE_MAX_AGE {
+            return None;
+        }
+        entry.at = Instant::now();
+        Some(entry.value.clone())
+    }
+
+    /// Fetch JSON with a conditional request once a cached representation is
+    /// stale. 304 refreshes the cache timestamp without attempting to parse a
+    /// body. HTTP API errors deliberately never fall back to stale data:
+    /// otherwise a deleted detail could be mistaken for a live catalog entry.
+    async fn cached_json(
+        &self,
+        cache: &Mutex<HashMap<String, Cached>>,
+        key: &str,
+        ttl: Duration,
+        url: Url,
+        label: &str,
+        force_revalidate: bool,
+    ) -> Result<Value, String> {
+        if !force_revalidate {
+            if let Some(fresh) = Self::cache_fresh(cache, key, ttl) {
+                return Ok(fresh);
+            }
+        }
+
+        let previous = Self::cache_any(cache, key);
+        let mut request = self.http.get(url);
+        if let Some(etag) = previous.as_ref().and_then(|entry| entry.etag.as_deref()) {
+            request = request.header(IF_NONE_MATCH, etag);
+        }
+        let response = match request.send().await {
+            Ok(response) => response,
+            Err(error) => {
+                // Catalog browsing may remain available while offline, but an
+                // install/activation decision must be based on a live (or
+                // conditionally revalidated 304) detail response. Returning
+                // a stale candidate here would let a revoked revision cross
+                // the confirmation boundary after a network failure.
+                if !force_revalidate {
+                    if let Some(stale) = previous {
+                        return Ok(stale.value);
+                    }
+                }
+                return Err(format!("{label} request failed: {error}"));
+            }
+        };
+        if response.status() == reqwest::StatusCode::NOT_MODIFIED {
+            return Self::cache_revalidated(cache, key)
+                .ok_or_else(|| format!("{label} returned HTTP 304 without a cached response"));
+        }
+
+        let status = response.status();
+        let etag = response
+            .headers()
+            .get(ETAG)
+            .and_then(|value| value.to_str().ok())
+            .map(str::to_owned);
+        let body = read_limited_json_body(response).await?;
+        if !status.is_success() {
+            return Err(format_api_error(label, status, &body));
+        }
+        let json = serde_json::from_slice::<Value>(&body)
+            .map_err(|e| format!("{label} response was not JSON: {e}"))?;
+        Self::cache_put(cache, key, json.clone(), etag);
+        Ok(json)
     }
 
     pub async fn search(
@@ -235,9 +372,13 @@ impl MarketClient {
         category: Option<&str>,
         limit: Option<u32>,
         cursor: Option<&str>,
-        platform: &str,
+        dsh_version: &str,
     ) -> Result<Value, String> {
-        let limit = limit.unwrap_or(30);
+        // The Desktop catalog is intentionally never an all-platform endpoint.
+        // The backend command hardcodes this too; retaining it here prevents a
+        // future caller from accidentally widening the request.
+        let platform = "desktop";
+        let limit = limit.unwrap_or(50).clamp(1, 100);
         let cache_key = format!(
             "{:?}",
             (
@@ -245,125 +386,98 @@ impl MarketClient {
                 category.unwrap_or(""),
                 limit,
                 cursor.unwrap_or(""),
-                platform
+                platform,
+                dsh_version
             )
         );
-        if let Some(fresh) = Self::cache_get(&self.search_cache, &cache_key, SEARCH_TTL) {
-            return Ok(fresh);
-        }
-
         let url = format!("{}/plugins", self.base_url.trim_end_matches('/'));
-        let mut url = reqwest::Url::parse(&url).map_err(|e| format!("bad market base URL: {e}"))?;
+        let mut url = Url::parse(&url).map_err(|e| format!("bad market base URL: {e}"))?;
         url.query_pairs_mut()
             .append_pair("q", query)
             .append_pair("platform", platform)
             .append_pair("limit", &limit.to_string());
-        if let Some(cursor) = cursor {
-            if !cursor.is_empty() {
-                url.query_pairs_mut().append_pair("cursor", cursor);
-            }
+        if let Some(cursor) = cursor.filter(|cursor| !cursor.is_empty()) {
+            // Cursor values are opaque: only hand the exact server value back.
+            url.query_pairs_mut().append_pair("cursor", cursor);
         }
-        if let Some(category) = category {
+        if let Some(category) = category.filter(|category| !category.is_empty()) {
             url.query_pairs_mut().append_pair("category", category);
         }
 
-        let fetch = async {
-            let response = self
-                .http
-                .get(url)
-                .send()
-                .await
-                .map_err(|e| format!("market search request failed: {e}"))?;
-            if !response.status().is_success() {
-                return Err(format!("market search failed: HTTP {}", response.status()));
-            }
-            let body = read_limited_json_body(response).await?;
-            let mut parsed: MarketSearchResponse = serde_json::from_slice(&body)
-                .map_err(|e| format!("market search response was not JSON: {e}"))?;
-            // Defensive only: the server already filters by `platform`.
-            // Keep `count` and `page` exactly as sent — they are the server's
-            // cursor-pagination truth. If the server ignored the filter, the
-            // worst case is an item/count mismatch, not a wrong-platform
-            // install (the UI still checks platforms before installing).
-            parsed
-                .items
-                .retain(|item| item.platforms.iter().any(|p| p == platform));
-            let json = serde_json::to_value(parsed)
-                .map_err(|e| format!("market search response serialization failed: {e}"))?;
-            MarketClient::cache_put(&self.search_cache, &cache_key, json.clone());
-            Ok(json)
-        };
-
-        match fetch.await {
-            Ok(value) => Ok(value),
-            Err(error) => {
-                if let Some(stale) = Self::cache_get(
-                    &self.search_cache,
-                    &cache_key,
-                    Duration::from_secs(24 * 60 * 60),
-                ) {
-                    Ok(stale)
-                } else {
-                    Err(error)
-                }
-            }
+        let raw = self
+            .cached_json(
+                &self.search_cache,
+                &cache_key,
+                SEARCH_TTL,
+                url,
+                "market search",
+                false,
+            )
+            .await?;
+        let mut parsed: MarketSearchResponse = serde_json::from_value(raw)
+            .map_err(|e| format!("market search response did not match the v4 DTO: {e}"))?;
+        for item in &mut parsed.items {
+            annotate_installability(item, dsh_version);
         }
+        // Defensive only: the server already filters by platform. Keep count
+        // and page untouched because they are the server's pagination truth.
+        parsed
+            .items
+            .retain(|item| item.platforms.iter().any(|value| value == platform));
+        serde_json::to_value(parsed)
+            .map_err(|e| format!("market search response serialization failed: {e}"))
     }
 
-    pub async fn detail(&self, slug: &str) -> Result<Value, String> {
+    async fn fetch_detail(
+        &self,
+        slug: &str,
+        force_revalidate: bool,
+    ) -> Result<MarketDetail, String> {
         if !is_valid_market_slug(slug) {
             return Err("invalid market slug".to_string());
         }
-        let cache_key = slug.to_string();
-        if let Some(fresh) = Self::cache_get(&self.detail_cache, &cache_key, DETAIL_TTL) {
-            return Ok(fresh);
-        }
-
         let url = format!("{}/plugins/{slug}", self.base_url.trim_end_matches('/'));
+        let url = Url::parse(&url).map_err(|e| format!("bad market base URL: {e}"))?;
+        let raw = self
+            .cached_json(
+                &self.detail_cache,
+                slug,
+                DETAIL_TTL,
+                url,
+                "market detail",
+                force_revalidate,
+            )
+            .await?;
+        serde_json::from_value(raw)
+            .map_err(|e| format!("market detail response did not match the v4 DTO: {e}"))
+    }
 
-        let fetch = async {
-            let response = self
-                .http
-                .get(url)
-                .send()
-                .await
-                .map_err(|e| format!("market detail request failed: {e}"))?;
-            if !response.status().is_success() {
-                return Err(format!("market detail failed: HTTP {}", response.status()));
-            }
-            let body = read_limited_json_body(response).await?;
-            let detail: MarketDetail = serde_json::from_slice(&body)
-                .map_err(|e| format!("market detail response was not JSON: {e}"))?;
-            let json = serde_json::to_value(detail)
-                .map_err(|e| format!("market detail response serialization failed: {e}"))?;
-            MarketClient::cache_put(&self.detail_cache, &cache_key, json.clone());
-            Ok(json)
-        };
+    pub async fn detail(&self, slug: &str, dsh_version: &str) -> Result<Value, String> {
+        let mut detail = self.fetch_detail(slug, false).await?;
+        annotate_installability(&mut detail.entry, dsh_version);
+        serde_json::to_value(detail)
+            .map_err(|e| format!("market detail response serialization failed: {e}"))
+    }
 
-        match fetch.await {
-            Ok(value) => Ok(value),
-            Err(error) => {
-                if let Some(stale) = Self::cache_get(
-                    &self.detail_cache,
-                    &cache_key,
-                    Duration::from_secs(24 * 60 * 60),
-                ) {
-                    Ok(stale)
-                } else {
-                    Err(error)
-                }
-            }
-        }
+    /// Revalidate the detail even if its normal cache TTL has not elapsed.
+    /// A 304 still proves the previously cached entry is the current revision.
+    pub async fn prepare_install(
+        &self,
+        slug: &str,
+        dsh_version: &str,
+    ) -> Result<MarketInstallCandidate, String> {
+        let detail = self.fetch_detail(slug, true).await?;
+        candidate_from_entry(&detail.entry, dsh_version)
     }
 
     pub async fn image(&self, url: &str) -> Result<Value, String> {
-        let parsed = reqwest::Url::parse(url).map_err(|e| format!("invalid image URL: {e}"))?;
-        if !base_url_allowed(&parsed) {
-            return Err("market images must use an allowed market host".to_string());
+        let parsed = Url::parse(url).map_err(|e| format!("invalid image URL: {e}"))?;
+        if !image_url_allowed(&parsed) {
+            return Err("market images must use https://cdn.cordis.run".to_string());
         }
         let response = self
             .http
-            .get(url)
+            .get(parsed)
             .send()
             .await
             .map_err(|e| format!("image request failed: {e}"))?;
@@ -373,7 +487,7 @@ impl MarketClient {
         let content_type = response
             .headers()
             .get(CONTENT_TYPE)
-            .and_then(|v| v.to_str().ok())
+            .and_then(|value| value.to_str().ok())
             .unwrap_or("application/octet-stream")
             .to_string();
         if !content_type.starts_with("image/") {
@@ -382,6 +496,194 @@ impl MarketClient {
         let bytes = read_limited_image_body(response).await?;
         let data_url = format!("data:{content_type};base64,{}", base64_encode(&bytes));
         Ok(serde_json::json!({ "dataUrl": data_url }))
+    }
+}
+
+fn format_api_error(label: &str, status: reqwest::StatusCode, body: &[u8]) -> String {
+    match serde_json::from_slice::<ApiErrorBody>(body) {
+        Ok(parsed) => {
+            let request = parsed
+                .error
+                .request_id
+                .filter(|id| !id.is_empty())
+                .map(|id| format!(" (requestId: {id})"))
+                .unwrap_or_default();
+            format!(
+                "{label} failed: {} {}: {}{request}",
+                status, parsed.error.code, parsed.error.message
+            )
+        }
+        Err(_) => format!("{label} failed: HTTP {status}"),
+    }
+}
+
+fn required_wire_string<'a>(value: &'a Option<String>, field: &str) -> Result<&'a str, String> {
+    let value = value
+        .as_deref()
+        .ok_or_else(|| format!("market entry is missing {field}"))?;
+    if value.is_empty() || value.trim() != value || value.chars().any(char::is_control) {
+        return Err(format!("market entry has invalid {field}"));
+    }
+    Ok(value)
+}
+
+fn secure_https_url(raw: &str, field: &str) -> Result<Url, String> {
+    let url = Url::parse(raw).map_err(|e| format!("market entry has invalid {field}: {e}"))?;
+    if url.scheme() != "https"
+        || url.host_str().is_none()
+        || url.port().is_some()
+        || !url.username().is_empty()
+        || url.password().is_some()
+        || url.fragment().is_some()
+    {
+        return Err(format!("market entry has unsafe {field} URL"));
+    }
+    Ok(url)
+}
+
+fn is_valid_sha512_integrity(value: &str) -> bool {
+    let Some(encoded) = value.strip_prefix("sha512-") else {
+        return false;
+    };
+    if encoded.len() != 88 || !encoded.is_ascii() {
+        return false;
+    }
+    let bytes = encoded.as_bytes();
+    let padding = if bytes.ends_with(b"==") {
+        2
+    } else if bytes.ends_with(b"=") {
+        1
+    } else {
+        0
+    };
+    if padding > 2 || bytes[..bytes.len() - padding].contains(&b'=') {
+        return false;
+    }
+    if !bytes[..bytes.len() - padding]
+        .iter()
+        .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'+' | b'/'))
+    {
+        return false;
+    }
+    // SHA-512 output is 64 bytes, which always has two trailing "=" in
+    // canonical standard base64. Reject unusual encodings rather than trying
+    // to normalize them before they reach the lockfile verifier.
+    padding == 2 && (encoded.len() / 4) * 3 - padding == 64
+}
+
+fn parse_dsh_requirement(raw: &str) -> Result<VersionReq, String> {
+    VersionReq::parse(raw)
+        .or_else(|_| {
+            let normalized = raw.split_whitespace().collect::<Vec<_>>().join(", ");
+            VersionReq::parse(&normalized)
+        })
+        .map_err(|e| format!("market entry has invalid engines.dsh: {e}"))
+}
+
+/// Store distributions have an additional, locally pinned review boundary.
+/// Keep it in the candidate gate so the catalog UI, the confirmation preview,
+/// and the mutation command all agree that an unreviewed package is not
+/// installable. The command repeats this check as defense in depth because
+/// IPC callers must never rely on UI-derived state.
+fn distribution_allows_package(package_name: &str, store_build: bool) -> bool {
+    !store_build || crate::curated_plugins::is_allowed(package_name)
+}
+
+fn candidate_from_entry(
+    entry: &MarketEntry,
+    dsh_version: &str,
+) -> Result<MarketInstallCandidate, String> {
+    if !is_valid_market_slug(&entry.slug) {
+        return Err("market entry has invalid slug".to_string());
+    }
+    if entry.blocked != Some(false) {
+        return Err("this market entry is blocked and cannot be installed".to_string());
+    }
+    if entry.deprecated != Some(false) {
+        return Err("this market entry is deprecated and cannot be installed".to_string());
+    }
+    if !entry.platforms.iter().any(|platform| platform == "desktop") {
+        return Err("this market entry does not support desktop".to_string());
+    }
+
+    let entry_revision = required_wire_string(&entry.entry_revision, "entryRevision")?.to_owned();
+    let source = entry
+        .source
+        .as_ref()
+        .ok_or_else(|| "market entry is missing nested source".to_string())?;
+    if source.source_type.as_deref() != Some("npm") {
+        return Err("this market entry is not an npm source".to_string());
+    }
+    let package_name = required_wire_string(&source.package_name, "source.packageName")?;
+    if !crate::plugins::is_valid_package_name(package_name) {
+        return Err("market entry has invalid source.packageName".to_string());
+    }
+    if !distribution_allows_package(package_name, crate::build_info::STORE_BUILD) {
+        return Err(
+            "this market entry is not on the Microsoft Store reviewed plugin list".to_string(),
+        );
+    }
+    let version = required_wire_string(&source.version, "source.version")?;
+    Version::parse(version).map_err(|e| format!("market entry has invalid source.version: {e}"))?;
+    let integrity = required_wire_string(&source.integrity, "source.integrity")?;
+    if !is_valid_sha512_integrity(integrity) {
+        return Err("market entry has invalid source.integrity".to_string());
+    }
+    let registry_raw = required_wire_string(&source.registry, "source.registry")?;
+    let registry = secure_https_url(registry_raw, "source.registry")?;
+    let registry_host = registry
+        .host_str()
+        .ok_or_else(|| "market entry has invalid source.registry host".to_string())?;
+    if registry.path() != "/" || registry.query().is_some() {
+        return Err("market entry has unsafe source.registry URL".to_string());
+    }
+    if !APPROVED_NPM_REGISTRY_HOSTS.contains(&registry_host) {
+        return Err("market entry uses an unapproved npm registry host".to_string());
+    }
+    let tarball = required_wire_string(&source.tarball, "source.tarball")?;
+    let tarball_url = secure_https_url(tarball, "source.tarball")?;
+    if tarball_url.host_str() != Some(registry_host) {
+        return Err("market entry tarball host does not match its registry".to_string());
+    }
+    if tarball_url.query().is_some() {
+        return Err("market entry has unsafe source.tarball URL".to_string());
+    }
+
+    let dsh_range = entry
+        .engines
+        .as_ref()
+        .and_then(|engines| engines.get("dsh"))
+        .ok_or_else(|| "market entry is missing engines.dsh".to_string())?;
+    let requirement = parse_dsh_requirement(dsh_range)?;
+    let current = Version::parse(dsh_version)
+        .map_err(|e| format!("Desktop DSH version is unavailable or invalid: {e}"))?;
+    if !requirement.matches(&current) {
+        return Err(format!(
+            "this market entry requires DSH {dsh_range}, but Desktop runs {dsh_version}"
+        ));
+    }
+
+    Ok(MarketInstallCandidate {
+        slug: entry.slug.clone(),
+        entry_revision,
+        package_name: package_name.to_owned(),
+        version: version.to_owned(),
+        integrity: integrity.to_owned(),
+        registry: registry_raw.to_owned(),
+        tarball: tarball.to_owned(),
+    })
+}
+
+fn annotate_installability(entry: &mut MarketEntry, dsh_version: &str) {
+    match candidate_from_entry(entry, dsh_version) {
+        Ok(_) => {
+            entry.installable = true;
+            entry.install_reason = None;
+        }
+        Err(error) => {
+            entry.installable = false;
+            entry.install_reason = Some(error);
+        }
     }
 }
 
@@ -441,103 +743,297 @@ async fn read_limited_image_body(response: reqwest::Response) -> Result<Vec<u8>,
 #[allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
 mod tests {
     use super::*;
+    use std::io::{Read, Write};
+    use std::net::TcpListener;
 
-    #[test]
-    fn base_url_defaults_to_cordis_run() {
-        // Constructor reads env; the default path is covered by base_url builder.
-        let base = std::env::var("CORDIS_RUN_API").unwrap_or_else(|_| DEFAULT_BASE_URL.to_string());
-        assert_eq!(base, DEFAULT_BASE_URL);
+    const VALID_INTEGRITY: &str =
+        "sha512-CQpnWPrDwmP1+SMHXZhtLtJv90yiyVfluGsX5iNCVkrhQtU3TQHsUWPG9wkdk9Lgd5yNpAg9jQEo90CBaXgWMA==";
+
+    fn valid_entry() -> MarketEntry {
+        serde_json::from_value(serde_json::json!({
+            "slug": "fixture-plugin",
+            "name": "Fixture Plugin",
+            "entryRevision": "revision-1",
+            "description": {"zh": "中文说明", "en": "English description"},
+            "source": {
+                "type": "npm",
+                "packageName": "dsh-cc-tui",
+                "version": "1.0.0",
+                "integrity": VALID_INTEGRITY,
+                "registry": "https://registry.npmjs.org",
+                "tarball": "https://registry.npmjs.org/dsh-cc-tui/-/dsh-cc-tui-1.0.0.tgz"
+            },
+            "platforms": ["desktop"],
+            "engines": {"dsh": ">=0.1.0-rc.6 <0.2.0"},
+            "blocked": false,
+            "deprecated": false
+        }))
+        .expect("valid fixture entry")
     }
 
-    #[test]
-    fn parses_cursor_page_and_defensively_filters_items() {
-        let body = r#"{
-            "items": [
-                {
-                    "slug":"a",
-                    "name":"A",
-                    "source":{"type":"npm","packageName":"a-pkg","version":"1.0.0"},
-                    "description":{"zh":"甲","en":"A"},
-                    "platforms":["web","desktop"]
-                },
-                {
-                    "slug":"b",
-                    "name":"B",
-                    "source":{"type":"npm","packageName":"b-pkg","version":"2.0.0"},
-                    "platforms":["web"]
-                },
-                {
-                    "slug":"c",
-                    "name":"C",
-                    "source":{"type":"npm","packageName":"c-pkg","version":"3.0.0"},
-                    "platforms":["desktop"]
+    fn response(status: &str, headers: &[(&str, &str)], body: &str) -> String {
+        let mut out = format!("HTTP/1.1 {status}\r\nContent-Length: {}\r\n", body.len());
+        for (name, value) in headers {
+            out.push_str(&format!("{name}: {value}\r\n"));
+        }
+        out.push_str("\r\n");
+        out.push_str(body);
+        out
+    }
+
+    fn test_server(responses: Vec<String>) -> (String, std::thread::JoinHandle<Vec<String>>) {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind fixture server");
+        let port = listener.local_addr().expect("fixture address").port();
+        let worker = std::thread::spawn(move || {
+            let mut requests = Vec::new();
+            for response in responses {
+                let (mut stream, _) = listener.accept().expect("accept request");
+                let mut bytes = Vec::new();
+                let mut chunk = [0_u8; 1024];
+                loop {
+                    let count = stream.read(&mut chunk).expect("read request");
+                    if count == 0 {
+                        break;
+                    }
+                    bytes.extend_from_slice(&chunk[..count]);
+                    if bytes.windows(4).any(|window| window == b"\r\n\r\n") {
+                        break;
+                    }
                 }
-            ],
-            "count": 3,
-            "page": {"cursor":"opaque","hasMore":true,"limit":50}
-        }"#;
-        let mut parsed: MarketSearchResponse =
-            serde_json::from_str(body).expect("fixture should parse");
-        assert_eq!(parsed.page.limit, 50);
-        assert!(parsed.page.has_more);
-        assert_eq!(parsed.page.cursor.as_deref(), Some("opaque"));
-        parsed
-            .items
-            .retain(|item| item.platforms.iter().any(|p| p == "desktop"));
-        assert_eq!(parsed.items.len(), 2);
-        assert_eq!(parsed.items[0].slug, "a");
-        assert_eq!(
-            parsed.items[0]
-                .source
-                .as_ref()
-                .and_then(|s| s.package_name.as_deref()),
-            Some("a-pkg")
-        );
-        assert_eq!(parsed.items[1].slug, "c");
-        // Server pagination fields are preserved untouched.
-        assert_eq!(parsed.count, 3);
-        assert_eq!(parsed.page.limit, 50);
-        assert!(parsed.page.has_more);
-        assert_eq!(parsed.page.cursor.as_deref(), Some("opaque"));
-        match parsed.items[0].description.as_ref() {
-            Some(Description::Localized { zh, en }) => {
-                assert_eq!(zh.as_deref(), Some("甲"));
-                assert_eq!(en.as_deref(), Some("A"));
+                requests.push(String::from_utf8(bytes).expect("request is UTF-8"));
+                stream
+                    .write_all(response.as_bytes())
+                    .expect("write response");
             }
-            _ => panic!("description should parse as localized text"),
-        }
+            requests
+        });
+        (format!("http://127.0.0.1:{port}/api/v1"), worker)
+    }
+
+    fn test_server_disconnects_after_first_response(
+        first_response: String,
+    ) -> (String, std::thread::JoinHandle<()>) {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind fixture server");
+        let port = listener.local_addr().expect("fixture address").port();
+        let worker = std::thread::spawn(move || {
+            let (mut first, _) = listener.accept().expect("accept first request");
+            let mut bytes = [0_u8; 1024];
+            let _ = first.read(&mut bytes).expect("read first request");
+            first
+                .write_all(first_response.as_bytes())
+                .expect("write first response");
+            drop(first);
+
+            // Accept the conditional revalidation request and close the
+            // socket without a response. This models an interrupted network
+            // path, not an HTTP API error (which already must not be stale).
+            let (mut second, _) = listener.accept().expect("accept second request");
+            let _ = second.read(&mut bytes).expect("read second request");
+        });
+        (format!("http://127.0.0.1:{port}/api/v1"), worker)
     }
 
     #[test]
-    fn detail_defaults_screenshots_to_empty_and_parses_source() {
-        let detail: MarketDetail = serde_json::from_str(
-            r#"{"slug":"x","name":"X","platforms":["desktop"],"source":{"type":"npm","packageName":"x-pkg","version":"1.0.0"}}"#,
-        )
-        .expect("detail fixture should parse");
-        assert!(detail.screenshots.is_empty());
-        assert_eq!(detail.platforms, vec!["desktop".to_string()]);
+    fn parses_nested_source_and_bilingual_description() {
+        let entry = valid_entry();
         assert_eq!(
-            detail
+            entry
                 .source
                 .as_ref()
-                .and_then(|s| s.package_name.as_deref()),
-            Some("x-pkg")
+                .and_then(|source| source.package_name.as_deref()),
+            Some("dsh-cc-tui")
         );
+        match entry.description.as_ref() {
+            Some(Description::Localized { zh, en }) => {
+                assert_eq!(zh.as_deref(), Some("中文说明"));
+                assert_eq!(en.as_deref(), Some("English description"));
+            }
+            _ => panic!("localized description should deserialize"),
+        }
     }
 
     #[test]
-    fn loopback_allowed_only_in_debug_builds() {
-        let release_cordis =
-            base_url_allowed(&reqwest::Url::parse("https://cordis.run/api/v1").expect("url"));
-        assert!(release_cordis);
-        if cfg!(debug_assertions) {
-            let loopback = base_url_allowed(
-                &reqwest::Url::parse("http://127.0.0.1:8787/api/v1").expect("url"),
-            );
-            assert!(loopback);
+    fn candidate_accepts_only_complete_nested_npm_source() {
+        let entry = valid_entry();
+        let candidate =
+            candidate_from_entry(&entry, "0.1.0-rc.7").expect("fixture should be installable");
+        assert_eq!(candidate.entry_revision, "revision-1");
+        assert_eq!(candidate.package_name, "dsh-cc-tui");
+
+        let mut blocked = valid_entry();
+        blocked.blocked = Some(true);
+        assert!(candidate_from_entry(&blocked, "0.1.0-rc.7").is_err());
+
+        let mut deprecated = valid_entry();
+        deprecated.deprecated = Some(true);
+        assert!(candidate_from_entry(&deprecated, "0.1.0-rc.7").is_err());
+
+        let legacy: MarketEntry = serde_json::from_value(serde_json::json!({
+            "slug": "legacy",
+            "name": "Legacy",
+            "npm": "legacy-package",
+            "version": "1.0.0",
+            "platforms": ["desktop"],
+            "blocked": false,
+            "deprecated": false
+        }))
+        .expect("legacy display shape can deserialize");
+        assert!(candidate_from_entry(&legacy, "0.1.0-rc.7").is_err());
+    }
+
+    #[test]
+    fn blocked_entry_is_displayable_but_never_produces_install_candidate() {
+        let mut blocked = valid_entry();
+        blocked.blocked = Some(true);
+        annotate_installability(&mut blocked, "0.1.0-rc.7");
+        assert!(!blocked.installable);
+        assert!(blocked
+            .install_reason
+            .as_deref()
+            .is_some_and(|reason| reason.contains("blocked")));
+        assert!(candidate_from_entry(&blocked, "0.1.0-rc.7").is_err());
+    }
+
+    #[test]
+    fn candidate_rejects_bad_source_host_or_engine() {
+        let mut entry = valid_entry();
+        entry.source.as_mut().expect("source").tarball =
+            Some("https://evil.example/fixture-plugin.tgz".to_string());
+        assert!(candidate_from_entry(&entry, "0.1.0-rc.7").is_err());
+
+        let mut incompatible = valid_entry();
+        incompatible.engines = Some(BTreeMap::from([("dsh".to_string(), ">=0.2.0".to_string())]));
+        assert!(candidate_from_entry(&incompatible, "0.1.0-rc.7").is_err());
+        assert!(is_valid_sha512_integrity(VALID_INTEGRITY));
+        assert!(!is_valid_sha512_integrity("sha512-AAAA"));
+    }
+
+    #[test]
+    fn store_distribution_only_allows_the_reviewed_snapshot() {
+        assert!(distribution_allows_package("dsh-cc-tui", true));
+        assert!(!distribution_allows_package("fixture-plugin", true));
+        assert!(distribution_allows_package("fixture-plugin", false));
+    }
+
+    #[test]
+    fn search_uses_desktop_cursor_category_and_etag_revalidation() {
+        let body = serde_json::json!({
+            "items": [serde_json::to_value(valid_entry()).expect("serialize entry")],
+            "count": 1,
+            "page": {"cursor": "fixture:next", "hasMore": true, "limit": 1}
+        })
+        .to_string();
+        let (base, worker) = test_server(vec![
+            response(
+                "200 OK",
+                &[
+                    ("Content-Type", "application/json"),
+                    ("ETag", "\"fixture-v1\""),
+                ],
+                &body,
+            ),
+            response("304 Not Modified", &[("ETag", "\"fixture-v1\"")], ""),
+        ]);
+        let client = MarketClient::with_base_url(base).expect("client");
+        let first = tauri::async_runtime::block_on(client.search(
+            "",
+            Some("agent"),
+            Some(1),
+            Some("fixture:0"),
+            "0.1.0-rc.7",
+        ))
+        .expect("first search");
+        assert_eq!(first["count"], 1);
+        assert_eq!(first["page"]["cursor"], "fixture:next");
+        assert_eq!(first["items"][0]["installable"], true);
+        {
+            let mut cache = client.search_cache.lock().expect("cache");
+            for entry in cache.values_mut() {
+                entry.at = Instant::now() - SEARCH_TTL;
+            }
         }
-        assert!(!base_url_allowed(
-            &reqwest::Url::parse("https://evil.example/api/v1").expect("url")
+        let second = tauri::async_runtime::block_on(client.search(
+            "",
+            Some("agent"),
+            Some(1),
+            Some("fixture:0"),
+            "0.1.0-rc.7",
+        ))
+        .expect("304 should reuse cache");
+        assert_eq!(second["items"][0]["slug"], "fixture-plugin");
+        let requests = worker.join().expect("fixture worker");
+        let first_request = requests[0].to_ascii_lowercase();
+        assert!(first_request.contains("platform=desktop"));
+        assert!(first_request.contains("category=agent"));
+        assert!(first_request.contains("cursor=fixture%3a0"));
+        assert!(requests[1]
+            .to_ascii_lowercase()
+            .contains("if-none-match: \"fixture-v1\""));
+    }
+
+    #[test]
+    fn detail_404_is_reported_as_json_api_error() {
+        let (base, worker) = test_server(vec![response(
+            "404 Not Found",
+            &[("Content-Type", "application/json")],
+            r#"{"error":{"code":"NOT_FOUND","message":"no such slug","requestId":"req-1"}}"#,
+        )]);
+        let client = MarketClient::with_base_url(base).expect("client");
+        let error = tauri::async_runtime::block_on(client.detail("missing", "0.1.0-rc.7"))
+            .expect_err("detail should fail");
+        assert!(error.contains("NOT_FOUND: no such slug"));
+        assert!(error.contains("requestId: req-1"));
+        let _ = worker.join().expect("fixture worker");
+    }
+
+    #[test]
+    fn install_prepare_does_not_fall_back_to_stale_detail_after_network_failure() {
+        let body = serde_json::json!({
+            "slug": "fixture-plugin",
+            "name": "Fixture Plugin",
+            "entryRevision": "revision-1",
+            "source": {
+                "type": "npm",
+                "packageName": "fixture-plugin",
+                "version": "1.0.0",
+                "integrity": VALID_INTEGRITY,
+                "registry": "https://registry.npmjs.org",
+                "tarball": "https://registry.npmjs.org/fixture-plugin/-/fixture-plugin-1.0.0.tgz"
+            },
+            "platforms": ["desktop"],
+            "engines": {"dsh": ">=0.1.0-rc.6 <0.2.0"},
+            "blocked": false,
+            "deprecated": false
+        })
+        .to_string();
+        let (base, worker) = test_server_disconnects_after_first_response(response(
+            "200 OK",
+            &[
+                ("Content-Type", "application/json"),
+                ("ETag", "\"fixture-v1\""),
+            ],
+            &body,
+        ));
+        let client = MarketClient::with_base_url(base).expect("client");
+        let detail = tauri::async_runtime::block_on(client.detail("fixture-plugin", "0.1.0-rc.7"));
+        assert!(detail.is_ok(), "first detail request should populate cache");
+        let error =
+            tauri::async_runtime::block_on(client.prepare_install("fixture-plugin", "0.1.0-rc.7"))
+                .expect_err("install preparation must require live revalidation");
+        assert!(error.contains("market detail request failed"));
+        worker.join().expect("fixture worker");
+    }
+
+    #[test]
+    fn image_urls_are_cdn_only() {
+        assert!(image_url_allowed(
+            &Url::parse("https://cdn.cordis.run/screenshots/x/1.webp").expect("url")
+        ));
+        assert!(!image_url_allowed(
+            &Url::parse("https://cordis.run/screenshots/x/1.webp").expect("url")
+        ));
+        assert!(!image_url_allowed(
+            &Url::parse("http://127.0.0.1/fixture.png").expect("url")
         ));
     }
 

--- a/src-tauri/src/plugins.rs
+++ b/src-tauri/src/plugins.rs
@@ -561,6 +561,50 @@ fn lockfile_package_key(line: &str) -> Option<&str> {
     Some(raw)
 }
 
+/// pnpm writes the package key as `name@version` when no peer context is
+/// involved, but appends one or more parenthesized peer contexts when it is
+/// (for example `name@1.2.3(react@18.3.1)`).  The peer context is not part of
+/// the reviewed package identity, so accept it only after an exact
+/// `name@version` prefix and only when its delimiters are well-formed.  Do not
+/// use a loose prefix match here: `name@1.2.30(...)` must never satisfy a
+/// candidate for `name@1.2.3`.
+fn lockfile_package_key_matches(key: &str, expected: &str) -> bool {
+    if key == expected {
+        return true;
+    }
+    let Some(suffix) = key.strip_prefix(expected) else {
+        return false;
+    };
+    if !suffix.starts_with('(') {
+        return false;
+    }
+
+    let mut depth = 0_usize;
+    let mut group_has_content = false;
+    for character in suffix.chars() {
+        if character.is_control() || character.is_whitespace() {
+            return false;
+        }
+        match character {
+            '(' => {
+                if depth == 0 {
+                    group_has_content = false;
+                }
+                depth += 1;
+            }
+            ')' => {
+                if depth == 0 || !group_has_content {
+                    return false;
+                }
+                depth -= 1;
+            }
+            _ if depth == 0 => return false,
+            _ => group_has_content = true,
+        }
+    }
+    depth == 0 && group_has_content
+}
+
 fn yaml_scalar(raw: &str) -> &str {
     let raw = raw.trim();
     if raw.len() >= 2
@@ -612,7 +656,7 @@ fn lockfile_integrity(profile: &Path, package_name: &str, version: &str) -> Resu
             break;
         }
         if let Some(key) = lockfile_package_key(line) {
-            in_target = key == expected_key;
+            in_target = lockfile_package_key_matches(key, &expected_key);
             in_resolution = false;
             continue;
         }
@@ -1089,6 +1133,44 @@ mod tests {
                 .expect("quoted scoped package key should resolve"),
             candidate.integrity
         );
+        let _ = std::fs::remove_dir_all(&home);
+    }
+
+    #[test]
+    fn market_lockfile_reads_exact_version_with_pnpm_peer_context() {
+        let home = std::env::temp_dir().join(format!(
+            "dsh-market-peer-context-lock-{}",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_dir_all(&home);
+        let profile = home.join("profiles").join("web");
+        std::fs::create_dir_all(&profile).unwrap();
+        let candidate = crate::market::MarketInstallCandidate {
+            package_name: "@scope/demo".to_string(),
+            version: "1.0.0".to_string(),
+            ..market_candidate()
+        };
+        std::fs::write(
+            profile.join("pnpm-lock.yaml"),
+            format!(
+                "lockfileVersion: '9.0'\n\npackages:\n\n  '{}@{}(react@18.3.1)(typescript@5.7.3)':\n    resolution:\n      integrity: {}\n\nsnapshots:\n",
+                candidate.package_name, candidate.version, candidate.integrity
+            ),
+        )
+        .unwrap();
+        assert_eq!(
+            lockfile_integrity(&profile, &candidate.package_name, &candidate.version)
+                .expect("exact package version with peer context should resolve"),
+            candidate.integrity
+        );
+        assert!(!lockfile_package_key_matches(
+            "@scope/demo@1.0.00(react@18.3.1)",
+            "@scope/demo@1.0.0"
+        ));
+        assert!(!lockfile_package_key_matches(
+            "@scope/demo@1.0.0(peer context)",
+            "@scope/demo@1.0.0"
+        ));
         let _ = std::fs::remove_dir_all(&home);
     }
 

--- a/src-tauri/src/plugins.rs
+++ b/src-tauri/src/plugins.rs
@@ -6,6 +6,10 @@
 //! reconcile logic is untouched — we only make sure it finds a pnpm.
 
 use dsh_sidecar::platform::PlatformChild;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use std::collections::{BTreeMap, HashSet};
+use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Mutex;
@@ -185,6 +189,633 @@ pub fn ensure_pnpm_shim(dsh_home: &Path, node: &Path, pnpm_cjs: &Path) -> Result
             .map_err(|e| e.to_string())?;
     }
     Ok(dir)
+}
+
+// ---------------------------------------------------------------------------
+// cordis.run market installation state
+// ---------------------------------------------------------------------------
+//
+// The upstream dsh plugin add command intentionally reconciles every
+// installed dsh.bundle into dsh.profile.bundles. That is correct for its CLI,
+// but it would violate the market contract's pending-activation boundary.
+// Market installs therefore invoke the bundled pnpm directly (with scripts
+// disabled) and maintain this narrowly scoped, Desktop-owned pending record.
+
+const MARKET_PENDING_FILE: &str = "market-pending.json";
+const MARKET_PENDING_MAX_BYTES: u64 = 256 * 1024;
+const PROFILE_LOCK_MAX_BYTES: u64 = 4 * 1024 * 1024;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct MarketPendingPlugin {
+    pub slug: String,
+    pub entry_revision: String,
+    pub package_name: String,
+    pub version: String,
+    pub integrity: String,
+    pub registry: String,
+    pub tarball: String,
+}
+
+impl From<&crate::market::MarketInstallCandidate> for MarketPendingPlugin {
+    fn from(candidate: &crate::market::MarketInstallCandidate) -> Self {
+        MarketPendingPlugin {
+            slug: candidate.slug.clone(),
+            entry_revision: candidate.entry_revision.clone(),
+            package_name: candidate.package_name.clone(),
+            version: candidate.version.clone(),
+            integrity: candidate.integrity.clone(),
+            registry: candidate.registry.clone(),
+            tarball: candidate.tarball.clone(),
+        }
+    }
+}
+
+impl MarketPendingPlugin {
+    fn matches(&self, candidate: &crate::market::MarketInstallCandidate) -> bool {
+        self.slug == candidate.slug
+            && self.entry_revision == candidate.entry_revision
+            && self.package_name == candidate.package_name
+            && self.version == candidate.version
+            && self.integrity == candidate.integrity
+            && self.registry == candidate.registry
+            && self.tarball == candidate.tarball
+    }
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+struct MarketPendingFile {
+    #[serde(default)]
+    plugins: BTreeMap<String, MarketPendingPlugin>,
+}
+
+/// A bootstrap-facing installed-plugin row. pending is the only state that
+/// may be activated through the Desktop IPC; generic upstream-installed
+/// dependencies stay displayable but never gain a synthetic Activate button.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct InstalledPlugin {
+    pub name: String,
+    pub version: String,
+    pub state: String,
+    pub slug: Option<String>,
+    pub entry_revision: Option<String>,
+}
+
+fn checked_real_dir(path: &Path, label: &str) -> Result<(), String> {
+    let metadata =
+        std::fs::symlink_metadata(path).map_err(|e| format!("cannot inspect {label}: {e}"))?;
+    if metadata.file_type().is_symlink() {
+        return Err(format!("{label} must not be a symbolic link"));
+    }
+    if !metadata.is_dir() {
+        return Err(format!("{label} is not a directory"));
+    }
+    Ok(())
+}
+
+fn market_tools_dir(dsh_home: &Path) -> Result<PathBuf, String> {
+    checked_real_dir(dsh_home, "DSH_HOME")?;
+    let tools = dsh_home.join(".desktop-tools");
+    match std::fs::symlink_metadata(&tools) {
+        Ok(metadata) if metadata.file_type().is_symlink() => {
+            return Err("refusing to use symlinked .desktop-tools".to_string())
+        }
+        Ok(metadata) if !metadata.is_dir() => {
+            return Err(".desktop-tools is not a directory".to_string())
+        }
+        Ok(_) => {}
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            std::fs::create_dir_all(&tools)
+                .map_err(|e| format!("cannot create .desktop-tools: {e}"))?;
+        }
+        Err(error) => return Err(format!("cannot inspect .desktop-tools: {error}")),
+    }
+    checked_real_dir(&tools, ".desktop-tools")?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(&tools, std::fs::Permissions::from_mode(0o700))
+            .map_err(|e| format!("cannot chmod .desktop-tools: {e}"))?;
+    }
+    Ok(tools)
+}
+
+fn pending_path(dsh_home: &Path) -> Result<PathBuf, String> {
+    Ok(market_tools_dir(dsh_home)?.join(MARKET_PENDING_FILE))
+}
+
+fn load_pending(dsh_home: &Path) -> Result<MarketPendingFile, String> {
+    let path = pending_path(dsh_home)?;
+    match std::fs::symlink_metadata(&path) {
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            return Ok(MarketPendingFile::default())
+        }
+        Err(error) => return Err(format!("cannot inspect market pending state: {error}")),
+        Ok(metadata) if metadata.file_type().is_symlink() => {
+            return Err("market pending state must not be a symbolic link".to_string())
+        }
+        Ok(metadata) if !metadata.is_file() => {
+            return Err("market pending state is not a regular file".to_string())
+        }
+        Ok(metadata) if metadata.len() > MARKET_PENDING_MAX_BYTES => {
+            return Err("market pending state exceeds 256 KiB".to_string())
+        }
+        Ok(_) => {}
+    }
+    let text = std::fs::read_to_string(&path)
+        .map_err(|e| format!("cannot read market pending state: {e}"))?;
+    serde_json::from_str(&text).map_err(|e| format!("invalid market pending state: {e}"))
+}
+
+/// Replace a same-directory temporary file without ever following the
+/// destination as a symlink. `std::fs::rename` replaces an existing file on
+/// Unix but intentionally does not do so on Windows, where it would make the
+/// second pending-state write (the Activate path) fail. MoveFileExW supplies
+/// the corresponding replace-existing operation there.
+fn replace_existing_file(temp: &Path, destination: &Path, label: &str) -> Result<(), String> {
+    #[cfg(windows)]
+    {
+        use std::iter::once;
+        use std::os::windows::ffi::OsStrExt;
+        use windows_sys::Win32::Storage::FileSystem::{
+            MoveFileExW, MOVEFILE_REPLACE_EXISTING, MOVEFILE_WRITE_THROUGH,
+        };
+
+        let temp_wide: Vec<u16> = temp.as_os_str().encode_wide().chain(once(0)).collect();
+        let destination_wide: Vec<u16> = destination
+            .as_os_str()
+            .encode_wide()
+            .chain(once(0))
+            .collect();
+        // SAFETY: both buffers are NUL-terminated UTF-16 paths and remain
+        // alive throughout the synchronous Win32 call.
+        if unsafe {
+            MoveFileExW(
+                temp_wide.as_ptr(),
+                destination_wide.as_ptr(),
+                MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH,
+            )
+        } == 0
+        {
+            return Err(format!(
+                "cannot replace {label}: {}",
+                std::io::Error::last_os_error()
+            ));
+        }
+        Ok(())
+    }
+    #[cfg(not(windows))]
+    {
+        std::fs::rename(temp, destination).map_err(|e| format!("cannot replace {label}: {e}"))
+    }
+}
+
+fn write_pending(dsh_home: &Path, pending: &MarketPendingFile) -> Result<(), String> {
+    let path = pending_path(dsh_home)?;
+    match std::fs::symlink_metadata(&path) {
+        Ok(metadata) if metadata.file_type().is_symlink() => {
+            return Err("market pending state must not be a symbolic link".to_string())
+        }
+        Ok(metadata) if !metadata.is_file() => {
+            return Err("market pending state is not a regular file".to_string())
+        }
+        Ok(_) => {}
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+        Err(error) => return Err(format!("cannot inspect market pending state: {error}")),
+    }
+    let encoded = serde_json::to_vec_pretty(pending)
+        .map_err(|e| format!("cannot serialize market pending state: {e}"))?;
+    if encoded.len() as u64 > MARKET_PENDING_MAX_BYTES {
+        return Err("market pending state exceeds 256 KiB".to_string());
+    }
+    let millis = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|duration| duration.as_millis())
+        .unwrap_or(0);
+    let temp = path.with_file_name(format!(
+        ".market-pending-{}-{}.tmp",
+        std::process::id(),
+        millis
+    ));
+    let mut file = std::fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(&temp)
+        .map_err(|e| format!("cannot create pending-state temp file: {e}"))?;
+    file.write_all(&encoded)
+        .map_err(|e| format!("cannot write pending-state temp file: {e}"))?;
+    file.write_all(b"\n")
+        .map_err(|e| format!("cannot finalize pending-state temp file: {e}"))?;
+    file.sync_all()
+        .map_err(|e| format!("cannot sync pending-state temp file: {e}"))?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(&temp, std::fs::Permissions::from_mode(0o600))
+            .map_err(|e| format!("cannot chmod pending-state temp file: {e}"))?;
+    }
+    replace_existing_file(&temp, &path, "market pending state")?;
+    Ok(())
+}
+
+fn profile_dir(dsh_home: &Path) -> Result<PathBuf, String> {
+    checked_real_dir(dsh_home, "DSH_HOME")?;
+    let profiles = dsh_home.join("profiles");
+    checked_real_dir(&profiles, "profiles directory")?;
+    let web = profiles.join("web");
+    checked_real_dir(&web, "web profile directory")?;
+    let manifest = web.join("package.json");
+    let metadata = std::fs::symlink_metadata(&manifest)
+        .map_err(|e| format!("cannot inspect web profile package.json: {e}"))?;
+    if metadata.file_type().is_symlink() || !metadata.is_file() {
+        return Err("web profile package.json must be a regular file".to_string());
+    }
+    Ok(web)
+}
+
+/// Resolve the already-initialized web profile for a direct market pnpm
+/// operation. It deliberately does not create a profile: Harness owns the
+/// initialization template and must have started successfully first.
+pub fn market_profile_dir(dsh_home: &Path) -> Result<PathBuf, String> {
+    profile_dir(dsh_home)
+}
+
+fn read_profile_manifest(dsh_home: &Path) -> Result<(PathBuf, Value), String> {
+    let profile = profile_dir(dsh_home)?;
+    let manifest = profile.join("package.json");
+    let text = std::fs::read_to_string(&manifest)
+        .map_err(|e| format!("cannot read web profile package.json: {e}"))?;
+    let value: Value = serde_json::from_str(&text)
+        .map_err(|e| format!("web profile package.json is invalid JSON: {e}"))?;
+    if !value.is_object() {
+        return Err("web profile package.json must contain an object".to_string());
+    }
+    Ok((profile, value))
+}
+
+fn write_profile_manifest(profile: &Path, value: &Value) -> Result<(), String> {
+    let path = profile.join("package.json");
+    let metadata = std::fs::symlink_metadata(&path)
+        .map_err(|e| format!("cannot inspect web profile package.json: {e}"))?;
+    if metadata.file_type().is_symlink() || !metadata.is_file() {
+        return Err("web profile package.json must be a regular file".to_string());
+    }
+    let text = serde_json::to_string_pretty(value)
+        .map_err(|e| format!("cannot serialize web profile package.json: {e}"))?;
+    let millis = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|duration| duration.as_millis())
+        .unwrap_or(0);
+    let temp = path.with_file_name(format!(
+        ".profile-package-{}-{}.tmp",
+        std::process::id(),
+        millis
+    ));
+    let mut file = std::fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(&temp)
+        .map_err(|e| format!("cannot create web profile package.json temp file: {e}"))?;
+    file.write_all(text.as_bytes())
+        .map_err(|e| format!("cannot write web profile package.json: {e}"))?;
+    file.write_all(b"\n")
+        .map_err(|e| format!("cannot finalize web profile package.json: {e}"))?;
+    file.sync_all()
+        .map_err(|e| format!("cannot sync web profile package.json: {e}"))?;
+    #[cfg(unix)]
+    {
+        std::fs::set_permissions(&temp, metadata.permissions())
+            .map_err(|e| format!("cannot preserve web profile package.json permissions: {e}"))?;
+    }
+    replace_existing_file(&temp, &path, "web profile package.json")
+}
+
+fn profile_bundles_mut(value: &mut Value) -> Result<&mut Vec<Value>, String> {
+    value
+        .get_mut("dsh")
+        .and_then(Value::as_object_mut)
+        .and_then(|dsh| dsh.get_mut("profile"))
+        .and_then(Value::as_object_mut)
+        .and_then(|profile| profile.get_mut("bundles"))
+        .and_then(Value::as_array_mut)
+        .ok_or_else(|| "web profile package.json has no dsh.profile.bundles array".to_string())
+}
+
+fn profile_bundles(value: &Value) -> Result<HashSet<&str>, String> {
+    let values = value
+        .get("dsh")
+        .and_then(Value::as_object)
+        .and_then(|dsh| dsh.get("profile"))
+        .and_then(Value::as_object)
+        .and_then(|profile| profile.get("bundles"))
+        .and_then(Value::as_array)
+        .ok_or_else(|| "web profile package.json has no dsh.profile.bundles array".to_string())?;
+    values
+        .iter()
+        .map(|value| {
+            value
+                .as_str()
+                .ok_or_else(|| "web profile bundles contains a non-string value".to_string())
+        })
+        .collect()
+}
+
+fn profile_dependencies(value: &Value) -> Result<&serde_json::Map<String, Value>, String> {
+    value
+        .get("dependencies")
+        .and_then(Value::as_object)
+        .ok_or_else(|| "web profile package.json has no dependencies object".to_string())
+}
+
+/// Before direct pnpm installation, remove an already active catalog package
+/// from the bundle list. This guarantees a replacement cannot take effect
+/// while its new artifact is being inspected and verified.
+pub fn pre_disable_market_plugin(
+    dsh_home: &Path,
+    candidate: &crate::market::MarketInstallCandidate,
+) -> Result<(), String> {
+    let (profile, mut manifest) = read_profile_manifest(dsh_home)?;
+    let bundles = profile_bundles_mut(&mut manifest)?;
+    for bundle in bundles.iter() {
+        if bundle.as_str().is_none() {
+            return Err("web profile bundles contains a non-string value".to_string());
+        }
+    }
+    bundles.retain(|bundle| bundle.as_str() != Some(candidate.package_name.as_str()));
+    write_profile_manifest(&profile, &manifest)
+}
+
+fn lockfile_package_key(line: &str) -> Option<&str> {
+    let raw = line.strip_prefix("  ")?;
+    if raw.starts_with("  ") || !raw.ends_with(':') {
+        return None;
+    }
+    let raw = raw.strip_suffix(':')?;
+    if raw.len() >= 2
+        && ((raw.starts_with('\'') && raw.ends_with('\''))
+            || (raw.starts_with('"') && raw.ends_with('"')))
+    {
+        return Some(&raw[1..raw.len() - 1]);
+    }
+    Some(raw)
+}
+
+fn yaml_scalar(raw: &str) -> &str {
+    let raw = raw.trim();
+    if raw.len() >= 2
+        && ((raw.starts_with('\'') && raw.ends_with('\''))
+            || (raw.starts_with('"') && raw.ends_with('"')))
+    {
+        &raw[1..raw.len() - 1]
+    } else {
+        raw
+    }
+}
+
+fn inline_lockfile_integrity(line: &str) -> Option<&str> {
+    let fields = line
+        .trim()
+        .strip_prefix("resolution: {")?
+        .strip_suffix('}')?;
+    fields
+        .split(',')
+        .find_map(|field| field.trim().strip_prefix("integrity: "))
+        .map(yaml_scalar)
+}
+
+fn lockfile_integrity(profile: &Path, package_name: &str, version: &str) -> Result<String, String> {
+    let path = profile.join("pnpm-lock.yaml");
+    let metadata = std::fs::symlink_metadata(&path)
+        .map_err(|e| format!("cannot inspect pnpm lockfile: {e}"))?;
+    if metadata.file_type().is_symlink() || !metadata.is_file() {
+        return Err("pnpm lockfile must be a regular file".to_string());
+    }
+    if metadata.len() > PROFILE_LOCK_MAX_BYTES {
+        return Err("pnpm lockfile exceeds 4 MiB".to_string());
+    }
+    let text =
+        std::fs::read_to_string(&path).map_err(|e| format!("cannot read pnpm lockfile: {e}"))?;
+    let expected_key = format!("{package_name}@{version}");
+    let mut in_packages = false;
+    let mut in_target = false;
+    let mut in_resolution = false;
+    for line in text.lines() {
+        if line == "packages:" {
+            in_packages = true;
+            continue;
+        }
+        if !in_packages {
+            continue;
+        }
+        if line == "snapshots:" {
+            break;
+        }
+        if let Some(key) = lockfile_package_key(line) {
+            in_target = key == expected_key;
+            in_resolution = false;
+            continue;
+        }
+        if !in_target {
+            continue;
+        }
+        if let Some(integrity) = inline_lockfile_integrity(line) {
+            return Ok(integrity.to_string());
+        }
+        if line == "    resolution:" {
+            in_resolution = true;
+            continue;
+        }
+        if in_resolution {
+            if let Some(integrity) = line.trim().strip_prefix("integrity: ") {
+                return Ok(yaml_scalar(integrity).to_string());
+            }
+            if !line.starts_with("      ") {
+                in_resolution = false;
+            }
+        }
+    }
+    Err(format!(
+        "pnpm lockfile does not contain integrity for {package_name}@{version}"
+    ))
+}
+
+/// Verify all installation facts pnpm materialized. No build script can run
+/// in the market pnpm invocation, and normal pending verification requires
+/// the profile to stay pre-disabled throughout this check.
+fn verify_market_installation(
+    dsh_home: &Path,
+    candidate: &crate::market::MarketInstallCandidate,
+    require_inactive: bool,
+) -> Result<(), String> {
+    let (profile, manifest) = read_profile_manifest(dsh_home)?;
+    let spec = profile_dependencies(&manifest)?
+        .get(&candidate.package_name)
+        .and_then(Value::as_str)
+        .ok_or_else(|| "pnpm did not add the expected market dependency".to_string())?;
+    if spec != candidate.tarball {
+        return Err(
+            "pnpm saved a dependency source different from the reviewed tarball".to_string(),
+        );
+    }
+    if require_inactive && profile_bundles(&manifest)?.contains(candidate.package_name.as_str()) {
+        return Err("market package became active before explicit activation".to_string());
+    }
+
+    let installed_manifest = profile
+        .join("node_modules")
+        .join(&candidate.package_name)
+        .join("package.json");
+    let text = std::fs::read_to_string(&installed_manifest)
+        .map_err(|e| format!("cannot read installed market package: {e}"))?;
+    let installed: Value = serde_json::from_str(&text)
+        .map_err(|e| format!("installed market package has invalid JSON: {e}"))?;
+    if installed.get("name").and_then(Value::as_str) != Some(candidate.package_name.as_str())
+        || installed.get("version").and_then(Value::as_str) != Some(candidate.version.as_str())
+    {
+        return Err(
+            "installed market package name/version differs from the reviewed source".to_string(),
+        );
+    }
+    if installed
+        .get("dsh")
+        .and_then(Value::as_object)
+        .and_then(|dsh| dsh.get("bundle"))
+        .and_then(Value::as_object)
+        .and_then(|bundle| bundle.get("patch"))
+        .and_then(Value::as_str)
+        .filter(|patch| !patch.is_empty())
+        .is_none()
+    {
+        return Err("installed market package is not a DSH bundle".to_string());
+    }
+    if lockfile_integrity(&profile, &candidate.package_name, &candidate.version)?
+        != candidate.integrity
+    {
+        return Err("pnpm lockfile integrity differs from the reviewed source".to_string());
+    }
+
+    Ok(())
+}
+
+/// Verify all installation facts pnpm materialized before recording a pending
+/// activation. No build script can run in the market pnpm invocation, and the
+/// profile remains pre-disabled throughout this check.
+pub fn verify_and_mark_market_pending(
+    dsh_home: &Path,
+    candidate: &crate::market::MarketInstallCandidate,
+) -> Result<(), String> {
+    verify_market_installation(dsh_home, candidate, true)?;
+
+    let mut pending = load_pending(dsh_home)?;
+    pending.plugins.insert(
+        candidate.package_name.clone(),
+        MarketPendingPlugin::from(candidate),
+    );
+    write_pending(dsh_home, &pending)
+}
+
+/// Explicit activation gate. The caller has freshly revalidated the catalog
+/// candidate first; this function verifies the local pending record and
+/// materialized package one more time before touching dsh.profile.bundles.
+///
+/// The bundle list is committed before the marker is removed. If the process
+/// stops in between, the next read shows the package as active and a retry can
+/// finish marker cleanup instead of leaving it falsely pending forever.
+pub fn activate_market_plugin(
+    dsh_home: &Path,
+    candidate: &crate::market::MarketInstallCandidate,
+) -> Result<(), String> {
+    let mut pending = load_pending(dsh_home)?;
+    let expected = pending
+        .plugins
+        .get(&candidate.package_name)
+        .ok_or_else(|| "market package is not awaiting activation".to_string())?;
+    if !expected.matches(candidate) {
+        return Err(
+            "market package pending state does not match the current catalog entry".to_string(),
+        );
+    }
+    // A previous Activate can have completed the profile write just before a
+    // process crash. In that recovery case accept the already-active bundle
+    // after re-verifying its exact source, then clean up the marker below.
+    verify_market_installation(dsh_home, candidate, false)?;
+
+    let (profile, mut manifest) = read_profile_manifest(dsh_home)?;
+    let bundles = profile_bundles_mut(&mut manifest)?;
+    for bundle in bundles.iter() {
+        if bundle.as_str().is_none() {
+            return Err("web profile bundles contains a non-string value".to_string());
+        }
+    }
+    if !bundles
+        .iter()
+        .any(|bundle| bundle.as_str() == Some(candidate.package_name.as_str()))
+    {
+        bundles.push(Value::String(candidate.package_name.clone()));
+        write_profile_manifest(&profile, &manifest)?;
+    }
+
+    // Keep the marker until after the activation write. A cleanup failure is
+    // surfaced explicitly; the installed-list view prioritizes the active
+    // bundle, so it will never invite a second activation.
+    pending.plugins.remove(&candidate.package_name);
+    write_pending(dsh_home, &pending).map_err(|error| {
+        format!("plugin was activated, but pending-state cleanup failed: {error}")
+    })?;
+    Ok(())
+}
+
+/// Read package rows for the bootstrap UI. Failure is intentionally
+/// non-fatal for the status page: the command returns an empty list while
+/// mutation paths above remain fail-closed.
+pub fn installed_plugins(dsh_home: &Path) -> Vec<InstalledPlugin> {
+    let Ok((profile, manifest)) = read_profile_manifest(dsh_home) else {
+        return Vec::new();
+    };
+    let Ok(dependencies) = profile_dependencies(&manifest) else {
+        return Vec::new();
+    };
+    let bundles = profile_bundles(&manifest).unwrap_or_default();
+    let pending = load_pending(dsh_home).unwrap_or_default();
+    let mut entries = Vec::new();
+    for name in dependencies.keys() {
+        let version =
+            std::fs::read_to_string(profile.join("node_modules").join(name).join("package.json"))
+                .ok()
+                .and_then(|text| serde_json::from_str::<Value>(&text).ok())
+                .and_then(|package| {
+                    package
+                        .get("version")
+                        .and_then(Value::as_str)
+                        .map(str::to_owned)
+                })
+                .unwrap_or_else(|| "—".to_string());
+        let marker = pending
+            .plugins
+            .get(name)
+            .filter(|marker| marker.version == version);
+        let (state, slug, entry_revision) = if bundles.contains(name.as_str()) {
+            ("active".to_string(), None, None)
+        } else if let Some(marker) = marker {
+            (
+                "pending".to_string(),
+                Some(marker.slug.clone()),
+                Some(marker.entry_revision.clone()),
+            )
+        } else {
+            ("installed".to_string(), None, None)
+        };
+        entries.push(InstalledPlugin {
+            name: name.clone(),
+            version,
+            state,
+            slug,
+            entry_revision,
+        });
+    }
+    entries.sort_by(|left, right| left.name.cmp(&right.name));
+    entries
 }
 
 /// The runner state managed by the shell: single-flight flag, app-exit
@@ -375,6 +1006,158 @@ mod tests {
             String::from_utf8_lossy(&output.stderr),
         );
         assert!(!String::from_utf8_lossy(&output.stdout).trim().is_empty());
+        let _ = std::fs::remove_dir_all(&home);
+    }
+
+    fn market_candidate() -> crate::market::MarketInstallCandidate {
+        crate::market::MarketInstallCandidate {
+            slug: "fixture-plugin".to_string(),
+            entry_revision: "revision-1".to_string(),
+            package_name: "fixture-plugin".to_string(),
+            version: "1.0.0".to_string(),
+            integrity: "sha512-CQpnWPrDwmP1+SMHXZhtLtJv90yiyVfluGsX5iNCVkrhQtU3TQHsUWPG9wkdk9Lgd5yNpAg9jQEo90CBaXgWMA==".to_string(),
+            registry: "https://registry.npmjs.org".to_string(),
+            tarball: "https://registry.npmjs.org/fixture-plugin/-/fixture-plugin-1.0.0.tgz".to_string(),
+        }
+    }
+
+    fn setup_market_profile(home: &Path, candidate: &crate::market::MarketInstallCandidate) {
+        let profile = home.join("profiles").join("web");
+        std::fs::create_dir_all(profile.join("node_modules").join(&candidate.package_name))
+            .unwrap();
+        let mut dependencies = serde_json::Map::new();
+        dependencies.insert(
+            candidate.package_name.clone(),
+            Value::String(candidate.tarball.clone()),
+        );
+        let manifest = serde_json::json!({
+            "name": "dsh-profile-web",
+            "private": true,
+            "dependencies": dependencies,
+            "dsh": {"profile": {"bundles": [candidate.package_name.clone()]}}
+        });
+        std::fs::write(
+            profile.join("package.json"),
+            serde_json::to_string_pretty(&manifest).unwrap(),
+        )
+        .unwrap();
+        let package = serde_json::json!({
+            "name": candidate.package_name,
+            "version": candidate.version,
+            "dsh": {"bundle": {"patch": "./cordis.patch.yml"}}
+        });
+        std::fs::write(
+            profile
+                .join("node_modules")
+                .join(&candidate.package_name)
+                .join("package.json"),
+            serde_json::to_string_pretty(&package).unwrap(),
+        )
+        .unwrap();
+        std::fs::write(
+            profile.join("pnpm-lock.yaml"),
+            format!(
+                "lockfileVersion: '9.0'\n\npackages:\n\n  {}@{}:\n    resolution: {{integrity: {}}}\n\nsnapshots:\n",
+                candidate.package_name, candidate.version, candidate.integrity
+            ),
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn market_lockfile_reads_quoted_scoped_pnpm_package_keys() {
+        let home =
+            std::env::temp_dir().join(format!("dsh-market-scoped-lock-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&home);
+        let profile = home.join("profiles").join("web");
+        std::fs::create_dir_all(&profile).unwrap();
+        let candidate = crate::market::MarketInstallCandidate {
+            package_name: "@tauri-apps/api".to_string(),
+            version: "2.11.1".to_string(),
+            ..market_candidate()
+        };
+        std::fs::write(
+            profile.join("pnpm-lock.yaml"),
+            format!(
+                "lockfileVersion: '9.0'\n\npackages:\n\n  '{}@{}':\n    resolution: {{integrity: {}}}\n\nsnapshots:\n",
+                candidate.package_name, candidate.version, candidate.integrity
+            ),
+        )
+        .unwrap();
+        assert_eq!(
+            lockfile_integrity(&profile, &candidate.package_name, &candidate.version)
+                .expect("quoted scoped package key should resolve"),
+            candidate.integrity
+        );
+        let _ = std::fs::remove_dir_all(&home);
+    }
+
+    #[test]
+    fn market_package_stays_pending_until_explicit_activation() {
+        let home = std::env::temp_dir().join(format!("dsh-market-pending-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&home);
+        std::fs::create_dir_all(&home).unwrap();
+        let candidate = market_candidate();
+        setup_market_profile(&home, &candidate);
+
+        pre_disable_market_plugin(&home, &candidate).expect("pre-disable");
+        let (_, manifest) = read_profile_manifest(&home).expect("profile after pre-disable");
+        assert!(!profile_bundles(&manifest)
+            .expect("bundle list")
+            .contains(candidate.package_name.as_str()));
+
+        verify_and_mark_market_pending(&home, &candidate).expect("verified pending");
+        let rows = installed_plugins(&home);
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].state, "pending");
+        let (_, pending_manifest) = read_profile_manifest(&home).expect("pending profile");
+        assert!(!profile_bundles(&pending_manifest)
+            .expect("bundle list")
+            .contains(candidate.package_name.as_str()));
+
+        activate_market_plugin(&home, &candidate).expect("explicit activation");
+        let rows = installed_plugins(&home);
+        assert_eq!(rows[0].state, "active");
+        let (_, active_manifest) = read_profile_manifest(&home).expect("active profile");
+        assert!(profile_bundles(&active_manifest)
+            .expect("bundle list")
+            .contains(candidate.package_name.as_str()));
+        assert!(load_pending(&home)
+            .expect("pending state")
+            .plugins
+            .is_empty());
+
+        let _ = std::fs::remove_dir_all(&home);
+    }
+
+    #[test]
+    fn activation_recovers_if_marker_cleanup_was_interrupted() {
+        let home = std::env::temp_dir().join(format!(
+            "dsh-market-activate-recovery-{}",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_dir_all(&home);
+        std::fs::create_dir_all(&home).unwrap();
+        let candidate = market_candidate();
+        setup_market_profile(&home, &candidate);
+        pre_disable_market_plugin(&home, &candidate).expect("pre-disable");
+        verify_and_mark_market_pending(&home, &candidate).expect("verified pending");
+
+        // Simulate a crash after the activation profile write but before the
+        // pending marker can be removed.
+        let (profile, mut manifest) = read_profile_manifest(&home).expect("profile");
+        profile_bundles_mut(&mut manifest)
+            .expect("bundle list")
+            .push(Value::String(candidate.package_name.clone()));
+        write_profile_manifest(&profile, &manifest).expect("simulate activation write");
+
+        assert_eq!(installed_plugins(&home)[0].state, "active");
+        activate_market_plugin(&home, &candidate).expect("recovery activation");
+        assert!(load_pending(&home)
+            .expect("pending state")
+            .plugins
+            .is_empty());
+
         let _ = std::fs::remove_dir_all(&home);
     }
 }

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -510,9 +510,21 @@
   }
 
   async function reportContent() {
-    const url = new URL("mailto:contact@dsharness.app");
-    url.searchParams.set("subject", "DSH Desktop: report AI content");
-    await openUrl(url.toString()).catch(() => {});
+    try {
+      const url = new URL("https://github.com/web-casa/DeepSeek-Harness-Desktop/issues/new");
+      url.searchParams.set("title", "[Content] 报告 AI 生成内容");
+      url.searchParams.set(
+        "body",
+        [
+          "请说明需要报告的 AI 生成内容、使用的模型服务以及期望的处理方式。",
+          "",
+          "请勿粘贴 API key、个人数据、私密文件内容或其他敏感信息。",
+        ].join("\n"),
+      );
+      await openUrl(url.toString());
+    } catch (e) {
+      showToast(`打开失败：${e}`);
+    }
   }
 
   async function reportIssue() {

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -37,12 +37,16 @@
     onPresetInstallRequest,
     marketSearch,
     marketPlugin,
+    marketPrepareInstall,
+    marketInstallPlugin,
+    activateMarketPlugin,
     marketImage,
     sideloadPlugin,
     pickSideloadFile,
     type MarketPluginSummary,
     type MarketPluginDetail,
     type MarketDescription,
+    type MarketInstallPreview,
     type RemotePresetRequest,
     type RemotePresetPreview,
     type Status,
@@ -91,15 +95,21 @@
   let pluginLogs = $state<string[]>([]);
   let pluginLogsOpen = $state(false);
   let pluginError = $state<string | null>(null);
+  let pluginOperation = $state<"generic" | "market-install" | "sideload" | null>(null);
   let pluginInstallRequest = $state<PluginInstallRequest | null>(null);
   let remotePresetRequest = $state<RemotePresetRequest | null>(null);
   let remotePresetPreview = $state<RemotePresetPreview | null>(null);
   let remotePresetDownloading = $state(false);
   let marketQuery = $state("");
+  let marketCategory = $state("");
   let marketItems = $state<MarketPluginSummary[]>([]);
+  let marketCount = $state<number | null>(null);
+  let marketNextCursor = $state<string | null>(null);
+  let marketHasMore = $state(false);
   let marketBusy = $state(false);
   let marketError = $state<string | null>(null);
-  let marketConfirm = $state<MarketPluginSummary | null>(null);
+  let marketPreparing = $state(false);
+  let marketConfirm = $state<MarketInstallPreview | null>(null);
   let marketDetail = $state<MarketPluginDetail | null>(null);
   let marketDetailBusy = $state(false);
   let marketImages = $state<string[]>([]);
@@ -151,10 +161,16 @@
     if (pluginInstallRequest) {
       if (
         pluginInstallRequest.name !== request.name ||
-        pluginInstallRequest.source !== request.source
+        pluginInstallRequest.source !== request.source ||
+        pluginInstallRequest.slug !== request.slug
       ) {
         showToast("已有待确认的安装请求，新请求已忽略");
       }
+      return;
+    }
+    if (marketConfirm || marketPreparing) {
+      showToast("已有市场安装确认正在进行，插件安装请求已忽略");
+      void dismissPendingPluginInstall().catch(() => {});
       return;
     }
     if (remotePresetRequest || presetPreview) {
@@ -165,7 +181,7 @@
   }
 
   function presentRemotePresetRequest(request: RemotePresetRequest) {
-    if (pluginInstallRequest || presetPreview) {
+    if (pluginInstallRequest || presetPreview || marketConfirm || marketPreparing) {
       showToast("已有待处理的安装请求，预设请求已忽略");
       void dismissRemotePreset(request.requestId).catch(() => {});
       return;
@@ -201,7 +217,7 @@
   }
 
   function marketPackageName(item: MarketPluginSummary | MarketPluginDetail): string {
-    return item.source?.packageName?.trim() || item.name.trim();
+    return item.source?.packageName?.trim() || "（未提供可安装 npm 来源）";
   }
 
   function marketDescriptionText(desc: MarketDescription | null | undefined): string {
@@ -210,15 +226,39 @@
     return desc.zh ?? desc.en ?? "";
   }
 
-  async function doMarketSearch() {
+  function pluginStateText(state: PluginEntry["state"]): string {
+    if (state === "pending") return "待激活";
+    if (state === "active") return "已激活";
+    return "已安装";
+  }
+
+  async function doMarketSearch(reset = true) {
     if (marketBusy) return;
+    if (!reset && (!marketHasMore || marketNextCursor === null)) return;
     marketBusy = true;
     marketError = null;
     try {
-      const res = await marketSearch(marketQuery.trim(), undefined, 30, undefined, "desktop");
-      marketItems = res.items ?? [];
+      const res = await marketSearch(
+        marketQuery.trim(),
+        marketCategory || undefined,
+        30,
+        reset ? undefined : marketNextCursor ?? undefined,
+        "desktop",
+      );
+      const received = res.items ?? [];
+      if (reset) {
+        marketItems = received;
+      } else {
+        const known = new Set(marketItems.map((item) => item.slug));
+        marketItems = [...marketItems, ...received.filter((item) => !known.has(item.slug))];
+      }
+      // count and hasMore are catalog facts. Cursor values are opaque and are
+      // stored exactly as returned rather than interpreted as a page number.
+      marketCount = res.count;
+      marketNextCursor = res.page?.cursor ?? null;
+      marketHasMore = res.page?.hasMore === true;
     } catch (e) {
-      marketError = `市场搜索失败：${e}`;
+      marketError = "市场搜索失败：" + e;
     }
     marketBusy = false;
   }
@@ -247,17 +287,63 @@
     marketDetailBusy = false;
   }
 
-  function doMarketInstall(item: MarketPluginSummary) {
-    if (pluginBusy) return;
-    marketConfirm = item;
+  async function prepareMarketInstall(slug: string) {
+    if (pluginBusy || marketPreparing) return;
+    marketPreparing = true;
+    marketError = null;
+    try {
+      // This refetches the detail with ETag revalidation. The modal then
+      // presents its current entryRevision for an explicit user confirmation.
+      marketConfirm = await marketPrepareInstall(slug);
+    } catch (e) {
+      marketError = "无法准备安装：" + e;
+    }
+    marketPreparing = false;
+  }
+
+  async function doMarketInstall(item: MarketPluginSummary) {
+    if (item.installable !== true) return;
+    await prepareMarketInstall(item.slug);
   }
 
   function confirmMarketInstall() {
-    const item = marketConfirm;
-    if (!item || pluginBusy) return;
-    const name = item.source?.packageName?.trim() || item.name.trim();
+    const preview = marketConfirm;
+    if (!preview || pluginBusy) return;
     marketConfirm = null;
-    startPluginOp(name, "install");
+    pluginBusy = true;
+    pluginOperation = "market-install";
+    pluginError = null;
+    pluginLogs = [];
+    pluginLogsOpen = true;
+    void marketInstallPlugin(preview.slug, preview.entryRevision).catch((e) => {
+      pluginBusy = false;
+      pluginOperation = null;
+      pluginError = "市场安装失败：" + e;
+      pluginLogsOpen = true;
+      void refreshPlugins();
+    });
+    showToast("正在校验并安装 " + preview.packageName + "；完成后仍需显式激活");
+  }
+
+  async function doActivateMarketPlugin(plugin: PluginEntry) {
+    if (
+      pluginBusy ||
+      plugin.state !== "pending" ||
+      !plugin.slug ||
+      !plugin.entryRevision
+    ) {
+      return;
+    }
+    pluginBusy = true;
+    pluginError = null;
+    try {
+      await activateMarketPlugin(plugin.slug, plugin.entryRevision);
+      showToast("已激活 " + plugin.name + "；请重启 Harness 后加载");
+      await refreshPlugins();
+    } catch (e) {
+      pluginError = "激活失败：" + e;
+    }
+    pluginBusy = false;
   }
 
   async function doPickSideload() {
@@ -274,6 +360,7 @@
     const path = sideloadPath;
     sideloadPath = null;
     pluginBusy = true;
+    pluginOperation = "sideload";
     pluginError = null;
     pluginLogs = [];
     pluginLogsOpen = true;
@@ -282,6 +369,7 @@
       await sideloadPlugin(path);
     } catch (e) {
       pluginBusy = false;
+      pluginOperation = null;
       pluginError = `离线安装失败：${e}`;
       pluginLogsOpen = true;
       void refreshPlugins();
@@ -543,6 +631,7 @@
   function startPluginOp(name: string, op: "install" | "uninstall") {
     if (pluginBusy || !name.trim()) return;
     pluginBusy = true;
+    pluginOperation = "generic";
     pluginError = null;
     pluginLogs = [];
     pluginLogsOpen = true;
@@ -550,6 +639,7 @@
     const call = op === "install" ? installPlugin(name.trim()) : uninstallPlugin(name.trim());
     void call.catch((e) => {
       pluginBusy = false;
+      pluginOperation = null;
       pluginError = `${op === "install" ? "安装" : "卸载"}失败：${e}`;
       pluginLogsOpen = true;
       // Resync busy: "an operation is already running" means another
@@ -577,12 +667,18 @@
     }
   }
 
-  function confirmPluginInstallRequest() {
+  async function confirmPluginInstallRequest() {
     const request = pluginInstallRequest;
-    if (!request || pluginBusy) return;
+    if (!request || pluginBusy || marketPreparing) return;
     pluginInstallRequest = null;
-    void dismissPendingPluginInstall().catch(() => {});
-    startPluginOp(request.name, "install");
+    try {
+      await dismissPendingPluginInstall();
+    } catch {
+      // The request was already removed from the UI. The market command still
+      // validates the Rust-derived slug and freshly revalidates the entry
+      // before any profile mutation.
+    }
+    await prepareMarketInstall(request.slug);
   }
 
   // Initial data load (async onMount is fine here — no cleanup needed).
@@ -673,9 +769,15 @@
     let unlistenFn: (() => void) | null = null;
     onPluginDone((p) => {
       pluginBusy = false;
+      const completedOperation = pluginOperation;
+      pluginOperation = null;
       if (p.exit === 0) {
         pluginName = "";
-        showToast("插件操作完成");
+        showToast(
+          completedOperation === "market-install"
+            ? "插件已校验完成，正在等待你的显式激活"
+            : "插件操作完成",
+        );
       } else {
         pluginError = `插件操作失败（exit ${p.exit ?? "被终止"}），详情见安装日志`;
         pluginLogsOpen = true;
@@ -985,7 +1087,12 @@
           if (e.key === "Enter") doMarketSearch();
         }}
       />
-      <button class="primary" onclick={doMarketSearch} disabled={marketBusy || !marketQuery.trim()}>
+      <select class="plugin-input" bind:value={marketCategory} disabled={marketBusy} aria-label="插件类别">
+        <option value="">全部类别</option>
+        <option value="agent">Agent</option>
+        <option value="market">市场</option>
+      </select>
+      <button class="primary" onclick={() => doMarketSearch(true)} disabled={marketBusy}>
         {marketBusy ? "搜索中…" : "搜索"}
       </button>
     </div>
@@ -993,6 +1100,9 @@
       <div class="notice-box">{marketError}</div>
     {/if}
     {#if marketItems.length > 0}
+      {#if marketCount !== null}
+        <div class="preset-issues">当前筛选共 {marketCount} 个条目；按 cursor 顺序加载。</div>
+      {/if}
       {#each marketItems as item (item.slug)}
         <div class="preset-row">
           <span class="preset-id">
@@ -1003,16 +1113,33 @@
             <span class="badge">{item.platforms.includes("desktop") ? "desktop" : "web-only"}</span>
           </span>
           <button class="ghost" onclick={() => doMarketDetail(item.slug)} disabled={marketDetailBusy}>详情</button>
-          {#if item.platforms.includes("desktop")}
-            <button class="primary" onclick={() => doMarketInstall(item)} disabled={pluginBusy}>安装</button>
+          {#if item.installable === true}
+            <button
+              class="primary"
+              onclick={() => doMarketInstall(item)}
+              disabled={pluginBusy || marketPreparing}
+            >{marketPreparing ? "校验中…" : "安装"}</button>
           {:else}
-            <button class="ghost" disabled>仅网页版</button>
+            <button class="ghost" disabled title={item.installReason ?? "该条目不可安装"}>
+              {item.blocked ? "已封禁" : item.deprecated ? "已弃用" : "不可安装"}
+            </button>
           {/if}
         </div>
         {#if marketDescriptionText(item.description)}
           <div class="preset-issues">{marketDescriptionText(item.description)}</div>
         {/if}
       {/each}
+      {#if marketHasMore}
+        <div class="plugin-row">
+          <button
+            class="ghost"
+            onclick={() => doMarketSearch(false)}
+            disabled={marketBusy || marketNextCursor === null}
+          >
+            {marketBusy ? "加载中…" : "加载更多"}
+          </button>
+        </div>
+      {/if}
     {:else}
       <div class="preset-row"><span class="l-empty">（输入关键词搜索插件市场）</span></div>
     {/if}
@@ -1064,7 +1191,15 @@
     {#if plugins.length > 0}
       {#each plugins as p (p.name)}
         <div class="preset-row">
-          <span>{p.name} <span class="badge">v{p.version}</span></span>
+          <span>
+            {p.name} <span class="badge">v{p.version}</span>
+            <span class="badge">{pluginStateText(p.state)}</span>
+          </span>
+          {#if p.state === "pending" && p.slug && p.entryRevision}
+            <button class="primary" onclick={() => doActivateMarketPlugin(p)} disabled={pluginBusy}>
+              Activate
+            </button>
+          {/if}
           <button class="ghost" onclick={() => startPluginOp(p.name, "uninstall")} disabled={pluginBusy}>卸载</button>
         </div>
       {/each}
@@ -1158,7 +1293,12 @@
       {#if marketImages.length > 0}
         <div class="market-shots">
           {#each marketImages as src, i (i)}
-            <img src={src} alt="{marketDetail.name} screenshot {i + 1}" class="market-shot" />
+            <img
+              src={src}
+              alt="{marketDetail.name} screenshot {i + 1}"
+              class="market-shot"
+              referrerpolicy="no-referrer"
+            />
           {/each}
         </div>
       {/if}
@@ -1173,13 +1313,18 @@
   <div class="modal-backdrop">
     <div class="modal" role="dialog" aria-modal="true" aria-label="安装 Cordis 插件确认">
       <div class="modal-title">安装 Cordis 插件？</div>
-      <div class="modal-name">{marketPackageName(marketConfirm)}</div>
+      <div class="modal-name">{marketConfirm.packageName} v{marketConfirm.version}</div>
       <div class="modal-meta">
-        来源：<button class="inline-link" onclick={() => openSite(`https://cordis.run/plugins/${marketConfirm!.slug}`)}>
+        当前条目修订：{marketConfirm.entryRevision}
+      </div>
+      <div class="modal-meta">
+        来源：<button class="inline-link" onclick={() => openSite("https://cordis.run/plugins/" + marketConfirm!.slug)}>
           https://cordis.run/plugins/{marketConfirm.slug}
         </button>
       </div>
-      <div class="modal-warn">插件与 Agent 同权限运行工具和命令，仅安装可信插件。确认后将立即开始安装。</div>
+      <div class="modal-warn">
+        将校验此修订的 tarball 与 lockfile integrity，禁用构建脚本，并保持为待激活状态。安装完成后不会自动启用，需你再次点击 Activate。
+      </div>
       <div class="modal-actions">
         <button class="primary" onclick={confirmMarketInstall} disabled={pluginBusy}>确认安装</button>
         <button class="ghost" onclick={() => (marketConfirm = null)}>取消</button>
@@ -1206,7 +1351,7 @@
   <div class="modal-backdrop">
     <div class="modal" role="dialog" aria-modal="true" aria-label="安装 Cordis 插件确认">
       <div class="modal-title">安装 Cordis 插件？</div>
-      <div class="modal-name">{pluginInstallRequest.name}</div>
+      <div class="modal-name">链接声明的包：{pluginInstallRequest.name}</div>
       <div class="modal-meta">
         关联页面（未验证与插件包的对应关系）：<button
           class="inline-link"
@@ -1217,14 +1362,14 @@
         </button>
       </div>
       <div class="modal-warn">
-        该链接可由任意网页或程序构造，只能确认关联页面格式来自 cordis.run，无法证明插件包由该页面提供。插件与 Agent 同权限运行工具和命令，仅安装可信插件。确认后将立即开始安装，完成后需重新启动 Harness 生效。
+        该链接可由任意网页或程序构造。下一步只会使用 Rust 已校验的 Cordis slug 重新拉取市场详情，并显示当前 entryRevision 供你再次确认；不会按链接中的包名直接安装。插件与 Agent 同权限运行工具和命令，仅安装可信插件。
       </div>
       {#if pluginBusy}
         <div class="notice-box">当前已有插件操作正在进行，请等待完成后再确认安装。</div>
       {/if}
       <div class="modal-actions">
         <button class="primary" onclick={confirmPluginInstallRequest} disabled={pluginBusy}>
-          {pluginBusy ? "已有操作进行中…" : "确认安装"}
+          {pluginBusy ? "已有操作进行中…" : "继续核验"}
         </button>
         <button class="ghost" onclick={dismissPluginInstallRequest}>取消</button>
       </div>

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -98,6 +98,9 @@ export async function onUpdateProgress(
 export interface PluginEntry {
   name: string;
   version: string;
+  state: "active" | "pending" | "installed";
+  slug?: string | null;
+  entryRevision?: string | null;
 }
 
 export interface PluginList {
@@ -137,14 +140,18 @@ export type MarketDescription = string | { zh?: string; en?: string };
 export interface MarketPluginSummary {
   slug: string;
   name: string;
+  entryRevision?: string | null;
   source?: MarketPluginSource | null;
   description?: MarketDescription | null;
   category?: string | null;
   platforms: string[];
+  engines?: Record<string, string> | null;
   stars?: number | null;
   homepage?: string | null;
   blocked?: boolean | null;
   deprecated?: boolean | null;
+  installable?: boolean;
+  installReason?: string | null;
 }
 
 export interface MarketPluginVersion {
@@ -160,16 +167,30 @@ export interface MarketPluginVersion {
 export interface MarketPluginDetail {
   slug: string;
   name: string;
+  entryRevision?: string | null;
   source?: MarketPluginSource | null;
   description?: MarketDescription | null;
   category?: string | null;
   platforms: string[];
+  engines?: Record<string, string> | null;
   stars?: number | null;
   homepage?: string | null;
   blocked?: boolean | null;
   deprecated?: boolean | null;
+  installable?: boolean;
+  installReason?: string | null;
   screenshots?: string[];
   versions?: MarketPluginVersion[];
+}
+
+export interface MarketInstallPreview {
+  slug: string;
+  entryRevision: string;
+  packageName: string;
+  version: string;
+  integrity: string;
+  registry: string;
+  tarball: string;
 }
 
 export interface MarketSearchPage {
@@ -196,6 +217,19 @@ export const marketSearch = (
 export const marketPlugin = (slug: string): Promise<MarketPluginDetail> =>
   invoke("market_plugin", { slug });
 
+export const marketPrepareInstall = (slug: string): Promise<MarketInstallPreview> =>
+  invoke("market_prepare_install", { slug });
+
+export const marketInstallPlugin = (
+  slug: string,
+  entryRevision: string,
+): Promise<void> => invoke("market_install_plugin", { slug, entryRevision });
+
+export const activateMarketPlugin = (
+  slug: string,
+  entryRevision: string,
+): Promise<void> => invoke("activate_market_plugin", { slug, entryRevision });
+
 export const marketImage = (url: string): Promise<{ dataUrl: string }> =>
   invoke("market_image", { url });
 
@@ -208,6 +242,7 @@ export const pickSideloadFile = (): Promise<string | null> =>
 export interface PluginInstallRequest {
   name: string;
   source: string;
+  slug: string;
 }
 
 export const getPendingPluginInstall = (): Promise<PluginInstallRequest | null> =>

--- a/tools/cordis-fixture/fixture-data.json
+++ b/tools/cordis-fixture/fixture-data.json
@@ -2,6 +2,10 @@
   "schemaVersion": 1,
   "catalogRevision": "2026-08-18T00:00:00Z-8f3a",
   "updated": "2026-08-18T00:00:00Z",
+  "categories": {
+    "market": { "zh": "市场", "en": "Market" },
+    "agent": { "zh": "智能体", "en": "Agent" }
+  },
   "page": { "cursor": "opaque", "hasMore": false, "limit": 50 },
   "count": 2,
   "items": [
@@ -16,7 +20,7 @@
         "type": "npm",
         "packageName": "dshmarket",
         "version": "1.11.2",
-        "integrity": "sha512-CFx+GExHSBJVeF66kKBdGr+aQp7bbWF90fEEZpjW5REzmdpRC2gBnAt5BpkT9pcBSL7fkmW/2s4G2vFo7FD6Mw==",
+        "integrity": "sha512-dLKPe3Y7KOOHXtKFNzOLWqFiLu8ZSyLw74WlV0bElvIW9myc3Anm8VyUGH7LpORuutzWi9TKBBYw/PqziCKA8w==",
         "registry": "https://registry.npmjs.org",
         "tarball": "https://registry.npmjs.org/dshmarket/-/dshmarket-1.11.2.tgz"
       },

--- a/tools/cordis-fixture/fixture-server.mjs
+++ b/tools/cordis-fixture/fixture-server.mjs
@@ -1,49 +1,116 @@
-// cordis.run 本地 fixture server：桌面/Web 联调用。
-// 运行：node fixture-server.mjs
-// 打印端口后设置：CORDIS_RUN_API=http://127.0.0.1:<port>/api/v1
+// cordis.run v4 local fixture for Desktop integration.
+// Run: node tools/cordis-fixture/fixture-server.mjs
+// Then: CORDIS_RUN_API=http://127.0.0.1:<port>/api/v1 pnpm tauri dev
+//
+// This intentionally mirrors cordis-mp/spikes/S1: cursors are opaque,
+// page/per_page remains an accepted transition input, and JSON ETag/304 plus
+// JSON API errors are part of the adapter contract.
 import { createServer } from 'node:http'
 import { readFileSync } from 'node:fs'
 
 const data = JSON.parse(readFileSync(new URL('./fixture-data.json', import.meta.url)))
 const ETAG = '"cordis-fixture-v1"'
 
-// 1x1 红色 PNG，用于 market_image 联调
-const PNG_BASE64 = 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAADElEQVR4nGP4z8AAAAMBAQDJ/pLvAAAAAElFTkSuQmCC'
-const PNG = Buffer.from(PNG_BASE64, 'base64')
+function decodeCursor(value) {
+  if (!value) return null
+  const match = /^fixture:(\d+)$/.exec(value)
+  return match ? Number(match[1]) : Number.NaN
+}
+
+function nextCursor(start, limit, total) {
+  const next = start + limit
+  return next < total ? 'fixture:' + next : null
+}
 
 const server = createServer((req, res) => {
   const url = new URL(req.url, 'http://127.0.0.1')
   const path = url.pathname
   const json = (status, body, extra = {}) => {
-    res.writeHead(status, { 'content-type': 'application/json; charset=utf-8', etag: ETAG, ...extra })
+    if (status === 200 && req.headers['if-none-match'] === ETAG) {
+      res.writeHead(304, { etag: ETAG })
+      res.end()
+      return
+    }
+    res.writeHead(status, {
+      'content-type': 'application/json; charset=utf-8',
+      etag: ETAG,
+      ...extra,
+    })
     res.end(JSON.stringify(body))
   }
+
   if (path === '/api/v1/plugins') {
     const platform = url.searchParams.get('platform')
-    const q = (url.searchParams.get('q') || '').toLowerCase()
-    let items = data.items
-    if (platform) items = items.filter(i => (i.platforms || []).includes(platform))
-    if (q) items = items.filter(i => i.slug.toLowerCase().includes(q) || i.name.toLowerCase().includes(q))
-    json(200, { ...data, page: { ...data.page, hasMore: false, limit: items.length }, count: items.length, items })
-    return
-  }
-  if (path.startsWith('/api/v1/plugins/')) {
-    const slug = decodeURIComponent(path.slice('/api/v1/plugins/'.length))
-    const item = data.items.find(i => i.slug === slug)
-    if (!item) { json(404, { error: { code: 'NOT_FOUND', message: `no such slug: ${slug}` } }); return }
-    const port = server.address().port
+    const category = url.searchParams.get('category')
+    const query = (url.searchParams.get('q') || '').toLowerCase()
+    const legacyPage = Math.max(1, Number.parseInt(url.searchParams.get('page') || '1', 10) || 1)
+    const cursorValue = url.searchParams.get('cursor')
+    const requestedLimit = cursorValue
+      ? url.searchParams.get('limit')
+      : (url.searchParams.get('per_page') || url.searchParams.get('limit'))
+    const limit = Math.min(100, Math.max(1, Number.parseInt(requestedLimit || '50', 10) || 50))
+    const cursor = decodeCursor(cursorValue)
+    if (Number.isNaN(cursor)) {
+      json(400, { error: { code: 'BAD_CURSOR', message: 'cursor is invalid' } })
+      return
+    }
+    const sort = url.searchParams.get('sort') || 'stars'
+    const order = url.searchParams.get('order') || 'desc'
+    let items = [...data.items]
+    if (platform) items = items.filter((item) => (item.platforms || []).includes(platform))
+    if (category) items = items.filter((item) => item.category === category)
+    if (query) {
+      items = items.filter(
+        (item) =>
+          item.slug.toLowerCase().includes(query) ||
+          item.name.toLowerCase().includes(query),
+      )
+    }
+    const compare = sort === 'added'
+      ? (left, right) => String(left.added || '').localeCompare(String(right.added || ''))
+      : (left, right) => (left.stars || 0) - (right.stars || 0)
+    items = items.sort(compare)
+    if (order === 'desc') items.reverse()
+    const count = items.length
+    const start = cursor ?? (legacyPage - 1) * limit
+    const slice = items.slice(start, start + limit)
     json(200, {
-      ...item,
-      screenshots: [`http://127.0.0.1:${port}/fixtures/screenshot.png`],
-      versions: [{ version: item.source.version, source: item.source, platforms: item.platforms, engines: item.engines, blocked: item.blocked, deprecated: item.deprecated, publishedAt: item.updatedAt }],
+      ...data,
+      count,
+      page: {
+        cursor: nextCursor(start, limit, count),
+        hasMore: start + limit < count,
+        limit,
+      },
+      items: slice,
     })
     return
   }
-  if (path === '/fixtures/screenshot.png') {
-    res.writeHead(200, { 'content-type': 'image/png', 'content-length': PNG.length, 'cache-control': 'no-store' })
-    res.end(PNG)
+
+  if (path.startsWith('/api/v1/plugins/')) {
+    const slug = decodeURIComponent(path.slice('/api/v1/plugins/'.length))
+    const item = data.items.find((entry) => entry.slug === slug)
+    if (!item) {
+      json(404, { error: { code: 'NOT_FOUND', message: 'no such slug: ' + slug } })
+      return
+    }
+    json(200, {
+      ...item,
+      screenshots: ['https://cdn.cordis.run/screenshots/' + encodeURIComponent(slug) + '/1.webp'],
+      versions: [{
+        version: item.source.version,
+        source: item.source,
+        platforms: item.platforms,
+        engines: item.engines,
+        blocked: item.blocked,
+        deprecated: item.deprecated,
+        publishedAt: item.updatedAt,
+      }],
+    })
     return
   }
+
   json(404, { error: { code: 'NOT_FOUND', message: 'not found' } })
 })
+
 server.listen(0, '127.0.0.1', () => console.log(server.address().port))


### PR DESCRIPTION

## Summary
- migrate marketplace parsing and pagination to the Cordis v4 nested DTO, `platform=desktop`, and opaque cursor contract
- support ETag/304 revalidation and structured JSON API errors including JSON `NOT_FOUND`
- enforce fail-closed npm/install gates, trusted HTTPS source validation, fresh `entryRevision` confirmation, exact lockfile integrity verification, and pending activation
- keep activation explicit and revalidate blocked, deprecated, incompatible, non-npm, and unreviewed Store entries before mutation
- require the canonical Cordis preset endpoint to return direct `200 application/zip` without redirects
- add a read-only production market contract smoke and collision-resistant JSON 404 probe
- route Microsoft Store support and AI-content reports to working public support channels
- constrain the `CORDIS_RUN_API` fixture override to the canonical API boundary

## Review fixes
- accept pnpm peer-context lock keys only after an exact reviewed `package@version` match; version-prefix collisions remain rejected
- generate a unique valid missing slug for every production JSON 404 probe so a future real catalog entry cannot cause a false release failure
- remove the non-deliverable `contact@dsharness.app` support path and surface URL-opening failures to the user

## Validation
- `pnpm check` — 0 errors and 0 warnings
- `pnpm check:scripts`
- `pnpm test:scripts` — 15 passed
- `pnpm build`
- `pnpm audit --audit-level high` — no known vulnerabilities
- `pnpm release:preflight`
- `cargo nextest run --manifest-path src-tauri/Cargo.toml` — 97 passed
- `cargo nextest run --manifest-path crates/dsh-sidecar/Cargo.toml` — 35 passed
- `cargo fmt --check --manifest-path src-tauri/Cargo.toml`
- `cargo clippy --manifest-path src-tauri/Cargo.toml --all-targets -- -D warnings`
- `cargo deny --manifest-path src-tauri/Cargo.toml check`
- `cargo vet --locked --manifest-path src-tauri/Cargo.toml` — succeeded
- `actionlint`
- `node scripts/verify-bundle.ts --self-test`
- local Cordis fixture coverage for desktop/category/cursor, ETag 304, JSON NOT_FOUND, blocked visibility, and pending to explicit Activate

## Production contract status
- `https://cordis.run/api/presets/code/download` now returns direct `200 application/zip`; the former 307 release blocker is resolved
- `https://cordis.run/api/v1` passes direct JSON, ETag/304, and JSON 404 checks with `platform=desktop`
- the production desktop catalog currently reports `count=0`; no real public plugin was inspected or installed, so a named reviewed plugin probe remains a pre-release evidence item once one is published
- Microsoft Store public website, privacy, and support URLs are live

## Publishing boundary
The root npm workspace remains private. Any future public npm artifact must be owned and reviewed under the `web-casa` organization; this PR publishes no npm package.
