### PR TITLE
fix: preserve tag release after smoke source skip

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -991,8 +991,25 @@ jobs:
   release:
     name: Publish GitHub Release
     # Only real tag pushes publish; workflow_dispatch is the build+verify-only
-    # test channel.
-    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
+    # test channel. The Windows smoke jobs intentionally inherit a skipped
+    # windows-smoke-source ancestor on tag pushes. `always()` prevents that
+    # transitive skip from suppressing publication, while the explicit result
+    # checks keep every real release gate fail-closed.
+    if: >-
+      ${{
+        always() &&
+        github.event_name == 'push' &&
+        startsWith(github.ref, 'refs/tags/') &&
+        needs.build.result == 'success' &&
+        needs.notarize-macos.result == 'success' &&
+        needs.build-msix.result == 'success' &&
+        needs.soak.result == 'success' &&
+        needs.tag-gate.result == 'success' &&
+        needs.windows-deep-link-smoke.result == 'success' &&
+        needs.windows-msi-smoke.result == 'success' &&
+        needs.macos-deep-link-smoke.result == 'success' &&
+        needs.preset-download-contract.result == 'success'
+      }}
     # soak is a publish gate: a heartbeat regression must surface before
     # release, and the 5-minute soak overlaps the (much longer) platform
     # builds, so waiting on it adds no wall time.

--- a/scripts/lib/release-artifacts.test.ts
+++ b/scripts/lib/release-artifacts.test.ts
@@ -159,6 +159,34 @@ test("Windows installer smoke can safely reuse one completed Release run", () =>
   );
 });
 
+test("tag publication tolerates only the intentional transitive smoke-source skip", () => {
+  const workflow = readFileSync(
+    new URL("../../.github/workflows/release.yml", import.meta.url),
+    "utf8",
+  );
+  const releaseJob = workflow.slice(workflow.indexOf("\n  release:\n"));
+  assert.match(releaseJob, /always\(\)/);
+  assert.match(releaseJob, /github\.event_name == 'push'/);
+  assert.match(releaseJob, /startsWith\(github\.ref, 'refs\/tags\/'\)/);
+  for (const dependency of [
+    "build",
+    "notarize-macos",
+    "build-msix",
+    "soak",
+    "tag-gate",
+    "windows-deep-link-smoke",
+    "windows-msi-smoke",
+    "macos-deep-link-smoke",
+    "preset-download-contract",
+  ]) {
+    assert.equal(
+      releaseJob.includes(`needs.${dependency}.result == 'success'`),
+      true,
+      dependency,
+    );
+  }
+});
+
 test("MSI smoke accepts a valid 8.3 registry path but verifies the real file", () => {
   const workflow = readFileSync(
     new URL("../../.github/workflows/release.yml", import.meta.url),


### PR DESCRIPTION
## Summary
- prevent an intentional skipped Windows smoke source ancestor from suppressing tag publication
- require every direct release gate to report success explicitly
- add a regression test for the complete fail-closed dependency contract

## Root cause
Tag runs intentionally skip `windows-smoke-source`; the two installer smoke jobs use `always()` and succeed, but the release job inherited GitHub Actions implicit `success()` across that skipped ancestor and was skipped. v0.2.10 artifacts and all gates succeeded; the release was recovered manually after inventory and server-digest verification.

## Validation
- `pnpm check:scripts`
- `pnpm test:scripts` (62/62)
- `actionlint .github/workflows/release.yml`
- `git diff --check`