### PR TITLE
feat: 本地化 macOS 原生菜单

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
     tags: ["v*"]
   pull_request:
+  workflow_dispatch:
 
 # Least privilege: every job here only reads the checkout (quality.yml brings
 # its own block); nothing in this workflow needs write access to the repo.
@@ -48,6 +49,41 @@ jobs:
           cache: npm
           cache-dependency-path: runtime/package-lock.json
 
+      # Compile the native shell on a real Mac whenever its Rust/build inputs
+      # change. Event SHAs are data, never shell source: validate them before
+      # use and fail closed (run the check) when a comparison is unavailable.
+      - name: Detect macOS shell changes
+        id: macos-shell
+        if: runner.os == 'macOS'
+        shell: bash
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.before || '' }}
+          HEAD_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          run_check=true
+          sha_pattern='^[0-9a-fA-F]{40}$'
+          if [[ "$BASE_SHA" =~ $sha_pattern && "$HEAD_SHA" =~ $sha_pattern && ! "$BASE_SHA" =~ ^0+$ ]]; then
+            if ! git cat-file -e "${BASE_SHA}^{commit}" 2>/dev/null; then
+              if ! git fetch --no-tags --depth=1 origin "$BASE_SHA"; then
+                printf '%s\n' 'Base commit unavailable; running macOS shell check.'
+                printf 'run=true\n' >> "$GITHUB_OUTPUT"
+                exit 0
+              fi
+            fi
+            if git cat-file -e "${HEAD_SHA}^{commit}" 2>/dev/null && git diff --quiet "$BASE_SHA" "$HEAD_SHA" -- \
+              .github/workflows/test.yml \
+              Cargo.lock \
+              rust-toolchain.toml \
+              src-tauri/Cargo.toml \
+              src-tauri/build.rs \
+              src-tauri/src \
+              src-tauri/tauri.conf.json; then
+              run_check=false
+            fi
+          fi
+          printf 'run=%s\n' "$run_check" >> "$GITHUB_OUTPUT"
+
       # The exact P0 acceptance chain, on every platform:
       # sidecar → bundled node → dsh web --port 0 → readiness → HTTP 200
       # → restart → HTTP 200 → shutdown → no orphan processes.
@@ -62,6 +98,11 @@ jobs:
 
       - name: Check staged runtime links are relocatable
         run: node scripts/check-runtime-links.ts
+
+      - name: Compile native macOS shell
+        if: runner.os == 'macOS' && steps.macos-shell.outputs.run == 'true'
+        timeout-minutes: 10
+        run: cargo check --locked --manifest-path src-tauri/Cargo.toml --all-targets
 
       - name: Runtime smoke
         run: node scripts/verify-runtime.ts

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -74,9 +74,13 @@ jobs:
             if git cat-file -e "${HEAD_SHA}^{commit}" 2>/dev/null && git diff --quiet "$BASE_SHA" "$HEAD_SHA" -- \
               .github/workflows/test.yml \
               Cargo.lock \
+              Cargo.toml \
               rust-toolchain.toml \
+              crates/ \
               src-tauri/Cargo.toml \
               src-tauri/build.rs \
+              src-tauri/capabilities \
+              src-tauri/permissions \
               src-tauri/src \
               src-tauri/tauri.conf.json; then
               run_check=false

--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,12 @@ src-tauri/icons/ios/
 .pnpm-store/
 .tmp/
 
