### PR TITLE
feat: harden recovery attribution and market errors

### DIFF
--- a/src-tauri/src/market.rs
+++ b/src-tauri/src/market.rs
@@ -178,6 +178,15 @@ const HOME_CACHE_SCHEMA: u32 = 1;
 const HOME_CACHE_LIMIT: u32 = 30;
 const HOME_CACHE_MAX_AGE: Duration = Duration::from_secs(7 * 24 * 60 * 60);
 const APPROVED_NPM_REGISTRY_HOSTS: &[&str] = &["registry.npmjs.org"];
+const API_CODE_MAX_CHARS: usize = 64;
+const API_MESSAGE_MAX_CHARS: usize = 512;
+const API_REQUEST_ID_MAX_CHARS: usize = 128;
+
+const MARKET_TIMEOUT: &str = "MARKET_TIMEOUT";
+const MARKET_UNAVAILABLE: &str = "MARKET_UNAVAILABLE";
+const MARKET_INVALID_RESPONSE: &str = "MARKET_INVALID_RESPONSE";
+const MARKET_API_ERROR: &str = "MARKET_API_ERROR";
+const MARKET_HTTP_ERROR: &str = "MARKET_HTTP_ERROR";
 
 pub fn is_valid_market_slug(slug: &str) -> bool {
     let bytes = slug.as_bytes();
@@ -467,12 +476,12 @@ impl MarketClient {
                         });
                     }
                 }
