### PR TITLE
fix: retry transient macOS DMG failures

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -355,7 +355,7 @@ jobs:
       # compressed image directly: no mount, Finder, AppleScript, or detach.
       - name: Build macOS DMG without Finder automation
         if: runner.os == 'macOS'
-        timeout-minutes: 15
+        timeout-minutes: 35
         run: node scripts/build-macos-dmg.ts --arch ${{ matrix.arch }}
 
       - name: Verify signed DMG before notarization

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -42,7 +42,8 @@ git push origin v0.2.1
    x64/arm64 AppImage+DEB+RPM+Flatpak）：下载 Node（SHA-256）
    → prepare-harness（441+ 许可证 + 零链接断言）→ 构建 sidecar → 冒烟 →
    `tauri build`（macOS 只产生已签名 `.app`，DMG 由无 Finder 自动化的
-   有界 `hdiutil -srcfolder` 路径生成；Flatpak 从同一 DEB 导入）→
+   有界 `hdiutil -srcfolder` 路径生成；仅对已知的 DiskImages 瞬态故障最多
+   重试 3 次，确定性错误立即失败；Flatpak 从同一 DEB 导入）→
    **verify-bundle**（包元数据、
    二进制架构、必需文件、scoped 许可证
    绊线、零符号链接、执行位、无 quarantine）→ **verify-signing**（见下）→

--- a/scripts/build-macos-dmg.ts
+++ b/scripts/build-macos-dmg.ts
@@ -19,8 +19,11 @@ import { tmpdir } from "node:os";
 import { basename, join } from "node:path";
 import { fail, info, ok, readManifest, repoRoot } from "./lib/common.ts";
 import {
+  DMG_CREATE_MAX_ATTEMPTS,
+  DMG_CREATE_RETRY_DELAY_MS,
   DMG_CREATE_TIMEOUT_MS,
   DMG_TOOL_TIMEOUT_MS,
+  isRetryableDmgCreateFailure,
   macosDmgPaths,
 } from "./lib/macos-dmg.ts";
 import type { ReleaseArch } from "./lib/release-artifacts.ts";
@@ -47,6 +50,22 @@ function commandOutput(...values: readonly (string | null | undefined)[]): strin
     .slice(-5000);
 }
 