+# Agent-local planning records. These are working notes, not product docs;
+# keeping them ignored prevents an accidental `git add -A` from shipping them.
+/findings.md
+/progress.md
+/task_plan.md
+
 # Local updater-manifest artifact (scripts/updater-manifest.ts); the live
 # one is published by CI and must never be committed from a local run.
 latest.json

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -730,6 +730,7 @@ dependencies = [
  "futures-util",
  "getrandom 0.2.17",
  "libc",
+ "objc2-foundation",
  "proptest",
  "reqwest 0.12.28",
  "semver",

--- a/crates/dsh-sidecar/src/main.rs
+++ b/crates/dsh-sidecar/src/main.rs
@@ -19,7 +19,7 @@
 //! → {"id":2,"command":"status"}   →  {"type":"status","id":2,"state":"running","pid":…,"url":"…"}
 //! → {"id":3,"command":"restart"}  →  {"type":"stopping"} … {"type":"stopped","code":0} … {"type":"starting"} …
 //! → {"id":4,"command":"shutdown"} →  {"type":"stopped","code":0}   (sidecar keeps running)
-//! [stdin EOF]                     →  graceful shutdown of the tree, sidecar exits 0
+//! [stdin EOF]                     →  immediate forced teardown of the tree, sidecar exits 0
 //! ```
 //!
 //! While running, the sidecar also probes the ready URL (liveness heartbeat);
@@ -422,8 +422,9 @@ fn main() {
     let hb_gen: Arc<AtomicU64> = Arc::new(AtomicU64::new(0));
     let hb_enabled: Arc<AtomicBool> = Arc::new(AtomicBool::new(false));
 
-    // stdin reader: commands in. Parent death is detected via channel
-    // disconnect below (the thread ends on stdin EOF, closing the sender).
+    // stdin reader: commands in. Parent-control loss is detected via channel
+    // disconnect below (the thread ends on stdin EOF or a read error, closing
+    // the sender).
     thread::spawn(move || {
         let stdin = std::io::stdin();
         let _ = dsh_sidecar::for_each_bounded_line(
@@ -759,7 +760,11 @@ fn main() {
             },
             Err(TryRecvError::Empty) => {}
             Err(TryRecvError::Disconnected) => {
-                // stdin thread gone without EOF: treat as parent gone.
+                // The parent control channel is gone (normally stdin EOF).
+                // Do not wait for a session flush: a disappeared parent means
+                // the supervised tree must be torn down immediately. The
+                // platform parent-death guard/watchdog covers an abrupt
+                // sidecar death while this process exits.
                 if let Some(r) = running.as_ref() {
                     r.child.force();
                 }

--- a/scripts/lib/workflow-safety.test.ts
+++ b/scripts/lib/workflow-safety.test.ts
@@ -23,6 +23,17 @@ test("macOS shell path gate validates event SHAs and fails closed", () => {
   assert.ok(shell.includes('git cat-file -e "${BASE_SHA}^{commit}"'));
   assert.ok(shell.includes('git cat-file -e "${HEAD_SHA}^{commit}"'));
   assert.ok(shell.includes('git diff --quiet "$BASE_SHA" "$HEAD_SHA"'));
+  for (const requiredBuildInput of [
+    "Cargo.toml",
+    "crates/",
+    "src-tauri/capabilities",
+    "src-tauri/permissions",
+  ]) {
+    assert.ok(
+      shell.includes(requiredBuildInput),
+      `macOS path gate must include ${requiredBuildInput}`,
+    );
+  }
   assert.ok(shell.includes("printf 'run=true\\n' >> \"$GITHUB_OUTPUT\""));
   assert.ok(shell.includes("run_check=true"));
 });

--- a/scripts/lib/workflow-safety.test.ts
+++ b/scripts/lib/workflow-safety.test.ts
@@ -1,0 +1,37 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { test } from "node:test";
+
+const workflow = readFileSync(
+  new URL("../../.github/workflows/test.yml", import.meta.url),
+  "utf8",
+);
+
+test("macOS shell path gate validates event SHAs and fails closed", () => {
+  const start = workflow.indexOf("      - name: Detect macOS shell changes");
+  const end = workflow.indexOf("      # The exact P0 acceptance chain", start);
+  assert.ok(start >= 0 && end > start, "macOS path-gate step missing");
+  const step = workflow.slice(start, end);
+  const shellStart = step.indexOf("        run: |");
+  assert.ok(shellStart >= 0, "macOS path-gate shell body missing");
+  const shell = step.slice(shellStart);
+
+  assert.match(step, /BASE_SHA: \$\{\{ github\.event\.pull_request\.base\.sha/);
+  assert.match(step, /HEAD_SHA: \$\{\{ github\.sha \}\}/);
+  assert.doesNotMatch(shell, /\$\{\{/);
+  assert.ok(shell.includes("sha_pattern='^[0-9a-fA-F]{40}$'"));
+  assert.ok(shell.includes('git cat-file -e "${BASE_SHA}^{commit}"'));
+  assert.ok(shell.includes('git cat-file -e "${HEAD_SHA}^{commit}"'));
+  assert.ok(shell.includes('git diff --quiet "$BASE_SHA" "$HEAD_SHA"'));
+  assert.ok(shell.includes("printf 'run=true\\n' >> \"$GITHUB_OUTPUT\""));
+  assert.ok(shell.includes("run_check=true"));
+});
+
+test("native macOS compile is path-gated and bounded", () => {
+  assert.match(workflow, /workflow_dispatch:/);
+  assert.match(workflow, /timeout-minutes: 20/);
+  assert.match(
+    workflow,
+    /if: runner\.os == 'macOS' && steps\.macos-shell\.outputs\.run == 'true'\n        timeout-minutes: 10\n        run: cargo check --locked --manifest-path src-tauri\/Cargo\.toml --all-targets/,
+  );
+});

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -50,6 +50,12 @@ proptest = "1"
 # directly because Rust crates may not rely on transitive dependencies.
 windows-sys = { version = "0.61", features = ["Win32_Storage_FileSystem"] }
 
+[target.'cfg(target_os = "macos")'.dependencies]
+# Finder-launched GUI apps cannot rely on shell locale variables. Read the
+# ordered macOS language preference directly; keep the binding surface to the
+# three Foundation types used by app_menu.rs.
+objc2-foundation = { version = "=0.3.2", default-features = false, features = ["NSArray", "NSLocale", "NSString"] }
+
 [target.'cfg(unix)'.dependencies]
 # O_NOFOLLOW closes the final-component check/open race for Desktop-owned
 # private state and user-selected sideload archives.

--- a/src-tauri/src/app_menu.rs
+++ b/src-tauri/src/app_menu.rs
@@ -1,0 +1,390 @@
+//! Localized native application menu for macOS.
+//!
+//! The menu mirrors Tauri's default role-only surface. It intentionally adds
+//! no custom command, menu event, frontend IPC, reload, or developer action.
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum MenuLanguage {
+    English,
+    SimplifiedChinese,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct MenuLabels {
+    about_prefix: &'static str,
+    services: &'static str,
+    hide_prefix: &'static str,
+    hide_others: &'static str,
+    quit_prefix: &'static str,
+    file: &'static str,
+    close_window: &'static str,
+    edit: &'static str,
+    undo: &'static str,
+    redo: &'static str,
+    cut: &'static str,
+    copy: &'static str,
+    paste: &'static str,
+    select_all: &'static str,
+    view: &'static str,
+    fullscreen: &'static str,
+    window: &'static str,
+    minimize: &'static str,
+    zoom: &'static str,
+    help: &'static str,
+}
+
+const ENGLISH: MenuLabels = MenuLabels {
+    about_prefix: "About",
+    services: "Services",
+    hide_prefix: "Hide",
+    hide_others: "Hide Others",
+    quit_prefix: "Quit",
+    file: "File",
+    close_window: "Close Window",
+    edit: "Edit",
+    undo: "Undo",
+    redo: "Redo",
+    cut: "Cut",
+    copy: "Copy",
+    paste: "Paste",
+    select_all: "Select All",
+    view: "View",
+    fullscreen: "Enter Full Screen",
+    window: "Window",
+    minimize: "Minimize",
+    zoom: "Zoom",
+    help: "Help",
+};
+
+const SIMPLIFIED_CHINESE: MenuLabels = MenuLabels {
+    about_prefix: "关于",
+    services: "服务",
+    hide_prefix: "隐藏",
+    hide_others: "隐藏其他",
+    quit_prefix: "退出",
+    file: "文件",
+    close_window: "关闭窗口",
+    edit: "编辑",
+    undo: "撤销",
+    redo: "重做",
+    cut: "剪切",
+    copy: "拷贝",
+    paste: "粘贴",
+    select_all: "全选",
+    view: "显示",
+    fullscreen: "进入全屏幕",
+    window: "窗口",
+    minimize: "最小化",
+    zoom: "缩放",
+    help: "帮助",
+};
+
+impl MenuLanguage {
+    const fn labels(self) -> &'static MenuLabels {
+        match self {
+            Self::English => &ENGLISH,
+            Self::SimplifiedChinese => &SIMPLIFIED_CHINESE,
+        }
+    }
+}
+
+fn classify_language_tag(tag: &str) -> Option<MenuLanguage> {
+    let normalized = tag.trim().replace('_', "-").to_ascii_lowercase();
+    if matches!(normalized.as_str(), "zh" | "zh-cn" | "zh-sg" | "zh-hans")
+        || normalized.starts_with("zh-hans-")
+    {
+        return Some(MenuLanguage::SimplifiedChinese);
+    }
+    if normalized == "en" || normalized.starts_with("en-") {
+        return Some(MenuLanguage::English);
+    }
+    None
+}
+
+fn language_from_preferences<I, S>(preferences: I) -> MenuLanguage
+where
+    I: IntoIterator<Item = S>,
+    S: AsRef<str>,
+{
+    preferences
+        .into_iter()
+        .find_map(|tag| classify_language_tag(tag.as_ref()))
+        .unwrap_or(MenuLanguage::English)
+}
+
+#[derive(Debug, Eq, PartialEq)]
+struct MenuInstallFailure<E> {
+    install: E,
+    had_previous: bool,
+    restore: Option<E>,
+}
+
+fn replace_with_fallback<T, E>(
+    replacement: T,
+    previous: Option<T>,
+    mut apply: impl FnMut(T) -> Result<(), E>,
+) -> Result<(), MenuInstallFailure<E>> {
+    match apply(replacement) {
+        Ok(()) => Ok(()),
+        Err(install) => {
+            let had_previous = previous.is_some();
+            let restore = previous.and_then(|menu| apply(menu).err());
+            Err(MenuInstallFailure {
+                install,
+                had_previous,
+                restore,
+            })
+        }
+    }
+}
+
+#[cfg(target_os = "macos")]
+mod macos {
+    use super::{language_from_preferences, replace_with_fallback, MenuLabels};
+    use objc2_foundation::NSLocale;
+    use tauri::{
+        menu::{
+            AboutMetadata, Menu, PredefinedMenuItem, Submenu, HELP_SUBMENU_ID, WINDOW_SUBMENU_ID,
+        },
+        AppHandle, Wry,
+    };
+
+    fn preferred_labels() -> &'static MenuLabels {
+        let preferences = NSLocale::preferredLanguages();
+        language_from_preferences(preferences.iter().map(|language| language.to_string())).labels()
+    }
+
+    fn build_menu(app: &AppHandle) -> tauri::Result<Menu<Wry>> {
+        let labels = preferred_labels();
+        let package = app.package_info();
+        let app_name = package.name.clone();
+        let config = app.config();
+        let about_metadata = AboutMetadata {
+            name: Some(app_name.clone()),
+            version: Some(package.version.to_string()),
+            copyright: config.bundle.copyright.clone(),
+            authors: config
+                .bundle
+                .publisher
+                .clone()
+                .map(|publisher| vec![publisher]),
+            ..Default::default()
+        };
+
+        let about = format!("{} {app_name}", labels.about_prefix);
+        let hide = format!("{} {app_name}", labels.hide_prefix);
+        let quit = format!("{} {app_name}", labels.quit_prefix);
+
+        let app_menu = Submenu::with_items(
+            app,
+            &app_name,
+            true,
+            &[
+                &PredefinedMenuItem::about(app, Some(&about), Some(about_metadata))?,
+                &PredefinedMenuItem::separator(app)?,
+                &PredefinedMenuItem::services(app, Some(labels.services))?,
+                &PredefinedMenuItem::separator(app)?,
+                &PredefinedMenuItem::hide(app, Some(&hide))?,
+                &PredefinedMenuItem::hide_others(app, Some(labels.hide_others))?,
+                &PredefinedMenuItem::separator(app)?,
+                &PredefinedMenuItem::quit(app, Some(&quit))?,
+            ],
+        )?;
+        let file_menu = Submenu::with_items(
+            app,
+            labels.file,
+            true,
+            &[&PredefinedMenuItem::close_window(
+                app,
+                Some(labels.close_window),
+            )?],
+        )?;
+        let edit_menu = Submenu::with_items(
+            app,
+            labels.edit,
+            true,
+            &[
+                &PredefinedMenuItem::undo(app, Some(labels.undo))?,
+                &PredefinedMenuItem::redo(app, Some(labels.redo))?,
+                &PredefinedMenuItem::separator(app)?,
+                &PredefinedMenuItem::cut(app, Some(labels.cut))?,
+                &PredefinedMenuItem::copy(app, Some(labels.copy))?,
+                &PredefinedMenuItem::paste(app, Some(labels.paste))?,
+                &PredefinedMenuItem::select_all(app, Some(labels.select_all))?,
+            ],
+        )?;
+        let view_menu = Submenu::with_items(
+            app,
+            labels.view,
+            true,
+            &[&PredefinedMenuItem::fullscreen(
+                app,
+                Some(labels.fullscreen),
+            )?],
+        )?;
+        let window_menu = Submenu::with_id_and_items(
+            app,
+            WINDOW_SUBMENU_ID,
+            labels.window,
+            true,
+            &[
+                &PredefinedMenuItem::minimize(app, Some(labels.minimize))?,
+                &PredefinedMenuItem::maximize(app, Some(labels.zoom))?,
+                &PredefinedMenuItem::separator(app)?,
+                &PredefinedMenuItem::close_window(app, Some(labels.close_window))?,
+            ],
+        )?;
+        let help_menu = Submenu::with_id(app, HELP_SUBMENU_ID, labels.help, true)?;
+
+        Menu::with_items(
+            app,
+            &[
+                &app_menu,
+                &file_menu,
+                &edit_menu,
+                &view_menu,
+                &window_menu,
+                &help_menu,
+            ],
+        )
+    }
+
+    pub(crate) fn init(app: &AppHandle) {
+        let menu = match build_menu(app) {
+            Ok(menu) => menu,
+            Err(error) => {
+                eprintln!(
+                    "[dsh-desktop] localized macOS menu unavailable; keeping Tauri default: {error}"
+                );
+                return;
+            }
+        };
+        let previous = app.menu();
+        if let Err(failure) = replace_with_fallback(menu, previous, |candidate| {
+            app.set_menu(candidate).map(|_| ())
+        }) {
+            match failure.restore {
+                Some(restore) => eprintln!(
+                    "[dsh-desktop] localized macOS menu install failed: {}; default menu restore also failed: {restore}",
+                    failure.install
+                ),
+                None if failure.had_previous => eprintln!(
+                    "[dsh-desktop] localized macOS menu install failed; restored Tauri default: {}",
+                    failure.install
+                ),
+                None => eprintln!(
+                    "[dsh-desktop] localized macOS menu install failed and no previous menu was available: {}",
+                    failure.install
+                ),
+            }
+        }
+    }
+}
+
+#[cfg(target_os = "macos")]
+pub(crate) use macos::init;
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn selects_first_supported_preference_and_normalizes_separators() {
+        assert_eq!(
+            language_from_preferences(["fr-FR", "zh_Hans_CN", "en-US"]),
+            MenuLanguage::SimplifiedChinese
+        );
+        assert_eq!(
+            language_from_preferences(["ja-JP", "en_GB", "zh-CN"]),
+            MenuLanguage::English
+        );
+    }
+
+    #[test]
+    fn traditional_chinese_does_not_select_simplified_labels() {
+        assert_eq!(
+            language_from_preferences(["zh-Hant-TW", "en-US"]),
+            MenuLanguage::English
+        );
+        assert_eq!(
+            language_from_preferences(["zh-TW", "zh-CN"]),
+            MenuLanguage::SimplifiedChinese
+        );
+    }
+
+    #[test]
+    fn empty_or_unsupported_preferences_fall_back_to_english() {
+        assert_eq!(
+            language_from_preferences(std::iter::empty::<&str>()),
+            MenuLanguage::English
+        );
+        assert_eq!(
+            language_from_preferences(["fr-FR", "ja-JP"]),
+            MenuLanguage::English
+        );
+    }
+
+    #[test]
+    fn label_sets_cover_the_complete_native_surface() {
+        let english = MenuLanguage::English.labels();
+        assert_eq!(english.file, "File");
+        assert_eq!(english.close_window, "Close Window");
+        assert_eq!(english.fullscreen, "Enter Full Screen");
+        assert_eq!(english.help, "Help");
+
+        let chinese = MenuLanguage::SimplifiedChinese.labels();
+        assert_eq!(chinese.file, "文件");
+        assert_eq!(chinese.close_window, "关闭窗口");
+        assert_eq!(chinese.fullscreen, "进入全屏幕");
+        assert_eq!(chinese.help, "帮助");
+    }
+
+    #[test]
+    fn failed_replacement_restores_the_previous_menu() {
+        let mut attempts = Vec::new();
+        let result = replace_with_fallback("localized", Some("default"), |menu| {
+            attempts.push(menu);
+            if menu == "localized" {
+                Err("install failed")
+            } else {
+                Ok(())
+            }
+        });
+        assert_eq!(attempts, vec!["localized", "default"]);
+        assert_eq!(
+            result,
+            Err(MenuInstallFailure {
+                install: "install failed",
+                had_previous: true,
+                restore: None,
+            })
+        );
+    }
+
+    #[test]
+    fn reports_both_replacement_and_restore_failures() {
+        let result = replace_with_fallback("localized", Some("default"), Err);
+        assert_eq!(
+            result,
+            Err(MenuInstallFailure {
+                install: "localized",
+                had_previous: true,
+                restore: Some("default"),
+            })
+        );
+    }
+
+    #[test]
+    fn reports_when_no_previous_menu_can_be_restored() {
+        let result = replace_with_fallback("localized", None, Err);
+        assert_eq!(
+            result,
+            Err(MenuInstallFailure {
+                install: "localized",
+                had_previous: false,
+                restore: None,
+            })
+        );
+    }
+}

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -19,6 +19,9 @@ mod recovery;
 mod secure_fs;
 mod tray;
 
+#[cfg(any(target_os = "macos", test))]
+mod app_menu;
+
 fn main() {
     // Windows: give the shell a private hidden console before any plugin
     // child exists. Plugin children are spawned WITHOUT CREATE_NO_WINDOW so
@@ -97,6 +100,8 @@ fn main() {
                 .build(),
         )
         .setup(|app| {
+            #[cfg(target_os = "macos")]
+            app_menu::init(app.handle());
             // Observability is independent from DSH_HOME and must exist before
             // Harness resolution so initialization failures are still visible.
             // Failure to persist evidence does not block the application.


### PR DESCRIPTION
## 概要

- 按 macOS 首选语言选择简体中文或英文原生菜单
- 保留 Tauri 默认 predefined roles、快捷键、Window/Help 标准菜单 ID 与 About 元数据
- 菜单替换失败时恢复原默认菜单，不影响应用启动
- 在现有 macOS smoke runner 中增加安全、按路径触发且有超时边界的 Tauri shell 编译

## 安全边界

- 不新增命令、事件、ACL 或 capability
- 不修改 Harness webview、deep-link 或插件激活流程
- 不加入 Reload、DevTools、缩放级别等调试菜单
- GitHub 事件 SHA 仅经 env 传入，校验为 40 位十六进制后使用；判断失败时强制编译

## 验证

- cargo nextest：141/141
- cargo clippy --all-targets -- -D warnings
- cargo llvm-cov：62.21%，门槛 55%
- scripts tests：77/77
- frontend tests：3/3
- cargo deny
- cargo vet --locked
- release preflight
- bundled dsh plugin add/remove smoke

真实 macOS Foundation/Tauri 路径由本 PR 的 Runtime smoke macOS job 编译。