-                return Err(format!("{label} request failed: {error}"));
+                return Err(format_transport_error(label, &error));
             }
         };
         if response.status() == reqwest::StatusCode::NOT_MODIFIED {
             let cached = Self::cache_revalidated(cache, key)
-                .ok_or_else(|| format!("{label} returned HTTP 304 without a cached response"))?;
+                .ok_or_else(|| invalid_response(label, "returned 304 without a cache entry"))?;
             return Ok(CachedJson {
                 value: cached.value,
                 etag: cached.etag,
@@ -487,12 +496,12 @@ impl MarketClient {
             .get(ETAG)
             .and_then(|value| value.to_str().ok())
             .map(str::to_owned);
-        let body = read_limited_json_body(response).await?;
+        let body = read_limited_json_body(response, label).await?;
         if !status.is_success() {
             return Err(format_api_error(label, status, &body));
         }
         let json = serde_json::from_slice::<Value>(&body)
-            .map_err(|e| format!("{label} response was not JSON: {e}"))?;
+            .map_err(|_| invalid_response(label, "returned invalid JSON"))?;
         Self::cache_put(cache, key, json.clone(), etag.clone());
         Ok(CachedJson {
             value: json,
@@ -614,7 +623,7 @@ impl MarketClient {
             .await?;
         let raw = outcome.value;
         let mut parsed: MarketSearchResponse = serde_json::from_value(raw.clone())
-            .map_err(|e| format!("market search response did not match the v4 DTO: {e}"))?;
+            .map_err(|_| invalid_response("market search", "did not match the v4 DTO"))?;
         if is_home
             && matches!(
                 outcome.disposition,
@@ -672,7 +681,7 @@ impl MarketClient {
             .await?
             .value;
         serde_json::from_value(raw)
-            .map_err(|e| format!("market detail response did not match the v4 DTO: {e}"))
+            .map_err(|_| invalid_response("market detail", "did not match the v4 DTO"))
     }
 
     pub async fn detail(&self, slug: &str, dsh_version: &str) -> Result<Value, String> {
@@ -703,9 +712,12 @@ impl MarketClient {
             .get(parsed)
             .send()
             .await
-            .map_err(|e| format!("image request failed: {e}"))?;
+            .map_err(|error| format_transport_error("market image", &error))?;
         if !response.status().is_success() {
-            return Err(format!("image request failed: HTTP {}", response.status()));
+            return Err(format!(
+                "{MARKET_HTTP_ERROR}: market image failed with HTTP {}",
+                response.status()
+            ));
         }
         let content_type = response
             .headers()
@@ -737,6 +749,21 @@ fn is_transport_failure(error: &reqwest::Error) -> bool {
         || (error.is_request() && !error.is_builder() && !error.is_redirect())
 }
 
+fn format_transport_error(label: &str, error: &reqwest::Error) -> String {
+    if error.is_timeout() {
+        format!("{MARKET_TIMEOUT}: {label} request timed out")
+    } else {
+        // reqwest errors can include full URLs (including opaque cursors) and
+        // platform-specific socket details. Keep those in private diagnostics,
+        // never in the bootstrap UI error channel.
+        format!("{MARKET_UNAVAILABLE}: {label} is unavailable")
+    }
+}
+
+fn invalid_response(label: &str, reason: &str) -> String {
+    format!("{MARKET_INVALID_RESPONSE}: {label} {reason}")
+}
+
 fn load_disk_home_cache(path: &std::path::Path, expected_origin: &str) -> Option<DiskHomeCache> {
     let bytes = crate::secure_fs::read_bounded(path, JSON_MAX_BYTES as u64)
         .ok()
@@ -764,19 +791,65 @@ fn load_disk_home_cache(path: &std::path::Path, expected_origin: &str) -> Option
 fn format_api_error(label: &str, status: reqwest::StatusCode, body: &[u8]) -> String {
     match serde_json::from_slice::<ApiErrorBody>(body) {
         Ok(parsed) => {
+            let code =
+                bounded_api_code(&parsed.error.code).unwrap_or_else(|| "UNKNOWN".to_string());
+            let message = bounded_api_message(&parsed.error.message)
+                .unwrap_or_else(|| "request failed".to_string());
             let request = parsed
                 .error
                 .request_id
-                .filter(|id| !id.is_empty())
+                .as_deref()
+                .and_then(bounded_request_id)
                 .map(|id| format!(" (requestId: {id})"))
                 .unwrap_or_default();
-            format!(
-                "{label} failed: {} {}: {}{request}",
-                status, parsed.error.code, parsed.error.message
-            )
+            format!("{MARKET_API_ERROR}: {label} failed: {status} {code}: {message}{request}")
         }
-        Err(_) => format!("{label} failed: HTTP {status}"),
+        Err(_) => format!("{MARKET_HTTP_ERROR}: {label} failed with HTTP {status}"),
     }
+}
+
+fn bounded_api_code(raw: &str) -> Option<String> {
+    if raw.is_empty()
+        || raw.chars().count() > API_CODE_MAX_CHARS
+        || !raw
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'_' | b'-' | b'.'))
+    {
+        return None;
+    }
+    Some(raw.to_string())
+}
+
+fn is_unsafe_display_character(character: char) -> bool {
+    character.is_control()
+        || matches!(
+            character,
+            '\u{061c}'
+                | '\u{200b}'..='\u{200f}'
+                | '\u{2028}'..='\u{202e}'
+                | '\u{2060}'..='\u{206f}'
+                | '\u{feff}'
+        )
+}
+
+fn bounded_api_message(raw: &str) -> Option<String> {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() || trimmed.chars().any(is_unsafe_display_character) {
+        return None;
+    }
+    Some(trimmed.chars().take(API_MESSAGE_MAX_CHARS).collect())
+}
+
+fn bounded_request_id(raw: &str) -> Option<String> {
+    if raw.is_empty()
+        || raw.len() > API_REQUEST_ID_MAX_CHARS
+        || !raw
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'_' | b'-' | b'.' | b':'))
+    {
+        return None;
+    }
+    Some(raw.to_string())
 }
 
 fn required_wire_string<'a>(value: &'a Option<String>, field: &str) -> Result<&'a str, String> {
@@ -839,7 +912,7 @@ fn parse_dsh_requirement(raw: &str) -> Result<VersionReq, String> {
             let normalized = raw.split_whitespace().collect::<Vec<_>>().join(", ");
             VersionReq::parse(&normalized)
         })
-        .map_err(|e| format!("market entry has invalid engines.dsh: {e}"))
+        .map_err(|_| "market entry has invalid engines.dsh".to_string())
 }
 
 /// Store distributions have an additional, locally pinned review boundary.
@@ -886,7 +959,7 @@ fn candidate_from_entry(
         );
     }
     let version = required_wire_string(&source.version, "source.version")?;
-    Version::parse(version).map_err(|e| format!("market entry has invalid source.version: {e}"))?;
+    Version::parse(version).map_err(|_| "market entry has invalid source.version".to_string())?;
     let integrity = required_wire_string(&source.integrity, "source.integrity")?;
     if !is_valid_sha512_integrity(integrity) {
         return Err("market entry has invalid source.integrity".to_string());
@@ -921,7 +994,7 @@ fn candidate_from_entry(
         .map_err(|e| format!("Desktop DSH version is unavailable or invalid: {e}"))?;
     if !requirement.matches(&current) {
         return Err(format!(
-            "this market entry requires DSH {dsh_range}, but Desktop runs {dsh_version}"
+            "this market entry is incompatible with Desktop DSH {dsh_version}"
         ));
     }
 
@@ -973,14 +1046,17 @@ fn base64_encode(bytes: &[u8]) -> String {
     out
 }
 
-async fn read_limited_json_body(response: reqwest::Response) -> Result<Vec<u8>, String> {
+async fn read_limited_json_body(
+    response: reqwest::Response,
+    label: &str,
+) -> Result<Vec<u8>, String> {
     use futures_util::StreamExt;
     let mut body = Vec::new();
     let mut stream = response.bytes_stream();
     while let Some(chunk) = stream.next().await {
-        let chunk = chunk.map_err(|e| format!("market read failed: {e}"))?;
+        let chunk = chunk.map_err(|error| format_transport_error(label, &error))?;
         if body.len().saturating_add(chunk.len()) > JSON_MAX_BYTES {
-            return Err("market response exceeds 1 MiB".to_string());
+            return Err(invalid_response(label, "exceeded the 1 MiB limit"));
         }
         body.extend_from_slice(&chunk);
     }
@@ -992,9 +1068,9 @@ async fn read_limited_image_body(response: reqwest::Response) -> Result<Vec<u8>,
     let mut body = Vec::new();
     let mut stream = response.bytes_stream();
     while let Some(chunk) = stream.next().await {
-        let chunk = chunk.map_err(|e| format!("image read failed: {e}"))?;
+        let chunk = chunk.map_err(|error| format_transport_error("market image", &error))?;
         if body.len().saturating_add(chunk.len()) > IMAGE_MAX_BYTES {
-            return Err("image exceeds 2 MiB".to_string());
+            return Err(invalid_response("market image", "exceeded the 2 MiB limit"));
         }
         body.extend_from_slice(&chunk);
     }
@@ -1435,9 +1511,79 @@ mod tests {
         let client = MarketClient::with_base_url(base).expect("client");
         let error = tauri::async_runtime::block_on(client.detail("missing", "0.1.0-rc.7"))
             .expect_err("detail should fail");
+        assert!(error.starts_with(MARKET_API_ERROR));
         assert!(error.contains("NOT_FOUND: no such slug"));
         assert!(error.contains("requestId: req-1"));
         let _ = worker.join().expect("fixture worker");
+    }
+
+    #[test]
+    fn api_error_fields_are_bounded_and_reject_display_controls() {
+        assert_eq!(bounded_api_code("NOT_FOUND").as_deref(), Some("NOT_FOUND"));
+        assert!(bounded_api_code("NOT FOUND").is_none());
+        assert!(bounded_request_id("req-1:edge").is_some());
+        assert!(bounded_request_id("req\nspoof").is_none());
+        for unsafe_message in [
+            "safe\u{2028}second-line",
+            "safe\u{202e}spoof",
+            "safe\u{2060}hidden",
+            "safe\u{feff}hidden",
+        ] {
+            assert!(bounded_api_message(unsafe_message).is_none());
+        }
+        assert_eq!(
+            bounded_api_message(&"界".repeat(API_MESSAGE_MAX_CHARS + 20))
+                .expect("bounded message")
+                .chars()
+                .count(),
+            API_MESSAGE_MAX_CHARS
+        );
+
+        let malicious = serde_json::json!({
+            "error": {
+                "code": "BAD CODE",
+                "message": "safe\u{202e}spoof",
+                "requestId": "req\nspoof"
+            }
+        });
+        let formatted = format_api_error(
+            "market detail",
+            reqwest::StatusCode::BAD_REQUEST,
+            &serde_json::to_vec(&malicious).expect("error JSON"),
+        );
+        assert_eq!(
+            formatted,
+            "MARKET_API_ERROR: market detail failed: 400 Bad Request UNKNOWN: request failed"
+        );
+    }
+
+    #[test]
+    fn successful_html_and_orphan_304_are_invalid_responses() {
+        let (html_base, html_worker) = test_server(vec![response(
+            "200 OK",
+            &[("Content-Type", "text/html")],
+            "<html>not JSON</html>",
+        )]);
+        let html_client = MarketClient::with_base_url(html_base).expect("HTML client");
+        let html_error =
+            tauri::async_runtime::block_on(html_client.detail("fixture", "0.1.0-rc.7"))
+                .expect_err("HTML success response must fail");
+        assert_eq!(
+            html_error,
+            "MARKET_INVALID_RESPONSE: market detail returned invalid JSON"
+        );
+        html_worker.join().expect("HTML fixture worker");
+
+        let (cache_base, cache_worker) = test_server(vec![response("304 Not Modified", &[], "")]);
+        let cache_client = MarketClient::with_base_url(cache_base).expect("304 client");
+        let cache_error =
+            tauri::async_runtime::block_on(cache_client.detail("fixture", "0.1.0-rc.7"))
+                .expect_err("orphan 304 must fail");
+        assert_eq!(
+            cache_error,
+            "MARKET_INVALID_RESPONSE: market detail returned 304 without a cache entry"
+        );
+        cache_worker.join().expect("304 fixture worker");
     }
 
     #[test]
@@ -1474,7 +1620,7 @@ mod tests {
         let error =
             tauri::async_runtime::block_on(client.prepare_install("fixture-plugin", "0.1.0-rc.7"))
                 .expect_err("install preparation must require live revalidation");
-        assert!(error.contains("market detail request failed"));
+        assert_eq!(error, "MARKET_UNAVAILABLE: market detail is unavailable");
         worker.join().expect("fixture worker");
     }
 

--- a/src-tauri/src/recovery.rs
+++ b/src-tauri/src/recovery.rs
@@ -771,7 +771,7 @@ mod tests {
             secure_fs::random_suffix().unwrap()
         ));
         let web = home.join("profiles/web");
-        fs::create_dir_all(web.join("node_modules/broken-plugin")).unwrap();
+        fs::create_dir_all(&web).unwrap();
         fs::write(
             web.join("package.json"),
             br#"{
@@ -791,6 +791,19 @@ mod tests {
 "#,
         )
         .unwrap();
+        // Attribution is deliberately complete-or-unavailable. Model the two
+        // active fixture roots as installed packages so unrelated missing
+        // manifests do not accidentally turn every leaf-attribution test
+        // into the incomplete-graph case.
+        for package_name in ["broken-plugin", "healthy-plugin"] {
+            let package_dir = web.join("node_modules").join(package_name);
+            fs::create_dir_all(&package_dir).unwrap();
+            fs::write(
+                package_dir.join("package.json"),
+                format!(r#"{{"name":"{package_name}","version":"1.0.0","dependencies":{{}}}}"#),
+            )
+            .unwrap();
+        }
         home
     }
 

--- a/src-tauri/src/recovery.rs
+++ b/src-tauri/src/recovery.rs
@@ -18,8 +18,11 @@ use std::time::{SystemTime, UNIX_EPOCH};
 const JOURNAL_SCHEMA: u32 = 1;
 const JOURNAL_MAX_BYTES: usize = 64 * 1024;
 const PROFILE_MAX_BYTES: u64 = 4 * 1024 * 1024;
+const INSTALLED_MANIFEST_MAX_BYTES: u64 = 256 * 1024;
 const MAX_SIGNAL_LINE_BYTES: usize = 16 * 1024;
 const MAX_SIGNAL_LINES: usize = 500;
+const MAX_ACTIVE_ROOTS_FOR_ATTRIBUTION: usize = 128;
+const MAX_DECLARED_DEPENDENCIES: usize = 512;
 
 // Every recovery file and profile transition belongs to one state machine.
 // The PluginRunner busy flag serializes user-triggered mutations, but readers
@@ -255,15 +258,55 @@ fn detect_candidates(
     dsh_home: &Path,
     logs: &[(String, String)],
 ) -> Result<Vec<RecoveryCandidate>, String> {
-    let (_, _, manifest) = read_recovery_manifest(dsh_home)?;
+    let (profile, _, manifest) = read_recovery_manifest(dsh_home)?;
     let dependencies = plugins::profile_dependencies(&manifest)?;
     let active = plugins::profile_bundles(&manifest)?;
     let signals = parse_signals(logs);
-    let mut candidates = Vec::new();
-    for (package_name, kinds) in signals {
-        if !active.contains(package_name.as_str()) {
-            continue;
+    let mut evidence: BTreeMap<String, BTreeSet<String>> = BTreeMap::new();
+
+    // A signal naming an active third-party root is the strongest available
+    // proof. Core packages are never recoverable: disabling one would mutate
+    // the Harness boot substrate rather than isolate a user plugin.
+    for (package_name, kinds) in &signals {
+        if is_recoverable_root(package_name, &active, dependencies) {
+            evidence.insert(package_name.clone(), kinds.clone());
         }
+    }
+
+    // Harness often reports the official leaf package or loader entry that
+    // failed, not the user-installed root bundle that brought it in. Attribute
+    // such a leaf only when exactly one active third-party root declares it.
+    // Installed package manifests are untrusted input, so every path and read
+    // is bounded and a malformed/ambiguous graph simply yields no candidate.
+    if let Some(owners) = dependency_owner_index(&profile, &active, dependencies) {
+        for (package_name, kinds) in signals {
+            if evidence.contains_key(&package_name) {
+                continue;
+            }
+            // Official/core leaves are shared by the shipped profile and by many
+            // third-party bundles. A declaration in one user root is therefore
+            // not proof that the root owns a core failure.
+            if is_core_package(&package_name) {
+                continue;
+            }
+            let Some(root_owners) = owners.get(&package_name) else {
+                continue;
+            };
+            if root_owners.len() != 1 {
+                continue;
+            }
+            let Some(root) = root_owners.iter().next() else {
+                continue;
+            };
+            let root_evidence = evidence.entry(root.clone()).or_default();
+            for kind in kinds {
+                root_evidence.insert(format!("dependency-owner:{kind}"));
+            }
+        }
+    }
+
+    let mut candidates = Vec::new();
+    for (package_name, kinds) in evidence {
         let Some(version_spec) = dependencies.get(&package_name).and_then(Value::as_str) else {
             continue;
         };
@@ -271,11 +314,131 @@ fn detect_candidates(
             market_managed: plugins::active_market_receipt(dsh_home, &package_name)?.is_some(),
             package_name,
             version_spec: version_spec.to_string(),
-            signals: kinds.into_iter().collect(),
+            // Journal validation intentionally caps evidence. All signal names
+            // are static classifications; eight deterministic rows are enough
+            // to explain a candidate without allowing repeated log shapes to
+            // make the recovery transaction unreadable after it is written.
+            signals: kinds.into_iter().take(8).collect(),
         });
     }
     candidates.sort_by(|left, right| left.package_name.cmp(&right.package_name));
     Ok(candidates)
+}
+
+fn is_core_package(package_name: &str) -> bool {
+    package_name.starts_with("@deepseek-ai/") || package_name == "dshmarket"
+}
+
+fn is_recoverable_root(
+    package_name: &str,
+    active: &std::collections::HashSet<&str>,
+    dependencies: &serde_json::Map<String, Value>,
+) -> bool {
+    plugins::is_valid_package_name(package_name)
+        && !is_core_package(package_name)
+        && active.contains(package_name)
+        && dependencies
+            .get(package_name)
+            .and_then(Value::as_str)
+            .is_some_and(|spec| !spec.is_empty())
+}
+
+fn dependency_owner_index(
+    profile: &Path,
+    active: &std::collections::HashSet<&str>,
+    dependencies: &serde_json::Map<String, Value>,
+) -> Option<BTreeMap<String, BTreeSet<String>>> {
+    // A leaf-to-root claim is safe only if every relevant root was inspected.
+    // Returning `None` on any failure is deliberately different from an empty
+    // map: a skipped root may also own a leaf and must never make another root
+    // appear uniquely responsible. Direct root evidence was collected above
+    // and remains usable when this conservative inference is unavailable.
+    let roots: Vec<&str> = active
+        .iter()
+        .copied()
+        .filter(|root| is_recoverable_root(root, active, dependencies))
+        .collect();
+    if roots.len() > MAX_ACTIVE_ROOTS_FOR_ATTRIBUTION {
+        return None;
+    }
+    let mut owners: BTreeMap<String, BTreeSet<String>> = BTreeMap::new();
+    if roots.is_empty() {
+        return Some(owners);
+    }
+    let node_modules = profile.join("node_modules");
+    if checked_real_directory(&node_modules).is_err() {
+        return None;
+    }
+    for root in roots {
+        let declared = installed_dependency_names(&node_modules, root).ok()?;
+        for package_name in declared {
+            owners
+                .entry(package_name)
+                .or_default()
+                .insert(root.to_string());
+        }
+    }
+    Some(owners)
+}
+
+fn checked_real_directory(path: &Path) -> Result<(), String> {
+    let metadata = fs::symlink_metadata(path)
+        .map_err(|error| format!("cannot inspect installed package directory: {error}"))?;
+    if secure_fs::is_symlink_or_reparse(&metadata) || !metadata.is_dir() {
+        return Err("installed package path is not a real directory".to_string());
+    }
+    Ok(())
+}
+
+fn installed_dependency_names(
+    node_modules: &Path,
+    package_name: &str,
+) -> Result<BTreeSet<String>, String> {
+    if !plugins::is_valid_package_name(package_name) {
+        return Err("installed package name is invalid".to_string());
+    }
+    let mut package_dir = node_modules.to_path_buf();
+    if let Some((scope, name)) = package_name.split_once('/') {
+        package_dir.push(scope);
+        checked_real_directory(&package_dir)?;
+        package_dir.push(name);
+    } else {
+        package_dir.push(package_name);
+    }
+    checked_real_directory(&package_dir)?;
+    let bytes = secure_fs::read_bounded(
+        &package_dir.join("package.json"),
+        INSTALLED_MANIFEST_MAX_BYTES,
+    )?
+    .ok_or_else(|| "installed package manifest is missing".to_string())?;
+    let manifest: Value = serde_json::from_slice(&bytes)
+        .map_err(|_| "installed package manifest is invalid JSON".to_string())?;
+    if manifest.get("name").and_then(Value::as_str) != Some(package_name) {
+        return Err("installed package manifest name does not match its path".to_string());
+    }
+
+    let mut declared = BTreeSet::new();
+    // Peer dependencies express a compatibility requirement, not ownership:
+    // the package can be supplied by the Harness or another root. Only
+    // materialized direct/optional dependency edges are attribution evidence.
+    for field in ["dependencies", "optionalDependencies"] {
+        let Some(value) = manifest.get(field) else {
+            continue;
+        };
+        let object = value
+            .as_object()
+            .ok_or_else(|| format!("installed package {field} is not an object"))?;
+        for (name, spec) in object {
+            if !plugins::is_valid_package_name(name) || spec.as_str().is_none_or(str::is_empty) {
+                return Err("installed package dependency declaration is invalid".to_string());
+            }
+            declared.insert(name.clone());
+            if declared.len() > MAX_DECLARED_DEPENDENCIES {
+                return Err("installed package declares too many dependencies".to_string());
+            }
+        }
+    }
+    Ok(declared)
 }
 
 fn parse_signals(logs: &[(String, String)]) -> BTreeMap<String, BTreeSet<String>> {
@@ -294,6 +457,32 @@ fn parse_signals(logs: &[(String, String)]) -> BTreeMap<String, BTreeSet<String>
         ] {
             if let Some(package_name) = quoted_after(line, prefix) {
                 add_signal(&mut found, package_name, kind);
+            }
+        }
+
+        for (prefix, kind) in [
+            ("failed to apply loader entry ", "loader-apply-failure"),
+            ("failed to import loader entry ", "loader-import-failure"),
+        ] {
+            if let Some(package_name) = parenthesized_after_ascii_case(line, prefix) {
+                add_signal(&mut found, package_name, kind);
+            }
+        }
+        for (prefix, kind) in [
+            ("cannot resolve profile bundle ", "unresolved-bundle"),
+            ("profile bundle ", "invalid-bundle"),
+        ] {
+            if let Some(package_name) = quoted_after_ascii_case(line, prefix) {
+                if kind != "invalid-bundle"
+                    || line.to_ascii_lowercase().contains("declares no dsh.bundle")
+                {
+                    add_signal(&mut found, package_name, kind);
+                }
+            }
+        }
+        if let Some(package_names) = list_after_ascii_case(line, "plugin(s) failed to load: ") {
+            for package_name in package_names.split(',').map(str::trim) {
+                add_signal(&mut found, package_name, "plugin-load-failure");
             }
         }
 
@@ -324,6 +513,38 @@ fn quoted_after<'a>(line: &'a str, prefix: &str) -> Option<&'a str> {
     let start = line.find(prefix)? + prefix.len();
     let quote = prefix.chars().last()?;
     let value = line.get(start..)?.split(quote).next()?;
+    (!value.is_empty()).then_some(value)
+}
+
+fn quoted_after_ascii_case<'a>(line: &'a str, prefix: &str) -> Option<&'a str> {
+    let lower = line.to_ascii_lowercase();
+    let start = lower.find(prefix)? + prefix.len();
+    let remaining = line.get(start..)?.trim_start();
+    let quote = remaining.chars().next()?;
+    if !matches!(quote, '\'' | '"') {
+        return None;
+    }
+    let value = remaining.get(quote.len_utf8()..)?.split(quote).next()?;
+    (!value.is_empty()).then_some(value)
+}
+
+fn parenthesized_after_ascii_case<'a>(line: &'a str, prefix: &str) -> Option<&'a str> {
+    let lower = line.to_ascii_lowercase();
+    let start = lower.find(prefix)? + prefix.len();
+    let remaining = line.get(start..)?;
+    // Upstream formats this as `entry <id> (<package>): <detail>`. Select the
+    // parenthesis adjacent to the delimiter so parentheses inside an untrusted
+    // entry id cannot be mistaken for the package name.
+    let close = remaining.find("): ")?;
+    let open = remaining.get(..close)?.rfind('(')?;
+    let value = remaining.get(open + 1..close)?.trim();
+    (!value.is_empty()).then_some(value)
+}
+
+fn list_after_ascii_case<'a>(line: &'a str, prefix: &str) -> Option<&'a str> {
+    let lower = line.to_ascii_lowercase();
+    let start = lower.find(prefix)? + prefix.len();
+    let value = line.get(start..)?.split(';').next()?.trim();
     (!value.is_empty()).then_some(value)
 }
 