+class CommandFailure extends Error {
+  readonly output: string;
+  readonly timedOut: boolean;
+
+  constructor(
+    message: string,
+    output: string,
+    timedOut: boolean,
+  ) {
+    super(message);
+    this.name = "CommandFailure";
+    this.output = output;
+    this.timedOut = timedOut;
+  }
+}
+
 function run(command: string, args: string[], label: string, timeout: number): void {
   const result = spawnSync(command, args, {
     encoding: "utf8",
@@ -56,13 +75,39 @@ function run(command: string, args: string[], label: string, timeout: number): v
     maxBuffer: 64 * 1024 * 1024,
   });
   if (result.status !== 0) {
-    const timeoutHint = result.error?.message.includes("ETIMEDOUT")
+    const timedOut = result.error?.message.includes("ETIMEDOUT") === true;
+    const timeoutHint = timedOut
       ? ` after ${Math.ceil(timeout / 60000)} minutes`
       : "";
-    throw new Error(
+    const output = commandOutput(result.stdout, result.stderr);
+    throw new CommandFailure(
       `${label} failed${timeoutHint} (exit ${result.status}, ${result.error?.message ?? "no spawn error"}):\n` +
-        commandOutput(result.stdout, result.stderr),
+        output,
+      output,
+      timedOut,
     );
+  }
+}
+
+async function createDmg(args: string[], output: string): Promise<void> {
+  for (let attempt = 1; attempt <= DMG_CREATE_MAX_ATTEMPTS; attempt += 1) {
+    rmSync(output, { force: true });
+    try {
+      run("hdiutil", args, "direct DMG creation", DMG_CREATE_TIMEOUT_MS);
+      return;
+    } catch (error) {
+      const retryable =
+        error instanceof CommandFailure &&
+        isRetryableDmgCreateFailure(error.output, error.timedOut);
+      if (!retryable || attempt === DMG_CREATE_MAX_ATTEMPTS) throw error;
+
+      const delay = DMG_CREATE_RETRY_DELAY_MS * attempt;
+      console.warn(
+        `warning: transient DiskImages failure on attempt ${attempt}/${DMG_CREATE_MAX_ATTEMPTS}; ` +
+          `removing the partial image and retrying in ${delay / 1000}s`,
+      );
+      await new Promise((resolve) => setTimeout(resolve, delay));
+    }
   }
 }
 
@@ -118,8 +163,7 @@ try {
   );
   symlinkSync("/Applications", join(stagingDirectory, "Applications"));
 
-  run(
-    "hdiutil",
+  await createDmg(
     [
       "create",
       "-volname",
@@ -133,8 +177,7 @@ try {
       "-ov",
       paths.output,
     ],
-    "direct DMG creation",
-    DMG_CREATE_TIMEOUT_MS,
+    paths.output,
   );
 
   if (signingIdentity) {

--- a/scripts/lib/macos-dmg.test.ts
+++ b/scripts/lib/macos-dmg.test.ts
@@ -1,6 +1,10 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { dmgArtifactName, macosDmgPaths } from "./macos-dmg.ts";
+import {
+  dmgArtifactName,
+  isRetryableDmgCreateFailure,
+  macosDmgPaths,
+} from "./macos-dmg.ts";
 
 test("DMG names match the public Tauri-compatible architecture contract", () => {
   assert.equal(dmgArtifactName("DSH Desktop", "1.2.3", "x64"), "DSH Desktop_1.2.3_x64.dmg");
@@ -28,4 +32,17 @@ test("DMG naming rejects path traversal and empty metadata", () => {
     () => dmgArtifactName("DSH Desktop", "1.2.3", "powerpc" as never),
     /unsupported DMG architecture/,
   );
+});
+
+test("DMG creation retries only known transient DiskImages failures", () => {
+  for (const output of [
+    "hdiutil: create failed - Resource busy",
+    "hdiutil: resize: failed. Device not configured (6)",
+    "DiskImages helper temporarily unavailable",
+  ]) {
+    assert.equal(isRetryableDmgCreateFailure(output), true, output);
+  }
+  assert.equal(isRetryableDmgCreateFailure("", true), true);
+  assert.equal(isRetryableDmgCreateFailure("No such file or directory"), false);
+  assert.equal(isRetryableDmgCreateFailure("codesign identity is invalid"), false);
 });

--- a/scripts/lib/macos-dmg.ts
+++ b/scripts/lib/macos-dmg.ts
@@ -1,8 +1,17 @@
 import { join } from "node:path";
 import type { ReleaseArch } from "./release-artifacts.ts";
 
-export const DMG_CREATE_TIMEOUT_MS = 10 * 60 * 1000;
+export const DMG_CREATE_TIMEOUT_MS = 5 * 60 * 1000;
 export const DMG_TOOL_TIMEOUT_MS = 5 * 60 * 1000;
+export const DMG_CREATE_MAX_ATTEMPTS = 3;
+export const DMG_CREATE_RETRY_DELAY_MS = 15 * 1000;
+
+export function isRetryableDmgCreateFailure(output: string, timedOut = false): boolean {
+  if (timedOut) return true;
+  return /resource busy|temporarily unavailable|device not configured|diskimages?[- ](?:helper|help|controller)/i.test(
+    output,
+  );
+}
 
 function safeFileComponent(value: string, label: string): string {
   const trimmed = value.trim();


### PR DESCRIPTION
## Summary
- retry only known transient DiskImages failures during direct DMG creation
- bound retries to three attempts with cleanup and linear backoff
- keep deterministic failures fail-fast and document the release behavior

## Validation
- `pnpm check:scripts`
- `pnpm check`
- `pnpm build`
- `pnpm test:scripts` (61/61)
- `pnpm release:preflight`
- `actionlint .github/workflows/release.yml`
- `git diff --check`

Follow-up to the macOS x64 targeted Release run failure: `hdiutil: create failed - Resource busy`.