@@ -515,7 +736,7 @@ fn cleanup(paths: &RecoveryPaths) -> Result<(), String> {
     secure_fs::ensure_private_dir(&paths.active)?;
     for path in [&paths.journal, &paths.before, &paths.disabled] {
         match fs::symlink_metadata(path) {
-            Ok(metadata) if metadata.file_type().is_symlink() || !metadata.is_file() => {
+            Ok(metadata) if secure_fs::is_symlink_or_reparse(&metadata) || !metadata.is_file() => {
                 return Err("plugin recovery file is not a regular file".to_string())
             }
             Ok(_) => fs::remove_file(path)
@@ -612,6 +833,51 @@ mod tests {
         path
     }
 
+    fn add_active_root(home: &Path, package_name: &str) -> PathBuf {
+        let (profile, mut manifest) = plugins::read_profile_manifest(home).unwrap();
+        manifest["dependencies"][package_name] = Value::String("1.0.0".to_string());
+        plugins::profile_bundles_mut(&mut manifest)
+            .unwrap()
+            .push(Value::String(package_name.to_string()));
+        plugins::write_profile_manifest(&profile, &manifest).unwrap();
+
+        let mut package_dir = profile.join("node_modules");
+        if let Some((scope, name)) = package_name.split_once('/') {
+            package_dir.push(scope);
+            package_dir.push(name);
+        } else {
+            package_dir.push(package_name);
+        }
+        fs::create_dir_all(&package_dir).unwrap();
+        package_dir
+    }
+
+    fn write_installed_manifest(package_dir: &Path, package_name: &str, dependencies: &[&str]) {
+        let dependencies = dependencies
+            .iter()
+            .map(|name| ((*name).to_string(), Value::String("1.0.0".to_string())))
+            .collect::<serde_json::Map<_, _>>();
+        fs::write(
+            package_dir.join("package.json"),
+            serde_json::to_vec_pretty(&serde_json::json!({
+                "name": package_name,
+                "version": "1.0.0",
+                "dependencies": dependencies
+            }))
+            .unwrap(),
+        )
+        .unwrap();
+    }
+
+    fn loader_logs(package_name: &str) -> Vec<(String, String)> {
+        vec![(
+            "stderr".to_string(),
+            format!(
+                "DSH entry failed: failed to apply loader entry settings ({package_name}): fixture failure"
+            ),
+        )]
+    }
+
     #[test]
     fn signals_are_typed_and_intersect_exact_active_dependencies() {
         let home = profile("detect");
@@ -619,6 +885,179 @@ mod tests {
         assert_eq!(candidates.len(), 1);
         assert_eq!(candidates[0].package_name, "broken-plugin");
         assert_eq!(candidates[0].signals, vec!["error-stack"]);
+        fs::remove_dir_all(home).unwrap();
+    }
+
+    #[test]
+    fn uniquely_declared_leaf_is_attributed_to_its_active_root() {
+        let home = profile("dependency-owner");
+        let root = add_active_root(&home, "community-bundle");
+        write_installed_manifest(&root, "community-bundle", &["community-loader-leaf"]);
+
+        let candidates = detect_candidates(&home, &loader_logs("community-loader-leaf")).unwrap();
+        assert_eq!(candidates.len(), 1);
+        assert_eq!(candidates[0].package_name, "community-bundle");
+        assert_eq!(
+            candidates[0].signals,
+            vec!["dependency-owner:loader-apply-failure"]
+        );
+        fs::remove_dir_all(home).unwrap();
+    }
+
+    #[test]
+    fn ambiguous_leaf_owner_produces_no_recovery_candidate() {
+        let home = profile("ambiguous-owner");
+        for root_name in ["community-one", "community-two"] {
+            let root = add_active_root(&home, root_name);
+            write_installed_manifest(&root, root_name, &["shared-loader"]);
+        }
+        assert!(detect_candidates(&home, &loader_logs("shared-loader"))
+            .unwrap()
+            .is_empty());
+        fs::remove_dir_all(home).unwrap();
+    }
+
+    #[test]
+    fn incomplete_owner_inspection_never_makes_a_leaf_unique() {
+        let home = profile("incomplete-owner");
+        let readable = add_active_root(&home, "community-one");
+        write_installed_manifest(&readable, "community-one", &["shared-loader"]);
+        let unreadable = add_active_root(&home, "community-two");
+        fs::write(unreadable.join("package.json"), b"{").unwrap();
+
+        assert!(detect_candidates(&home, &loader_logs("shared-loader"))
+            .unwrap()
+            .is_empty());
+        fs::remove_dir_all(home).unwrap();
+    }
+
+    #[test]
+    fn direct_root_evidence_survives_incomplete_owner_inspection() {
+        let home = profile("incomplete-owner-direct");
+        let readable = add_active_root(&home, "community-one");
+        write_installed_manifest(&readable, "community-one", &["shared-loader"]);
+        let unreadable = add_active_root(&home, "community-two");
+        fs::write(unreadable.join("package.json"), b"{").unwrap();
+
+        let candidates = detect_candidates(&home, &loader_logs("community-one")).unwrap();
+        assert_eq!(candidates.len(), 1);
+        assert_eq!(candidates[0].package_name, "community-one");
+        assert_eq!(candidates[0].signals, vec!["loader-apply-failure"]);
+        fs::remove_dir_all(home).unwrap();
+    }
+
+    #[test]
+    fn core_and_peer_declarations_are_not_owner_evidence() {
+        let home = profile("non-owner-edges");
+        let root = add_active_root(&home, "community-bundle");
+        fs::write(
+            root.join("package.json"),
+            serde_json::to_vec_pretty(&serde_json::json!({
+                "name": "community-bundle",
+                "version": "1.0.0",
+                "dependencies": {
+                    "@deepseek-ai/dsh-sdk-jsonrpc-server": "1.0.0"
+                },
+                "peerDependencies": {
+                    "peer-owned-elsewhere": "1.0.0"
+                }
+            }))
+            .unwrap(),
+        )
+        .unwrap();
+
+        let mut signals = loader_logs("@deepseek-ai/dsh-sdk-jsonrpc-server");
+        signals.extend(loader_logs("peer-owned-elsewhere"));
+        assert!(detect_candidates(&home, &signals).unwrap().is_empty());
+        fs::remove_dir_all(home).unwrap();
+    }
+
+    #[test]
+    fn loader_entry_parentheses_use_the_package_slot() {
+        let parsed = parse_signals(&[(
+            "stderr".to_string(),
+            "failed to apply loader entry fake-id (wrong-package) (actual-package): failure"
+                .to_string(),
+        )]);
+        assert!(!parsed.contains_key("wrong-package"));
+        assert_eq!(
+            parsed
+                .get("actual-package")
+                .and_then(|kinds| kinds.iter().next())
+                .map(String::as_str),
+            Some("loader-apply-failure")
+        );
+    }
+
+    #[test]
+    fn core_and_path_like_signals_never_become_candidates() {
+        let home = profile("core-signal");
+        let core = add_active_root(&home, "@deepseek-ai/dsh-base");
+        write_installed_manifest(&core, "@deepseek-ai/dsh-base", &[]);
+        let signals = vec![
+            (
+                "stderr".to_string(),
+                "Cannot find module '../../outside'".to_string(),
+            ),
+            (
+                "stderr".to_string(),
+                "failed to apply loader entry base (@deepseek-ai/dsh-base): failure".to_string(),
+            ),
+        ];
+        assert!(detect_candidates(&home, &signals).unwrap().is_empty());
+        fs::remove_dir_all(home).unwrap();
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn symlinked_or_oversized_owner_manifest_is_rejected() {
+        use std::os::unix::fs::symlink;
+
+        let home = profile("unsafe-owner-manifest");
+        let symlinked = add_active_root(&home, "symlinked-root");
+        let outside = home.join("outside-package.json");
+        fs::write(
+            &outside,
+            br#"{"name":"symlinked-root","dependencies":{"leaf-one":"1.0.0"}}"#,
+        )
+        .unwrap();
+        symlink(&outside, symlinked.join("package.json")).unwrap();
+
+        let oversized = add_active_root(&home, "oversized-root");
+        fs::write(
+            oversized.join("package.json"),
+            vec![b' '; INSTALLED_MANIFEST_MAX_BYTES as usize + 1],
+        )
+        .unwrap();
+
+        let mut signals = loader_logs("leaf-one");
+        signals.extend(loader_logs("leaf-two"));
+        assert!(detect_candidates(&home, &signals).unwrap().is_empty());
+        fs::remove_dir_all(home).unwrap();
+    }
+
+    #[test]
+    fn inferred_roots_recover_sequentially_without_auto_activation() {
+        let home = profile("sequential-owners");
+        for (root_name, leaf_name) in [("community-one", "leaf-one"), ("community-two", "leaf-two")]
+        {
+            let root = add_active_root(&home, root_name);
+            write_installed_manifest(&root, root_name, &[leaf_name]);
+        }
+
+        let first_logs = loader_logs("leaf-one");
+        let first = begin(&home, &first_logs, true, "community-one").unwrap();
+        assert_eq!(first.phase, RecoveryPhase::DisabledAwaitingBoot);
+        commit_after_ready(&home).unwrap();
+        finalize(&home, &first.transaction_id).unwrap();
+
+        let second = detect_candidates(&home, &loader_logs("leaf-two")).unwrap();
+        assert_eq!(second.len(), 1);
+        assert_eq!(second[0].package_name, "community-two");
+        let (_, manifest) = plugins::read_profile_manifest(&home).unwrap();
+        let bundles = plugins::profile_bundles(&manifest).unwrap();
+        assert!(!bundles.contains("community-one"));
+        assert!(bundles.contains("community-two"));
         fs::remove_dir_all(home).unwrap();
     }
 

--- a/src-tauri/src/secure_fs.rs
+++ b/src-tauri/src/secure_fs.rs
@@ -1,7 +1,8 @@
 //! Small, dependency-free primitives for Desktop-owned private state.
 //!
 //! Callers must keep files below an already-checked private directory. Every
-//! leaf is rejected when it is a symlink, writes use private permissions, and
+//! leaf is rejected when it is a symlink or Windows reparse point, writes use
+//! private permissions, and
 //! replacement is staged beside the destination so a crash cannot expose a
 //! partially written JSON document.
 
@@ -20,10 +21,26 @@ const PRIVATE_DIR_MODE: u32 = 0o700;
 #[cfg(unix)]
 const PRIVATE_FILE_MODE: u32 = 0o600;
 
+pub(crate) fn is_symlink_or_reparse(metadata: &fs::Metadata) -> bool {
+    if metadata.file_type().is_symlink() {
+        return true;
+    }
+    #[cfg(windows)]
+    {
+        use windows_sys::Win32::Storage::FileSystem::FILE_ATTRIBUTE_REPARSE_POINT;
+
+        metadata.file_attributes() & FILE_ATTRIBUTE_REPARSE_POINT != 0
+    }
+    #[cfg(not(windows))]
+    {
+        false
+    }
+}
+
 pub fn ensure_private_dir(path: &Path) -> Result<(), String> {
     match fs::symlink_metadata(path) {
         Ok(meta) => {
-            if meta.file_type().is_symlink() || !meta.is_dir() {
+            if is_symlink_or_reparse(&meta) || !meta.is_dir() {
                 return Err(format!(
                     "private state path is not a real directory: {}",
                     path.display()
@@ -43,7 +60,7 @@ pub fn ensure_private_dir(path: &Path) -> Result<(), String> {
                     path.display()
                 )
             })?;
-            if meta.file_type().is_symlink() || !meta.is_dir() {
+            if is_symlink_or_reparse(&meta) || !meta.is_dir() {
                 return Err(format!(
                     "private state path is not a real directory: {}",
                     path.display()
@@ -110,17 +127,7 @@ fn validate_regular_handle(file: &File, path: &Path) -> Result<fs::Metadata, Str
     let metadata = file
         .metadata()
         .map_err(|e| format!("cannot inspect open file {}: {e}", path.display()))?;
-    #[cfg(windows)]
-    {
-        use windows_sys::Win32::Storage::FileSystem::FILE_ATTRIBUTE_REPARSE_POINT;
-        if metadata.file_attributes() & FILE_ATTRIBUTE_REPARSE_POINT != 0 {
-            return Err(format!(
-                "private state leaf is a reparse point: {}",
-                path.display()
-            ));
-        }
-    }
-    if !metadata.is_file() {
+    if is_symlink_or_reparse(&metadata) || !metadata.is_file() {
         return Err(format!(
             "private state leaf is not a regular file: {}",
             path.display()
@@ -145,7 +152,7 @@ pub fn open_regular_read(path: &Path) -> Result<File, String> {
 
 pub fn check_regular_or_missing(path: &Path) -> Result<(), String> {
     match fs::symlink_metadata(path) {
-        Ok(meta) if meta.file_type().is_symlink() || !meta.is_file() => Err(format!(
+        Ok(meta) if is_symlink_or_reparse(&meta) || !meta.is_file() => Err(format!(
             "private state leaf is not a regular file: {}",
             path.display()
         )),
@@ -197,7 +204,7 @@ pub fn read_bounded(path: &Path, max_bytes: u64) -> Result<Option<Vec<u8>>, Stri
             ))
         }
     };
-    if meta.file_type().is_symlink() || !meta.is_file() {
+    if is_symlink_or_reparse(&meta) || !meta.is_file() {
         return Err(format!(
             "private state leaf is not a regular file: {}",
             path.display()
@@ -399,6 +406,29 @@ mod tests {
             fs::metadata(&target).unwrap().permissions().mode() & 0o777,
             0o755
         );
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn junction_directory_is_rejected() {
+        let root = test_dir("junction");
+        fs::create_dir_all(&root).unwrap();
+        let target = root.join("target");
+        let junction = root.join("junction");
+        fs::create_dir_all(&target).unwrap();
+        let output = std::process::Command::new("cmd.exe")
+            .args(["/D", "/C", "mklink", "/J"])
+            .arg(&junction)
+            .arg(&target)
+            .output()
+            .unwrap();
+        assert!(
+            output.status.success(),
+            "mklink /J failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        assert!(ensure_private_dir(&junction).is_err());
         fs::remove_dir_all(root).unwrap();
     }
 }

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -72,6 +72,7 @@
     type InstallSurfaceSnapshot,
   } from "./lib/install-arbitration";
   import { trapDialog } from "./lib/dialog-trap";
+  import { marketFailureText } from "./lib/market-error";
 
   let status = $state<Status>("idle");
   let url = $state<string | null>(null);
@@ -295,7 +296,7 @@
       marketNextCursor = res.page?.cursor ?? null;
       marketHasMore = res.page?.hasMore === true;
     } catch (e) {
-      marketError = "市场搜索失败：" + e;
+      marketError = marketFailureText("市场搜索失败", e);
     }
     marketBusy = false;
   }
@@ -319,7 +320,7 @@
       );
       marketImages = loaded.filter((src): src is string => src !== null);
     } catch (e) {
-      marketError = `插件详情加载失败：${e}`;
+      marketError = marketFailureText("插件详情加载失败", e);
     }
     marketDetailBusy = false;
   }
@@ -333,7 +334,7 @@
       // presents its current entryRevision for an explicit user confirmation.
       marketConfirm = await marketPrepareInstall(slug);
     } catch (e) {
-      marketError = "无法准备安装：" + e;
+      marketError = marketFailureText("无法准备安装", e);
     }
     marketPreparing = false;
   }
@@ -353,7 +354,7 @@
     pluginLogsOpen = true;
     void marketInstallPlugin(preview.slug, preview.entryRevision).catch((e) => {
       pluginBusy = false;
-      pluginError = "市场安装失败：" + e;
+      pluginError = marketFailureText("市场安装失败", e);
       pluginLogsOpen = true;
       void refreshPlugins();
     });
@@ -378,7 +379,7 @@
       showToast("已激活 " + plugin.name + "；请重启 Harness 后加载");
       await refreshPlugins();
     } catch (e) {
-      pluginError = "激活失败：" + e;
+      pluginError = marketFailureText("激活失败", e);
     }
     pluginBusy = false;
   }

--- a/src/lib/market-error.ts
+++ b/src/lib/market-error.ts
@@ -1,0 +1,34 @@
+const ERROR_PREFIX = {
+  timeout: "MARKET_TIMEOUT:",
+  unavailable: "MARKET_UNAVAILABLE:",
+  invalidResponse: "MARKET_INVALID_RESPONSE:",
+  http: "MARKET_HTTP_ERROR:",
+  api: "MARKET_API_ERROR:",
+} as const;
+
+/**
+ * Convert the deliberately bounded Rust market-error protocol into a
+ * user-facing Chinese message. Unknown values deliberately do not echo the
+ * rejected value, which may contain an implementation-specific URL or socket
+ * detail outside that protocol.
+ */
+export function marketFailureText(context: string, error: unknown): string {
+  const raw = String(error);
+  if (raw.startsWith(ERROR_PREFIX.timeout)) {
+    return `${context}：请求超时，请检查网络后重试`;
+  }
+  if (raw.startsWith(ERROR_PREFIX.unavailable)) {
+    return `${context}：市场服务暂时不可用，请稍后重试`;
+  }
+  if (raw.startsWith(ERROR_PREFIX.invalidResponse)) {
+    return `${context}：市场服务返回了无法识别的数据`;
+  }
+  if (raw.startsWith(ERROR_PREFIX.http)) {
+    return `${context}：市场服务返回 HTTP 错误`;
+  }
+  if (raw.startsWith(ERROR_PREFIX.api)) {
+    const detail = raw.slice(ERROR_PREFIX.api.length).trim();
+    return detail ? `${context}：${detail}` : `${context}：市场服务返回错误`;
+  }
+  return `${context}：市场请求失败，请稍后重试`;
+}

--- a/tests/frontend/market-error.test.ts
+++ b/tests/frontend/market-error.test.ts
@@ -1,0 +1,42 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { marketFailureText } from "../../src/lib/market-error.ts";
+
+const context = "市场搜索失败";
+
+test("market error categories have stable user-facing messages", () => {
+  assert.equal(
+    marketFailureText(context, "MARKET_TIMEOUT: market search request timed out"),
+    "市场搜索失败：请求超时，请检查网络后重试",
+  );
+  assert.equal(
+    marketFailureText(context, "MARKET_UNAVAILABLE: market search is unavailable"),
+    "市场搜索失败：市场服务暂时不可用，请稍后重试",
+  );
+  assert.equal(
+    marketFailureText(context, "MARKET_INVALID_RESPONSE: market search invalid JSON"),
+    "市场搜索失败：市场服务返回了无法识别的数据",
+  );
+  assert.equal(
+    marketFailureText(context, "MARKET_HTTP_ERROR: market search failed with HTTP 502"),
+    "市场搜索失败：市场服务返回 HTTP 错误",
+  );
+});
+
+test("bounded API detail is retained but unknown error text is never reflected", () => {
+  assert.equal(
+    marketFailureText(
+      context,
+      "MARKET_API_ERROR: market detail failed: 404 Not Found NOT_FOUND: no such slug (requestId: req-1)",
+    ),
+    "市场搜索失败：market detail failed: 404 Not Found NOT_FOUND: no such slug (requestId: req-1)",
+  );
+  assert.equal(
+    marketFailureText(context, "MARKET_API_ERROR:"),
+    "市场搜索失败：市场服务返回错误",
+  );
+  assert.equal(
+    marketFailureText(context, "socket failed at https://secret.invalid/?token=not-for-ui"),
+    "市场搜索失败：市场请求失败，请稍后重试",
+  );
+});


### PR DESCRIPTION
Summary

- Attribute structured startup failures to a user-installed plugin root only when one real installed root has a direct or optional edge to the reported non-core leaf.
- Keep recovery fail-closed for core packages, peer-only or ambiguous ownership, malformed or oversized manifests, symlinks, and Windows reparse points; the existing backup, pre-disable, verify, explicit finalize or rollback flow is unchanged.
- Replace raw reqwest error leakage with bounded market error categories and sanitized API error fields, then map them to concise bootstrap UI messages.
- Preserve blocked and pending activation gates; no IPC, dependency, version, or Harness capability change.

Review fixes

- Reject Windows junctions and other reparse points in shared private-file checks.
- Parse only the upstream loader package slot, so parentheses in an entry id cannot spoof attribution.
- Exclude official core leaves and peerDependencies from responsibility inference.
- Reject line separators and zero-width formatting controls in server-provided error messages.
- Cap deterministic recovery journal evidence.

Validation

- cargo nextest: 135 passed
- cargo llvm-cov: 62.36% lines, threshold 25%
- cargo fmt and clippy -D warnings
- pnpm check, check:scripts, build, test:scripts
- command contract aligned; Harness capability remains empty
- runtime smoke, bundle self-test, release preflight
- cargo deny and cargo vet --locked
- production Cordis market JSON/ETag/304/404 probe
- production preset direct HTTP 200 application/zip probe

Windows note

A cfg(windows) regression test creates a real directory junction with mklink /J and requires the secure path checks to reject it. Local cross-check reached ring before stopping because this Linux host has no MSVC C toolchain; the GitHub Windows runner is the authoritative execution proof.