### PR TITLE
fix: harden Release dispatch and update Harness 0.1.1-rc.1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,10 +5,6 @@ on:
     tags: ["v*"]
   workflow_dispatch:
     inputs:
-      tag:
-        type: string
-        required: false
-        description: "Tag/branch to build & verify (defaults to the default branch). Does not publish."
       native_target:
         type: choice
         required: false
@@ -53,7 +49,11 @@ concurrency:
 jobs:
   release-plan:
     name: Validate release matrix
-    if: github.event_name != 'workflow_dispatch' || github.event.inputs.windows_smoke_source_run_id == ''
+    # A manually selected workflow ref must never start the signing/build graph:
+    # dispatches are allowed only from reviewed main. Every subsequent native
+    # build depends on this plan; the separate read-only diagnosis path below
+    # remains explicitly scoped to an already completed same-repository run.
+    if: github.event_name != 'workflow_dispatch' || (github.ref == 'refs/heads/main' && github.event.inputs.windows_smoke_source_run_id == '')
     runs-on: ubuntu-latest
     timeout-minutes: 5
     outputs:
@@ -63,7 +63,7 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1 (SHA-pinned)
         with:
-          ref: ${{ github.event.inputs.tag || github.ref }}
+          ref: ${{ github.event_name == 'workflow_dispatch' && 'refs/heads/main' || github.ref }}
 
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v7.0.0 (SHA-pinned)
         with:
@@ -71,11 +71,18 @@ jobs:
 
       - name: Emit reviewed native, notarization, and Store matrices
         id: matrix
+        env:
+          # workflow_dispatch values are external data even when the UI offers
+          # a choice. Keep them out of the shell source; release-plan.ts then
+          # enforces its exact reviewed target allowlist.
+          NATIVE_TARGET: ${{ github.event.inputs.native_target || 'all' }}
         run: |
+          native="$(node scripts/release-plan.ts --github-matrix --target "$NATIVE_TARGET")"
+          macos_notarization="$(node scripts/release-plan.ts --github-macos-notarization-matrix --target "$NATIVE_TARGET")"
           {
-            echo "native=$(node scripts/release-plan.ts --github-matrix --target '${{ github.event.inputs.native_target || 'all' }}')"
+            echo "native=$native"
             echo "msix=$(node scripts/release-plan.ts --github-msix-matrix)"
-            echo "macos_notarization=$(node scripts/release-plan.ts --github-macos-notarization-matrix --target '${{ github.event.inputs.native_target || 'all' }}')"
+            echo "macos_notarization=$macos_notarization"
           } >> "$GITHUB_OUTPUT"
 
   # The desktop deliberately refuses redirects/non-JSON responses at its
@@ -90,7 +97,7 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1 (SHA-pinned)
         with:
-          ref: ${{ github.event.inputs.tag || github.ref }}
+          ref: ${{ github.event_name == 'workflow_dispatch' && 'refs/heads/main' || github.ref }}
 
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v7.0.0 (SHA-pinned)
         with:
@@ -109,7 +116,7 @@ jobs:
     if: github.event_name != 'workflow_dispatch' || github.event.inputs.windows_smoke_source_run_id == ''
     uses: ./.github/workflows/quality.yml
     with:
-      checkout_ref: ${{ github.event.inputs.tag || github.ref }}
+      checkout_ref: ${{ github.event_name == 'workflow_dispatch' && 'refs/heads/main' || github.ref }}
 
   # Refuse to spend two platform builds (and a publish) on a tag that can
   # never be published: the tag commit must be an ancestor of main. The
@@ -129,7 +136,7 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1 (SHA-pinned)
         with:
-          ref: ${{ github.ref }}
+          ref: ${{ github.event_name == 'workflow_dispatch' && 'refs/heads/main' || github.ref }}
 
       - name: Enforce tag ancestry
         env:
@@ -158,7 +165,7 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1 (SHA-pinned)
         with:
-          ref: ${{ github.event.inputs.tag || github.ref }}
+          ref: ${{ github.event_name == 'workflow_dispatch' && 'refs/heads/main' || github.ref }}
 
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v7.0.0 (SHA-pinned)
         with:
@@ -203,7 +210,7 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1 (SHA-pinned)
         with:
-          ref: ${{ github.event.inputs.tag || github.ref }}
+          ref: ${{ github.event_name == 'workflow_dispatch' && 'refs/heads/main' || github.ref }}
 
       - name: Install Linux bundle and Flatpak dependencies
         if: runner.os == 'Linux'
@@ -497,7 +504,7 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1 (SHA-pinned)
         with:
-          ref: ${{ github.event.inputs.tag || github.ref }}
+          ref: ${{ github.event_name == 'workflow_dispatch' && 'refs/heads/main' || github.ref }}
 
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v7.0.0 (SHA-pinned)
         with:
@@ -582,7 +589,7 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1 (SHA-pinned)
         with:
-          ref: ${{ github.event.inputs.tag || github.ref }}
+          ref: ${{ github.event_name == 'workflow_dispatch' && 'refs/heads/main' || github.ref }}
 
       - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c  # stable (version via rust-toolchain.toml)
         with:
@@ -1030,7 +1037,7 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1 (SHA-pinned)
         with:
-          ref: ${{ github.ref }}
+          ref: ${{ github.event_name == 'workflow_dispatch' && 'refs/heads/main' || github.ref }}
 
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v7.0.0 (SHA-pinned)
         with:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,7 +49,7 @@ DSH CLI 的启动契约随版本演进，社区同类项目已实证踩坑（如
 1. bump `runtime/package.json` pin + `npm install` 刷新 lock +
    manifest.harnessVersion；
 2. 对照新版 `dsh --help` / `dsh web --help` 复核契约并记录变化（当前钉
-   0.1.0-rc.8 的基线：`web` = `--profile web` 别名；flag 仅
+   0.1.1-rc.1 的基线：`web` = `--profile web` 别名；flag 仅
    `--host`/`--port`/`--trusted-host`/`--no-open`（Desktop 启动必须显式
    `--no-open`，避免上游再拉起系统浏览器）；**无** `--expose-internals`/
    `--use-system-ca`；就绪行 MARKER 为 `dsh web: http://127.0.0.1:`；

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -141,7 +141,9 @@ Desktop 工作区直接改为公开发布。
 - draft 阶段发现问题：删除 draft + tag 后重新打 tag（tag 重新指向新提交）。
 - 已发布：永不覆盖资产；bump patch 版本重新发布，旧版标注。
 - workflow_dispatch（不发布）可用于在**不打 tag** 的情况下全流程演练构建
-  与验证（`tag` 输入为空时构建默认分支）。`native_target`
+  与验证；手动演练必须在受保护的 `main` 上启动，非 main workflow ref 不会进入
+  签名/构建图。Release 的全部源码 checkout 都固定为 `main`，且不接受
+  tag/branch 输入。`native_target`
   默认为 `all`；选 `macos-x64` 或 `macos-arm64` 时只跑对应的构建、
   Developer ID 签名、Submission-ID 公证与产物复验，并跳过 MSIX、
   Windows installer smoke 和 5 分钟 soak。此通道用于发布前低成本验证

--- a/runtime/package-lock.json
+++ b/runtime/package-lock.json
@@ -8,7 +8,7 @@
       "name": "dsh-desktop-runtime",
       "version": "0.1.0",
       "dependencies": {
-        "@deepseek-ai/dsh": "0.1.0-rc.8",
+        "@deepseek-ai/dsh": "0.1.1-rc.1",
         "pnpm": "11.21.0"
       }
     },
@@ -600,9 +600,9 @@
       "license": "MIT"
     },
     "node_modules/@deepseek-ai/dsh": {
-      "version": "0.1.0-rc.8",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh/-/dsh-0.1.0-rc.8.tgz",
-      "integrity": "sha512-VQU5NlomrKLRgcXuOf+sxWFvqxPA8q9vMhrKPlPPXiOJEhGlGlAdiyxZvZxkCVI+v0zbhe21cY3/luLyxpSzzA==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh/-/dsh-0.1.1-rc.1.tgz",
+      "integrity": "sha512-HVauMT0F7MWUctkxzBcu5PMFc8j0lm0kX+4IbcUsA7Oh+/xv7xhigEDP0SaSOM/kR48U/BldHbZru116DcZz0w==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
@@ -610,60 +610,60 @@
         "@deepseek-ai/cordis-plugin-include": "^1.0.6",
         "@deepseek-ai/cordis-plugin-loader": "^1.0.2",
         "@deepseek-ai/cordis-plugin-timer": "^1.1.3",
-        "@deepseek-ai/dsh-agent-instructions": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-agent-tool-presentation": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-app-boot": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-base": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-client-ui-agent-preset": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-client-ui-cordis": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-cmdline": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-command-compact": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-command-goal": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-compaction-basic": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-compaction-tool-result-pruner": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-cordis-client-runner": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-fs-local": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-goal": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-goal-round-driver": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-headless": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-home-paths": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-jobs-local": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-launch-environment": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-mcp-client": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-persona": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-plan-mode": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-pwsh-local": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-pwsh-sandbox": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-schedule": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-session-projection": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-session-reference": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-skill": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-skill-filesystem": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-terminal": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-terminal-bash": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-time-context": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-tmux-context": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-token-meter": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-tool-ask-user": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-tool-bash": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-tool-bash-persistent": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-tool-cordis": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-tool-fs": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-tool-fs-search": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-tool-goal": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-tool-jobs": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-tool-pwsh": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-tool-pwsh-persistent": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-tool-ralph": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-tool-skill": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-tool-str-replace-editor": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-tool-subagent": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-tool-subagent-control": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-tool-todo": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-tool-web": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-tool-workflow": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-web-app": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-workflow-worker-thread": "^0.1.0-rc.8",
+        "@deepseek-ai/dsh-agent-instructions": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-agent-tool-presentation": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-app-boot": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-base": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-ui-agent-preset": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-ui-cordis": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-cmdline": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-command-compact": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-command-goal": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-compaction-basic": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-compaction-tool-result-pruner": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-cordis-client-runner": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-fs-local": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-goal": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-goal-round-driver": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-headless": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-home-paths": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-jobs-local": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-launch-environment": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-mcp-client": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-persona": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-plan-mode": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-pwsh-local": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-pwsh-sandbox": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-schedule": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-session-projection": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-session-reference": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-skill": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-skill-filesystem": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-terminal": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-terminal-bash": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-time-context": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-tmux-context": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-token-meter": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-tool-ask-user": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-tool-bash": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-tool-bash-persistent": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-tool-cordis": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-tool-fs": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-tool-fs-search": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-tool-goal": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-tool-jobs": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-tool-pwsh": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-tool-pwsh-persistent": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-tool-ralph": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-tool-skill": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-tool-str-replace-editor": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-tool-subagent": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-tool-subagent-control": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-tool-todo": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-tool-web": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-tool-workflow": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-web-app": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-workflow-worker-thread": "^0.1.1-rc.1",
         "commander": "^15.0.0",
         "js-yaml": "^4.2.0",
         "node-addon-require-builtin": "^0.1.4"
@@ -673,80 +673,80 @@
       }
     },
     "node_modules/@deepseek-ai/dsh-agent": {
-      "version": "0.1.0-rc.8",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-agent/-/dsh-agent-0.1.0-rc.8.tgz",
-      "integrity": "sha512-fOl46ZvzoYHalrlyfOJAHNhzyKeVDTUnZZKNSJEr9GY/98WJTjcV21agVEofTXldkJ7a/ws2HpJkVNJVFMtslg==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-agent/-/dsh-agent-0.1.1-rc.1.tgz",
+      "integrity": "sha512-xE+oni6Ig32Q7QspcUVQqGOa9QYiWwwaqG8ci43+oc2vfslXbD9RJ+qnk9XFKidnVn6cwB95Aw4eeivy0ufDCg==",
       "license": "MIT",
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-llm": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-scope": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-session": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-system-prompt": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-typert-protocol": "^0.1.0-rc.8"
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-scope": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-typert-protocol": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-agent-default-model": {
-      "version": "0.1.0-rc.8",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-agent-default-model/-/dsh-agent-default-model-0.1.0-rc.8.tgz",
-      "integrity": "sha512-FSmgVy8yeVYx3krUwfWZR3JokLD202FSuEd/ZfGdxA+BhOKAOfhNv539kujatVqXyzCG3XiRNda7zWxCh2h7/A==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-agent-default-model/-/dsh-agent-default-model-0.1.1-rc.1.tgz",
+      "integrity": "sha512-PZl4y+vW3nhaYljebQ0mZELKvfw61neybWeuMYBdprrM0TnjbYStY0drxynowxqaGoBPUO5Ty3q9Px4hbUYaLw==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-llm": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-settings": "^0.1.0-rc.8"
+        "@deepseek-ai/dsh-agent": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-settings": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-agent-instructions": {
-      "version": "0.1.0-rc.8",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-agent-instructions/-/dsh-agent-instructions-0.1.0-rc.8.tgz",
-      "integrity": "sha512-T+JER2gUZbopOxNeHKUE7EfNof30yihsi7GXKB/lOLoy1XMvd5mlzjSHA/OzqjLxiZyyN4V7XAGURApVD3Z7sw==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-agent-instructions/-/dsh-agent-instructions-0.1.1-rc.1.tgz",
+      "integrity": "sha512-/BZNgV2qnwERp4EpH0Lu/U6RWUDEu+u7W0Xu9y3/b0PvGsBz5oeucPnaFOKEXIIHDVnuFvo2513sYOsaoj0xWA==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-fs": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-home-paths": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-llm": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-session": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-tools": "^0.1.0-rc.8"
+        "@deepseek-ai/dsh-agent": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-fs": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-home-paths": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-tools": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-agent-loop": {
-      "version": "0.1.0-rc.8",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-agent-loop/-/dsh-agent-loop-0.1.0-rc.8.tgz",
-      "integrity": "sha512-6Vg5oLy3UZ6lJKMPxldqqBylKSMOpbV/FRrqzDqn3hGdksYBzt9K2hUJm/rE2RyguYKUKFPm2hExs0nn4HKmWA==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-agent-loop/-/dsh-agent-loop-0.1.1-rc.1.tgz",
+      "integrity": "sha512-Cu/z/oT5DPV6jDU9+X1Hbi0ex4OPHMF7eK9+sMOjvgJSlXJWU2Htg7/XfFEOLMkrerA48CopieWrbNLSL1pFGg==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-llm": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-scope": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-session": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-session-persistence": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-settings": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-system-prompt": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-tools": "^0.1.0-rc.8"
+        "@deepseek-ai/dsh-agent": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-scope": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-session-persistence": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-settings": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-tools": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-agent-presets": {
-      "version": "0.1.0-rc.8",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-agent-presets/-/dsh-agent-presets-0.1.0-rc.8.tgz",
-      "integrity": "sha512-7h+kE0KDrJCk2Y8GAqF4fu4YqZmFi5U8/AarFkGUqRI3HDugD6oYf05c7ZWNF7lQXh1OmwmrSbuPhT/YXJapOg==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-agent-presets/-/dsh-agent-presets-0.1.1-rc.1.tgz",
+      "integrity": "sha512-m+IitPjH4knw1fWzIv/6AqkLj6vRH956oop0okNAa5tkbyz9B4XwR7I81+2ifqc7btp2e5TIBl8lgx4WyxUbhg==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1",
@@ -756,91 +756,91 @@
         "@deepseek-ai/cordis": "^4.0.1",
         "@deepseek-ai/cordis-plugin-include": "^1.0.6",
         "@deepseek-ai/cordis-plugin-loader": "^1.0.2",
-        "@deepseek-ai/dsh-agent": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-atomic-write": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-home-paths": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-scope": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-session": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-settings": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-system-prompt": "^0.1.0-rc.8"
+        "@deepseek-ai/dsh-agent": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-atomic-write": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-home-paths": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-scope": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-settings": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-agent-tool-presentation": {
-      "version": "0.1.0-rc.8",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-agent-tool-presentation/-/dsh-agent-tool-presentation-0.1.0-rc.8.tgz",
-      "integrity": "sha512-DQouZBh0yjKy8bi0EHQZrZ1B0E+Sc321o5oIyrrmL3hh1sbBsWVrnTvwKPP+SU7J6gnIzyITJ7qEV7pcCGOB2w==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-agent-tool-presentation/-/dsh-agent-tool-presentation-0.1.1-rc.1.tgz",
+      "integrity": "sha512-XH7Fik0+ktVGzx4FEvFKDDYJNYU/AhQfcyPi/BNhIegBPCXAdLTbomwh3bb5FBhMiYcwq1bPQknxS8kN+tmuFA==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-tools": "^0.1.0-rc.8"
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-tools": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-anonymous-user-id": {
-      "version": "0.1.0-rc.8",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-anonymous-user-id/-/dsh-anonymous-user-id-0.1.0-rc.8.tgz",
-      "integrity": "sha512-vUESbXtDdqIyelCNqX3ijOfqNfw65iSaJaqzfiqQhmSd9ZrNJ1fPUHl8FoW1BdfK8FjrDyh32R6BtuVpI7Zdhw==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-anonymous-user-id/-/dsh-anonymous-user-id-0.1.1-rc.1.tgz",
+      "integrity": "sha512-SBXf0wg4HO9PDTb+GFJuSQ8OzARDojF0UhoveD/j1roF6X6pnRjkDsRaYUWg3Uwmim3Bc5Dckutgu9p14hFn1Q==",
       "license": "MIT",
       "peer": true,
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-brand": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-home-paths": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.8"
+        "@deepseek-ai/dsh-brand": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-home-paths": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-api-gateway": {
-      "version": "0.1.0-rc.8",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-api-gateway/-/dsh-api-gateway-0.1.0-rc.8.tgz",
-      "integrity": "sha512-rNA9+Sq3lXFDmyoFLpXNbcuWg7iFeepCwDi+jt1oGjwZTdZJ2nEWpU6GKlOiqadQjHYzfwEbCqmcuJy32qke/A==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-api-gateway/-/dsh-api-gateway-0.1.1-rc.1.tgz",
+      "integrity": "sha512-+fi1Zo1bY1dB+Qr5Q+iLxr1kSL9sigWhdMiK0tV9dAPY4BxOunwjiTh614P6jsRTvDAh/VDaHEQsHcv1T4YY9Q==",
       "license": "MIT",
       "dependencies": {
-        "@deepseek-ai/dsh-typert-protocol": "^0.1.0-rc.8"
+        "@deepseek-ai/dsh-typert-protocol": "^0.1.1-rc.1"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-client-connection": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-typert-registry": "^0.1.0-rc.8"
+        "@deepseek-ai/dsh-client-connection": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-typert-registry": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-api-remotes": {
-      "version": "0.1.0-rc.8",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-api-remotes/-/dsh-api-remotes-0.1.0-rc.8.tgz",
-      "integrity": "sha512-s/zmFmU6R+dDxUWbHucIyfVgJG4v8kXa3YRjwjMO+Bu871ZG5Zsht6cvRqeSyu0A/Gs06ZfKYeKE0sdbCZ1NiA==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-api-remotes/-/dsh-api-remotes-0.1.1-rc.1.tgz",
+      "integrity": "sha512-TOeb0DsrjUyZIlL/Ih1loEg2UelVQdLX9Vck6LgCjZcH7UJvQdYuMKt5G8Tbvms3ZHvlpvCc7kue4sQlZ9rKDA==",
       "license": "MIT",
       "dependencies": {
-        "@deepseek-ai/dsh-typert-protocol": "^0.1.0-rc.8"
+        "@deepseek-ai/dsh-typert-protocol": "^0.1.1-rc.1"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-agent-presets": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-api-gateway": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-commands": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-cordis-host-runner": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-credentials": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-file-reference": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-goal": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-host-plugin-inventory": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-llm": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-message-feedback": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-session": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-session-persistence": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-session-reference": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-settings": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-typert-registry": "^0.1.0-rc.8"
+        "@deepseek-ai/dsh-agent": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-agent-presets": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-api-gateway": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-commands": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-cordis-host-runner": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-credentials": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-file-reference": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-goal": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-host-plugin-inventory": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-message-feedback": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-session-persistence": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-session-reference": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-settings": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-typert-registry": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-app-boot": {
-      "version": "0.1.0-rc.8",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-app-boot/-/dsh-app-boot-0.1.0-rc.8.tgz",
-      "integrity": "sha512-DS63o1PhX2Gvqdgl6Wd8vZnLl0qo8gJ9LpSHXeJBJL9HITpLPhdVYE3X6S0icIYdbGO2plNyhxVJOSN6ibO7VA==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-app-boot/-/dsh-app-boot-0.1.1-rc.1.tgz",
+      "integrity": "sha512-gef6HqCpdf/aLXH8G4TZ+fIxtq+ebiKDrtr2pslFiopWWrxEvqhZdNPgpiC9A8IDfX3waOxcNxhvmlPHpV2moQ==",
       "license": "MIT",
       "dependencies": {
         "js-yaml": "^4.2.0"
@@ -851,10 +851,10 @@
         "@deepseek-ai/cordis-plugin-hmr": "^1.0.16",
         "@deepseek-ai/cordis-plugin-include": "^1.0.6",
         "@deepseek-ai/cordis-plugin-loader": "^1.0.2",
-        "@deepseek-ai/dsh-home-paths": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-launch-environment": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-system-prompt": "^0.1.0-rc.8"
+        "@deepseek-ai/dsh-home-paths": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-launch-environment": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.1-rc.1"
       },
       "peerDependenciesMeta": {
         "@deepseek-ai/cordis-plugin-hmr": {
@@ -863,31 +863,31 @@
       }
     },
     "node_modules/@deepseek-ai/dsh-atomic-write": {
-      "version": "0.1.0-rc.8",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-atomic-write/-/dsh-atomic-write-0.1.0-rc.8.tgz",
-      "integrity": "sha512-SWP+NAat3oteaPi47zLPz4vxeYCHNVmFpN1aeKDuPHpe/ouNTl+WcyIONAJ+1MbZ+8APWhSaJIVu6ORJEUhVGw==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-atomic-write/-/dsh-atomic-write-0.1.1-rc.1.tgz",
+      "integrity": "sha512-8cSMtRK2+5OcyvRhyJRI6lVVuIp+r7MBKGlfESOIdK50OWnVUM35IvaWXuwQrMOI/xJDihyDF+KGF1o0aM1vhg==",
       "license": "MIT",
       "peer": true,
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.8"
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-attachment": {
-      "version": "0.1.0-rc.8",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-attachment/-/dsh-attachment-0.1.0-rc.8.tgz",
-      "integrity": "sha512-cCrg4WWiav7pGtbdU8dJTpAG28cPnkWVB2YPOrlBCgBbhQziGcG9Dv67Ti6L3PI4OQKC55gYBFinQghFO/7FGg==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-attachment/-/dsh-attachment-0.1.1-rc.1.tgz",
+      "integrity": "sha512-R5xKO2z+91Ze25E+ghk3qDJf7ZA4t2sqMF1wusp2/6KrF0UzhCpGt/SWtdjRXSwz6DTjsAfZzpPC5D+2EmuHxA==",
       "license": "MIT",
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-brand": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.8"
+        "@deepseek-ai/dsh-brand": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-attachment-local": {
-      "version": "0.1.0-rc.8",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-attachment-local/-/dsh-attachment-local-0.1.0-rc.8.tgz",
-      "integrity": "sha512-TPsDbDPA8yoE3hw1MtrW61AMh72oMiCY+rkO3bDnvc4MtGwKvXcHWtbNPeVpLgMeznaXsnTU3GUp9Fa6PXdp8A==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-attachment-local/-/dsh-attachment-local-0.1.1-rc.1.tgz",
+      "integrity": "sha512-KGJVu0q3yPlcfoPg+4FGTI1O8sS08B/POQ4jLQvKG7sjx3kXXx/S8xD5BTeFuYijM3mSCCC96AI4lha28v+04Q==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1",
@@ -895,104 +895,117 @@
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-attachment": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-home-paths": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.8"
+        "@deepseek-ai/dsh-attachment": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-home-paths": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-authorization": {
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-authorization/-/dsh-authorization-0.1.1-rc.1.tgz",
+      "integrity": "sha512-cf8LRUJJgpr88UVOPViQviKO+LJ92kdh465c4BvbO1HJDBHXME6fAgkDpDs+IbKdrdt3KWYqI/x2UK7tnFWqXg==",
+      "license": "MIT",
+      "peer": true,
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.1",
+        "@deepseek-ai/dsh-credentials": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-base": {
-      "version": "0.1.0-rc.8",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-base/-/dsh-base-0.1.0-rc.8.tgz",
-      "integrity": "sha512-aMjXT6d5t8SGQg24geOSX6O0ky+hJLijhzZklDcICrBvGSKXvuS8jxLOcL5u4s4pFCODXhuOpvTfFuUhN2RK3Q==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-base/-/dsh-base-0.1.1-rc.1.tgz",
+      "integrity": "sha512-fJ4IlNFjAHj+5PTByTAs6fEj7GFirNmpL0eYA+KTwK5SGEupJ0COVCBOsDeNMUJZspsDKptkZm0szo2u09Q0MQ==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/cordis-plugin-hmr": "^1.0.16",
         "@deepseek-ai/cordis-plugin-timer": "^1.1.3",
-        "@deepseek-ai/dsh-agent": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-agent-default-model": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-agent-instructions": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-agent-loop": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-api-gateway": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-attachment-local": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-bash-sandbox": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-command-compact": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-command-feedback": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-command-goal": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-commands": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-compaction-basic": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-compaction-tool-result-pruner": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-credentials-local": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-fs-local": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-fs-observation-policy": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-fs-sandbox": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-goal": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-goal-round-driver": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-jobs-local": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-llm": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-llm-deepseek": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-llm-pi-ai": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-llm-retry": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-permission-presets": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-plan-mode": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-pwsh-sandbox": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-repeat-tool-reminder": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-sandbox-local": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-sandbox-policy": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-session": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-session-checkpoint-policy": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-session-persistence-jsonl": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-session-projection": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-session-query-sqlite": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-session-telemetry-otel": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-session-title": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-session-title-first-prompt-llm": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-settings-file": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-shell-env": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-skill": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-skill-badge": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-skill-filesystem": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-spill-local": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-spill-policy": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-subagent": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-subagent-fork-in-process": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-subagent-spawn-in-process": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-subprocess-local": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-system-prompt": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-token-meter": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-tool-bash": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-tool-call-timeout-policy": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-tool-fs": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-tool-fs-search": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-tool-goal": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-tool-jobs": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-tool-pwsh": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-tool-ralph": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-tool-skill": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-tool-str-replace-editor": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-tool-subagent": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-tool-subagent-control": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-tool-subagent-report": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-tool-todo": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-tool-web": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-tool-workflow": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-tools": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-typert-loader": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-typert-registry": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-user-approval": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-user-questions": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-web": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-web-search-deepseek": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-workflow-worker-thread": "^0.1.0-rc.8"
+        "@deepseek-ai/dsh-agent": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-agent-default-model": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-agent-instructions": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-agent-loop": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-api-gateway": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-attachment-local": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-bash-sandbox": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-command-compact": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-command-feedback": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-command-goal": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-commands": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-compaction-basic": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-compaction-tool-result-pruner": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-credentials-local": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-fs-local": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-fs-observation-policy": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-fs-sandbox": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-goal": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-goal-round-driver": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-jobs-local": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-llm-deepseek": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-llm-pi-ai": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-llm-retry": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-permission-presets": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-plan-mode": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-pwsh-sandbox": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-repeat-tool-reminder": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-sandbox-local": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-sandbox-policy": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-session-checkpoint-policy": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-session-persistence-jsonl": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-session-projection": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-session-query-sqlite": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-session-telemetry-otel": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-session-title": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-session-title-first-prompt-llm": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-settings-file": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-shell-env": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-skill": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-skill-badge": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-skill-filesystem": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-spill-local": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-spill-policy": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-subagent": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-subagent-fork-in-process": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-subagent-spawn-in-process": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-subprocess-local": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-token-meter": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-tool-bash": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-tool-call-timeout-policy": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-tool-fs": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-tool-fs-search": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-tool-goal": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-tool-jobs": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-tool-pwsh": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-tool-ralph": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-tool-skill": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-tool-str-replace-editor": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-tool-subagent": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-tool-subagent-control": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-tool-subagent-report": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-tool-todo": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-tool-web": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-tool-workflow": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-tools": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-typert-loader": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-typert-registry": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-user-approval": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-user-questions": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-web": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-web-search-deepseek": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-workflow-worker-thread": "^0.1.1-rc.1"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.8"
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-bash-local": {
-      "version": "0.1.0-rc.8",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-bash-local/-/dsh-bash-local-0.1.0-rc.8.tgz",
-      "integrity": "sha512-vMf3dMRrvVvwWCLJxobYONSebPtWqy2ZZKpRZ6o5fBrZbM88irbvL6F/6r/mu4ADTIDigUtpoxlRpOEQKbSuTg==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-bash-local/-/dsh-bash-local-0.1.1-rc.1.tgz",
+      "integrity": "sha512-e0hgZMtQYPGSjB2gCJ6nTMlfKF+NXCE9IN6Z3TrpWMF9CQmqqqbyrUcY3+/JTVsoNoUk1aAMxMbXNFtGcYqEng==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -1000,41 +1013,41 @@
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-settings": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-shell": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-subprocess": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-timeout": "^0.1.0-rc.8"
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-settings": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-shell": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-subprocess": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-timeout": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-bash-sandbox": {
-      "version": "0.1.0-rc.8",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-bash-sandbox/-/dsh-bash-sandbox-0.1.0-rc.8.tgz",
-      "integrity": "sha512-gCFrmFwYyxjXJsSRrzs5RbvCli0I0Tn9JAJEHCWSskE8x9iCVU7ljtmrKvgRYr0J4YeXwzteNSfNhlJqasu/QQ==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-bash-sandbox/-/dsh-bash-sandbox-0.1.1-rc.1.tgz",
+      "integrity": "sha512-kH/rW2aXxlFoKpF+eLJcfO/WYvQxmqJYmmHzEZbJgbzbs6V6t1O2PMHnjIRvZXgzP4jXeb3a4+YwJzjfxVX13Q==",
       "license": "MIT",
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-bash-local": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-sandbox": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-sandbox-policy": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-shell": "^0.1.0-rc.8"
+        "@deepseek-ai/dsh-bash-local": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-sandbox": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-sandbox-policy": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-shell": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-brand": {
-      "version": "0.1.0-rc.8",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-brand/-/dsh-brand-0.1.0-rc.8.tgz",
-      "integrity": "sha512-402aUAfHxIZJrArBV4gDf0I/A/69A/By26FX6HTIOyFmCnB4wUBKh8jnglz1CorKWdZy8AKldAhh8HQhQEbGOQ==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-brand/-/dsh-brand-0.1.1-rc.1.tgz",
+      "integrity": "sha512-u5+q1x5koviWTTaOiOUA0629ZNEKaRl2hu7iiGArzhvj+CUz7abh2b6IF3+xI4AMSHyvn+mOWN9Vwa2WVfwGLg==",
       "license": "MIT",
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.8"
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-client-connection": {
-      "version": "0.1.0-rc.8",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-connection/-/dsh-client-connection-0.1.0-rc.8.tgz",
-      "integrity": "sha512-O1Y1NmkvJjpR/rCYkzulRrKbFwUbpMlINR4G6fbpGXaLy0VzTqN+ptk0b3wJ4RrnKPi4WWLKNNdV647Fg/1sCw==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-connection/-/dsh-client-connection-0.1.1-rc.1.tgz",
+      "integrity": "sha512-43j158P+X9hjJMZ76NsJsQTTDo7ws+aW5XMq3PmdJRVY6h15JsPrfALNosjaeiJjqxUXKSNOfHk7Oq8vJejsyw==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1",
@@ -1042,20 +1055,20 @@
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-attachment": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-commands": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-host-apiproxy": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-host-webserver": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-llm": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-session": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-tools": "^0.1.0-rc.8"
+        "@deepseek-ai/dsh-attachment": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-commands": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-host-apiproxy": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-host-webserver": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-tools": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-client-hmr": {
-      "version": "0.1.0-rc.8",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-hmr/-/dsh-client-hmr-0.1.0-rc.8.tgz",
-      "integrity": "sha512-Olzlpiw+2VIhNOZVEgi22b2U0jSv6HciAQpKj41TggI7oV+jhRDC2GuYFJoRQ8XBs3mcJCLG0DZtAcGrRP8n9Q==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-hmr/-/dsh-client-hmr-0.1.1-rc.1.tgz",
+      "integrity": "sha512-VQVrUtiBLB1FIvjlVBHx3OmK/TpR/nMoDqgxXFV9d0AAs3LdL20r9pSDcngpO0dhDI26LI9dcsgmVIp0MmV5AQ==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1"
@@ -1063,45 +1076,45 @@
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
         "@deepseek-ai/cordis-plugin-loader": "^1.0.2",
-        "@deepseek-ai/dsh-client-modules": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-host-webserver": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.8"
+        "@deepseek-ai/dsh-client-modules": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-host-webserver": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-client-locale": {
-      "version": "0.1.0-rc.8",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-locale/-/dsh-client-locale-0.1.0-rc.8.tgz",
-      "integrity": "sha512-S8ztym/oFU1aWPDtSZLTGWfprUBIuhfOrRNlw/qMAwhavJiQU/Ag0plg19JffGiOMAQuz2BU2n2mW/xhbpA5Vw==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-locale/-/dsh-client-locale-0.1.1-rc.1.tgz",
+      "integrity": "sha512-siclYHjadMhc+Wh0wmV5twiu9oyBE719POQ1F2nM+H0mfScokHLqpBHkml8AJqIl0rkq3dxtkC19kUoBEJvNTQ==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-api-remotes": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-client-connection": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-client-runtime": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-client-ui-settings": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-settings": "^0.1.0-rc.8"
+        "@deepseek-ai/dsh-api-remotes": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-connection": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-runtime": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-ui-settings": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-settings": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-client-modules": {
-      "version": "0.1.0-rc.8",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-modules/-/dsh-client-modules-0.1.0-rc.8.tgz",
-      "integrity": "sha512-K+uDZSmSbpmHFpvrKkdctHHDIjimv1NWDZoc7CYy7QIk0Vuis4jShDau6H5L0B9TScWBDyXAz/R7rXttFlwseA==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-modules/-/dsh-client-modules-0.1.1-rc.1.tgz",
+      "integrity": "sha512-cdBFlFE8sb+vD/w3gYKTu8LH+yH4OyPHXhxJTkzhQJF3bAhdC24k25mogaxkpZXg4rcHS16zWyCriZaOGQRgsQ==",
       "license": "MIT",
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
         "@deepseek-ai/cordis-plugin-loader": "^1.0.2",
-        "@deepseek-ai/dsh-host-webserver": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.8"
+        "@deepseek-ai/dsh-host-webserver": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-client-runtime": {
-      "version": "0.1.0-rc.8",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-runtime/-/dsh-client-runtime-0.1.0-rc.8.tgz",
-      "integrity": "sha512-wW/nktO/GVbGO/k163NlyJab/rK4D6xS5EL0bhYw4ojF1mxmWfrb3RUEYR5LcEUpFx/yXUHsUSgeO1ezmgIrvw==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-runtime/-/dsh-client-runtime-0.1.1-rc.1.tgz",
+      "integrity": "sha512-re0dq+vXlGIGMs5qQHJLMHael8FN+9zKTnGk2M0BQUH4fGr3jTOBUvoKUztbjW/DJP3l3f1k6uoDj2ri3DA0nA==",
       "license": "MIT",
       "dependencies": {
         "immer": "^10.1.1",
@@ -1109,91 +1122,91 @@
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-api-remotes": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-attachment": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-client-connection": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-commands": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-host-apiproxy": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-llm": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-llm-retry": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-session": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-session-projection": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-session-title": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-tools": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-typert-protocol": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-typert-registry": "^0.1.0-rc.8"
+        "@deepseek-ai/dsh-agent": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-api-remotes": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-attachment": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-connection": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-commands": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-host-apiproxy": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-llm-retry": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-session-projection": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-session-title": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-tools": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-typert-protocol": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-typert-registry": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-client-ui-agent-preset": {
-      "version": "0.1.0-rc.8",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-agent-preset/-/dsh-client-ui-agent-preset-0.1.0-rc.8.tgz",
-      "integrity": "sha512-z+okJSOT2/uAA4oomx1WNNl/2k9HsoNDmtewOeQVfSy9C8Ey9YBoVoiSQDsYyDHhesxxlBI8RMLU44Pj/w1uug==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-agent-preset/-/dsh-client-ui-agent-preset-0.1.1-rc.1.tgz",
+      "integrity": "sha512-z7u+1fFUURCQrpBXdqtcolPYpW1w6myFZBGMMgZeDpHP94p1CUsJ1KM/AP1FXJqnG4QmtbXaVQx6jR0LjAYdYA==",
       "license": "MIT",
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-api-remotes": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-client-connection": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-client-locale": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-client-runtime": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-client-ui-conversation": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-client-ui-settings": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.8"
+        "@deepseek-ai/dsh-api-remotes": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-connection": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-locale": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-runtime": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-ui-conversation": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-ui-settings": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-client-ui-attachment": {
-      "version": "0.1.0-rc.8",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-attachment/-/dsh-client-ui-attachment-0.1.0-rc.8.tgz",
-      "integrity": "sha512-TiKZEUGd22AFxkWpgQCLW9VmuSgWQ11RlIQd0941wPAc4RDZxtkjQWDMOlvRS/m8Oqod/5oKr3U6WRCZKS81vA==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-attachment/-/dsh-client-ui-attachment-0.1.1-rc.1.tgz",
+      "integrity": "sha512-mOZQO7jozY/kX7m8jHm6h9VbXYMKPVAyhtJI0wPJXzL/DoqCvyN/SBaQ88Me+OM4bgn/Io3yj54r2wAoxdp7eA==",
       "license": "MIT",
       "dependencies": {
         "clsx": "^2.0.0"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-attachment": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-client-runtime": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-client-ui-conversation": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.8"
+        "@deepseek-ai/dsh-attachment": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-runtime": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-ui-conversation": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-client-ui-brand-official": {
-      "version": "0.1.0-rc.8",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-brand-official/-/dsh-client-ui-brand-official-0.1.0-rc.8.tgz",
-      "integrity": "sha512-eHzJkJGOKlQpap6uYaAZSh62MyJFEoPX8EvIp/kV3YHFDr4bZNc7Yg+ZLMaEXfIjPXKp26FhPiCIia9SP56n8A==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-brand-official/-/dsh-client-ui-brand-official-0.1.1-rc.1.tgz",
+      "integrity": "sha512-CuWaMd44IEpF9878yZdI13Vd/Ky8hlEag4KXWs5G3C01eAQTS2oM0FyIwohtNnIOPqo2LygHWKpSqKYfDYTvIg==",
       "license": "MIT",
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-client-runtime": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-client-ui-conversation": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-client-ui-sidebar": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.8"
+        "@deepseek-ai/dsh-client-runtime": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-ui-conversation": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-ui-sidebar": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-client-ui-commands": {
-      "version": "0.1.0-rc.8",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-commands/-/dsh-client-ui-commands-0.1.0-rc.8.tgz",
-      "integrity": "sha512-nMDF0MbRM03AEmQJzXCbXQWZxSfVPHBO0z+9DqR6LgGXshYLkzVMp1zkfvqLs5QwFAwDSci4vi/GONJOBSL5WA==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-commands/-/dsh-client-ui-commands-0.1.1-rc.1.tgz",
+      "integrity": "sha512-ht3Nd+kczdVK5/w50xp/qpTozwiHTCZW5/R9w7093DapF3mAYQ7Hd0q2NmonNAIchVixj5gbB4zktUbdIaMOHw==",
       "license": "MIT",
       "dependencies": {
         "clsx": "^2.0.0"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-api-remotes": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-client-locale": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-client-runtime": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-client-ui-conversation": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-client-ui-input-trigger": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-commands": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.8"
+        "@deepseek-ai/dsh-api-remotes": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-locale": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-runtime": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-ui-conversation": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-ui-input-trigger": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-commands": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-client-ui-conversation": {
-      "version": "0.1.0-rc.8",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-conversation/-/dsh-client-ui-conversation-0.1.0-rc.8.tgz",
-      "integrity": "sha512-GnQSE47/goSm1UzxQpYQrQnMJLyTmYFH6NENdrOxrVJxQnB55ruactgM1kVwfFnc/WUQVYy0599AK7pxjbxjMg==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-conversation/-/dsh-client-ui-conversation-0.1.1-rc.1.tgz",
+      "integrity": "sha512-xHe2R37UevVNHV0/ieHPdFHuZWTlYIuEYBowLBcQ51Tz2XurWnjcM5CLFr/AChkIuw06dk/Ywm4nwjcCBKgCBQ==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1",
@@ -1201,272 +1214,272 @@
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-api-remotes": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-attachment": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-brand": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-client-connection": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-client-locale": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-client-runtime": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-client-ui-input-trigger": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-client-ui-layout": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-client-ui-settings": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-commands": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-compaction": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-goal": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-llm-retry": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-permission-presets": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-plan-mode": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-session-stats": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-settings": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-token-meter": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-tool-todo": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-tools": "^0.1.0-rc.8"
+        "@deepseek-ai/dsh-agent": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-api-remotes": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-attachment": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-brand": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-connection": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-locale": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-runtime": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-ui-input-trigger": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-ui-layout": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-ui-settings": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-commands": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-compaction": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-goal": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-llm-retry": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-permission-presets": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-plan-mode": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-session-stats": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-settings": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-token-meter": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-tool-todo": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-tools": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-client-ui-cordis": {
-      "version": "0.1.0-rc.8",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-cordis/-/dsh-client-ui-cordis-0.1.0-rc.8.tgz",
-      "integrity": "sha512-NvaSJxqC+HNPLPYPINHzJGRHI427mHSB2aaTGoyc9EFrYVJjvKpNu1QusWwObae5Y/Tx43I2NpFKTAcNVPXkOw==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-cordis/-/dsh-client-ui-cordis-0.1.1-rc.1.tgz",
+      "integrity": "sha512-U1T7BRdH5TaVg1W2YcBUAQleFEw9f47DFSAYEpyrcZRJX21p9/Zh+ZZErQAR9A8BbdiYOP0GdUJ28EPiEQfxtA==",
       "license": "MIT",
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-api-remotes": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-client-connection": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-client-locale": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-client-runtime": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-client-ui-input-trigger": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-client-ui-sidebar": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-client-ui-tool": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-cordis-client-runner": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.8"
+        "@deepseek-ai/dsh-api-remotes": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-connection": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-locale": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-runtime": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-ui-input-trigger": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-ui-sidebar": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-ui-tool": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-cordis-client-runner": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-client-ui-deliverables": {
-      "version": "0.1.0-rc.8",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-deliverables/-/dsh-client-ui-deliverables-0.1.0-rc.8.tgz",
-      "integrity": "sha512-b0XZ/V7FPpTTtmHoKNEVOgl9bJGXGqktzMNNJgifHGl/Us1nNnQVDhM9XDbuUV5iXFPnRrKsR29OTnuTB+txZA==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-deliverables/-/dsh-client-ui-deliverables-0.1.1-rc.1.tgz",
+      "integrity": "sha512-q3b8QGGLvf/zlztdFqmAonphDbt66GbDifOvTXp+U9Stc3cy2wAvImyFUMwxM1RWdI9tdozrJBu3q/u7UVrVsw==",
       "license": "MIT",
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-client-connection": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-client-locale": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-client-runtime": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-client-ui-conversation": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-system-prompt": "^0.1.0-rc.8"
+        "@deepseek-ai/dsh-client-connection": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-locale": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-runtime": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-ui-conversation": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-client-ui-directory-picker-browse": {
-      "version": "0.1.0-rc.8",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-directory-picker-browse/-/dsh-client-ui-directory-picker-browse-0.1.0-rc.8.tgz",
-      "integrity": "sha512-sjQcMuut8CRjqnFZHzX1Zzs1zISDlp/gYQVM9Wkyt9KF+XJfV5pHP0KTHZHwOslAqt2OJMnE38uW2yVncLg3sA==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-directory-picker-browse/-/dsh-client-ui-directory-picker-browse-0.1.1-rc.1.tgz",
+      "integrity": "sha512-g/LzjEqk9Ba+RMBCKYCAlyAadG9/9biEJQepTDmbVUrfjo6rVS9tkpuMYrwpHbV94r3wSCBYQ2BXYM/VubgC/A==",
       "license": "MIT",
       "dependencies": {
         "clsx": "^2.0.0"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-client-locale": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-client-runtime": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-client-ui-workspace": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.8"
+        "@deepseek-ai/dsh-client-locale": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-runtime": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-ui-workspace": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-client-ui-directory-picker-native": {
-      "version": "0.1.0-rc.8",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-directory-picker-native/-/dsh-client-ui-directory-picker-native-0.1.0-rc.8.tgz",
-      "integrity": "sha512-UPR5kSjfMGjLpO41fXXVxcen9Bq9eCzonStnhqMMk/6zC2EQUDkRs+KhYmaInkHI/CMjdTBBqBPRwjFG2iEsYQ==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-directory-picker-native/-/dsh-client-ui-directory-picker-native-0.1.1-rc.1.tgz",
+      "integrity": "sha512-PrudUDCCLHLKt+QGODE3udg7Ce57s5mChZa2F0g6Anp1TYpRmRWbR/ErkyeDMrvAGllg0PqeVFGzaJ5O535gGg==",
       "license": "MIT",
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-client-runtime": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-client-ui-workspace": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.8"
+        "@deepseek-ai/dsh-client-runtime": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-ui-workspace": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-client-ui-goal": {
-      "version": "0.1.0-rc.8",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-goal/-/dsh-client-ui-goal-0.1.0-rc.8.tgz",
-      "integrity": "sha512-kAs6DktlELshs27S3nnjzciK9bGhL2b6RXmZ/mUNYwgiYxeYY4/QYynSNbD0ZQINe0VeGy6yQTv9dbqDBArndA==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-goal/-/dsh-client-ui-goal-0.1.1-rc.1.tgz",
+      "integrity": "sha512-hQZ27T1+nX5B6S1ookTFpnobAQY9XrsFE7V0XXOTzGbDM6JbMhndgA8XnuOoAjVl84c8AkyBTJ6QxInJkF3HJw==",
       "license": "MIT",
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-api-remotes": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-client-locale": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-client-runtime": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-client-ui-conversation": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-commands": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-goal": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-session": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-typert-protocol": "^0.1.0-rc.8"
+        "@deepseek-ai/dsh-api-remotes": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-locale": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-runtime": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-ui-conversation": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-commands": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-goal": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-typert-protocol": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-client-ui-input-trigger": {
-      "version": "0.1.0-rc.8",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-input-trigger/-/dsh-client-ui-input-trigger-0.1.0-rc.8.tgz",
-      "integrity": "sha512-uVJEZ1ftUdMemLvNf17gzB6ThYw0DL4k+0kcQrUPc6LHNQ2ZeuuvOz/931OlqzzUKMtlAGZgy0LvWyJ62LlSog==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-input-trigger/-/dsh-client-ui-input-trigger-0.1.1-rc.1.tgz",
+      "integrity": "sha512-QvseCqtZXE+/5DGHEQFG0FFtXU/kBkCEMODZOwl4bJwRWGjM5xEpHfS4Uqkf8x0VXsIbjE6txCmcByRLknkmuQ==",
       "license": "MIT",
       "dependencies": {
         "clsx": "^2.0.0"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-client-locale": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-client-runtime": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-file-reference": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.8"
+        "@deepseek-ai/dsh-client-locale": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-runtime": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-file-reference": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-client-ui-jobs": {
-      "version": "0.1.0-rc.8",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-jobs/-/dsh-client-ui-jobs-0.1.0-rc.8.tgz",
-      "integrity": "sha512-gCJR9ymswAZa8OiyZQUKa9GpxRT2sP76tfqBGcF5pRN0xOKudlREM6xD3as2knY5EZELW5qQMVKlVVJZ2Uu7fA==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-jobs/-/dsh-client-ui-jobs-0.1.1-rc.1.tgz",
+      "integrity": "sha512-baib2zmrD76/WMyBfbEzLSZMRAxSBYwgjTw1chDCo/2dYywwM7udfyb5WNuzBa4/e66xX0PibqEmsHFAW4mTww==",
       "license": "MIT",
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-client-locale": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-client-runtime": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-client-ui-conversation": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.8"
+        "@deepseek-ai/dsh-client-locale": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-runtime": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-ui-conversation": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-client-ui-layout": {
-      "version": "0.1.0-rc.8",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-layout/-/dsh-client-ui-layout-0.1.0-rc.8.tgz",
-      "integrity": "sha512-tbHawbf8FsJqdwnXrU46V8u13bfAFVQQf0hA0OXH4k0PiLiThdZgQFn/T94+56JMUzD1QLqe7DLmNz29cwmjvQ==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-layout/-/dsh-client-ui-layout-0.1.1-rc.1.tgz",
+      "integrity": "sha512-cqZj1SRW7Z5I6imNt0BjVu+S2SztNi/EQ2vjl+OqyVV6jLxJKYIhYIFOZaZTHuUpMb6NkxIO8qfPDBqFWE9F5Q==",
       "license": "MIT",
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-client-runtime": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-client-ui-theme": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.8"
+        "@deepseek-ai/dsh-client-runtime": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-ui-theme": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-client-ui-message-feedback": {
-      "version": "0.1.0-rc.8",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-message-feedback/-/dsh-client-ui-message-feedback-0.1.0-rc.8.tgz",
-      "integrity": "sha512-tzm/vvhysNa3+1BlTnuj3WJit5+u8U1NDecLqMPTm6U1P2s2bjKtvUpmMNqk+AdeYGYcJjXPadLEuWSNsIWFlQ==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-message-feedback/-/dsh-client-ui-message-feedback-0.1.1-rc.1.tgz",
+      "integrity": "sha512-DcaHmqROaU52mKM1ZuswWMNfzSABl0BrGST464KIKEzqHw/KOshrSKyeWi/j43I0TT8PeaiV5P+5m89QwPsdUg==",
       "license": "MIT",
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-api-remotes": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-client-connection": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-client-locale": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-client-runtime": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-client-ui-conversation": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-message-feedback": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-typert-protocol": "^0.1.0-rc.8"
+        "@deepseek-ai/dsh-api-remotes": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-connection": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-locale": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-runtime": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-ui-conversation": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-message-feedback": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-typert-protocol": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-client-ui-model-selection": {
-      "version": "0.1.0-rc.8",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-model-selection/-/dsh-client-ui-model-selection-0.1.0-rc.8.tgz",
-      "integrity": "sha512-ODRo7IX4VKkgy6C0ibElP5p1Ek6NBm6Qz6S95cZQH2J+PXWTb57/6UvNfxqyst8nFh1wll4oRb1m4fm6MU/fqA==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-model-selection/-/dsh-client-ui-model-selection-0.1.1-rc.1.tgz",
+      "integrity": "sha512-VLn/XtMePhKMs2ozaoIUbgwsoLMQxfVNt96FZJEOCzctnXzlhehf1nVbEDoKR488N6yWWwKEXZSO6ySAuijZgg==",
       "license": "MIT",
       "dependencies": {
         "clsx": "^2.1.1"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-api-remotes": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-client-connection": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-client-locale": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-client-runtime": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-client-ui-commands": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-client-ui-conversation": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-client-ui-input-trigger": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.8"
+        "@deepseek-ai/dsh-api-remotes": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-connection": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-locale": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-runtime": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-ui-commands": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-ui-conversation": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-ui-input-trigger": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-client-ui-permission-presets": {
-      "version": "0.1.0-rc.8",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-permission-presets/-/dsh-client-ui-permission-presets-0.1.0-rc.8.tgz",
-      "integrity": "sha512-mYF/TX4GVJgRxDYPIk/iQKkGXz8qHkfFJE3GqIw5E27g+Msfg8AEGqfWEPp4CZeIK/3zcgpMLzgjMLOliWZ2dA==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-permission-presets/-/dsh-client-ui-permission-presets-0.1.1-rc.1.tgz",
+      "integrity": "sha512-yOiXg2btX/htZJ5Z6R4NffOvJAKFRI8v0HczblqgGaHeSwYjZW0vasZ4dfs3oAWJxzCZOfeLHGNXthZXmHnQMA==",
       "license": "MIT",
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-api-remotes": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-client-connection": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-client-locale": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-client-runtime": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-client-ui-commands": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-client-ui-input-trigger": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-client-ui-settings": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-permission-presets": "^0.1.0-rc.8"
+        "@deepseek-ai/dsh-api-remotes": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-connection": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-locale": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-runtime": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-ui-commands": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-ui-input-trigger": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-ui-settings": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-permission-presets": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-client-ui-plan": {
-      "version": "0.1.0-rc.8",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-plan/-/dsh-client-ui-plan-0.1.0-rc.8.tgz",
-      "integrity": "sha512-OmCuuYCqSlbYqd4s781WipQNKWdHGUn8TPIxrKrcbe94vJacuBtIUIJkDi48dy0IimI+ln/eHxD9WC/9+bJEmA==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-plan/-/dsh-client-ui-plan-0.1.1-rc.1.tgz",
+      "integrity": "sha512-byrSXTZnICVE7mtD0g+l4blWhNAUKFcN2y8akQObhLeOjxWSw7nTLxkpsjEyrHe8M0p+ciX8lLCmUn1N7jNsVQ==",
       "license": "MIT",
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-api-remotes": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-client-locale": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-client-runtime": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-client-ui-conversation": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-plan-mode": "^0.1.0-rc.8"
+        "@deepseek-ai/dsh-api-remotes": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-locale": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-runtime": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-ui-conversation": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-plan-mode": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-client-ui-reference": {
-      "version": "0.1.0-rc.8",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-reference/-/dsh-client-ui-reference-0.1.0-rc.8.tgz",
-      "integrity": "sha512-9qQYmOqG58qlsYNipOMsrL+Ay5Imx8lHJk9GV1rW++LGl6HMb6V1qZBHGIAwO/KOOInnJSEZE65DYB54r+z1Fw==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-reference/-/dsh-client-ui-reference-0.1.1-rc.1.tgz",
+      "integrity": "sha512-hvsaGrNJjMOfnRJ5Uawhh0Ujf8zC69cSWHV4i5F7S7aSNhejrWDZkMIiHLV5hvg9GgRbzbQjdcCij8nJz2KpNA==",
       "license": "MIT",
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-api-remotes": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-client-locale": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-client-runtime": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-client-ui-input-trigger": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-file-reference": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-session-reference": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-typert-protocol": "^0.1.0-rc.8"
+        "@deepseek-ai/dsh-api-remotes": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-locale": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-runtime": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-ui-input-trigger": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-file-reference": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-session-reference": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-typert-protocol": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-client-ui-renderer": {
-      "version": "0.1.0-rc.8",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-renderer/-/dsh-client-ui-renderer-0.1.0-rc.8.tgz",
-      "integrity": "sha512-/MpR9i++feUFNzJgCChLfct1RphTPJ1WKfZrIsczjyOAZNBzAM5LRjpvM0ZO5Vg7rs7id+PLJYuUKy2e2V5aAA==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-renderer/-/dsh-client-ui-renderer-0.1.1-rc.1.tgz",
+      "integrity": "sha512-vF4l1it4InbuppD7Nnm7Nc1nWteqowTYBsooBdiRfwjet1fPL6z/Wmd2eV7tUgPNZZcWpunkQLhIzR+4D+Ho+w==",
       "license": "MIT",
       "dependencies": {
         "use-sync-external-store": "1.2.0"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-client-runtime": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.8"
+        "@deepseek-ai/dsh-client-runtime": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-client-ui-settings": {
-      "version": "0.1.0-rc.8",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-settings/-/dsh-client-ui-settings-0.1.0-rc.8.tgz",
-      "integrity": "sha512-qSOjpmglOPsLzx6Q5yysrU4c4W6QWFOkyVyqePA5lNPOdny2MH19qbuNleQHbiBo4Zadh/dtBn/SuNRfSp+pjw==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-settings/-/dsh-client-ui-settings-0.1.1-rc.1.tgz",
+      "integrity": "sha512-ORGAHRQ6aTWVlUYYTqlAmV5CI6/E1OCoJsE7rbeufA0zGagUx/bAgK1l6I3bzSGOVDxJ6ZRhwOxJWg/3K0ZBig==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-api-remotes": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-client-connection": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-client-runtime": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-settings": "^0.1.0-rc.8"
+        "@deepseek-ai/dsh-api-remotes": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-connection": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-runtime": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-settings": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-client-ui-settings-general": {
-      "version": "0.1.0-rc.8",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-settings-general/-/dsh-client-ui-settings-general-0.1.0-rc.8.tgz",
-      "integrity": "sha512-lGGLCV17yUhKTHFAL+LWNY6LICLHmL614TbgaTFC80HWqeduURKzHU7a2PoySyMC2AOvYGpKjIRNUfifhv3aZw==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-settings-general/-/dsh-client-ui-settings-general-0.1.1-rc.1.tgz",
+      "integrity": "sha512-xFRY1mS71lRJtQiBtI/EFE6R6JymgjO26Co3h6zPwlhMbiLvWlq0hL919j8YQsiHOUEHdlLxk2FnjJc2eyYBTg==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1",
@@ -1474,115 +1487,115 @@
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-api-remotes": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-client-connection": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-client-locale": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-client-runtime": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-client-ui-settings": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-client-ui-sidebar": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-settings": "^0.1.0-rc.8"
+        "@deepseek-ai/dsh-api-remotes": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-connection": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-locale": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-runtime": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-ui-settings": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-ui-sidebar": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-settings": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-client-ui-settings-models": {
-      "version": "0.1.0-rc.8",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-settings-models/-/dsh-client-ui-settings-models-0.1.0-rc.8.tgz",
-      "integrity": "sha512-6iTLiQ4+4ErqV2e0Lxeunr1Q0JLFJ3EcJ1KcxvT0mEy5xzZuilX7KJxsBWq11q3Wy/I0MYhbHZzZC+d42mFM4g==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-settings-models/-/dsh-client-ui-settings-models-0.1.1-rc.1.tgz",
+      "integrity": "sha512-E9CXWfP9lrdaeYlZNhCSYcl+nIirG/cO+r5je6rOPmfdvupyvkdrR5w+Co0yDKjMjz9NsZ1qyxNa7MFxC3GJwg==",
       "license": "MIT",
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-api-remotes": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-client-connection": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-client-locale": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-client-runtime": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-client-ui-settings": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.8"
+        "@deepseek-ai/dsh-api-remotes": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-connection": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-locale": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-runtime": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-ui-settings": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-client-ui-settings-plugin-inventory": {
-      "version": "0.1.0-rc.8",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-settings-plugin-inventory/-/dsh-client-ui-settings-plugin-inventory-0.1.0-rc.8.tgz",
-      "integrity": "sha512-IiixKrJbNqn4D8kvpSIRbxsfetEEbYN5Z3Uz209UWLOiY8Ja9VdQaVbh6BZlecO9BXX1Lgo8l8q+tXlC0IpifA==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-settings-plugin-inventory/-/dsh-client-ui-settings-plugin-inventory-0.1.1-rc.1.tgz",
+      "integrity": "sha512-ycCL9EBBOCEZVJQfG9DsK3CAZ84s0/9tByY3csQXsALwDImBY1mPPmI5xp3ITJF28HYu6GC9CjlsZ0Q4CM/dXg==",
       "license": "MIT",
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-api-remotes": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-client-locale": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-client-runtime": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-client-ui-settings": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.8"
+        "@deepseek-ai/dsh-api-remotes": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-locale": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-runtime": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-ui-settings": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-client-ui-settings-plugins": {
-      "version": "0.1.0-rc.8",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-settings-plugins/-/dsh-client-ui-settings-plugins-0.1.0-rc.8.tgz",
-      "integrity": "sha512-BLLFFxBz4TmnXXsR5bnQaLMboXBOvCfhoqSbdPFqkqrmJSD+3KGbg4SQJZPcfLL19Kq7qeDraPCXwxo3wpIULg==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-settings-plugins/-/dsh-client-ui-settings-plugins-0.1.1-rc.1.tgz",
+      "integrity": "sha512-0Ato2FscNSwpO7MaZ8mI5QtHoUvrgavuhcnETVfOlSBbjuqACZyGxLjWBaJ3jc+6RvsZTidg4uYZaAhRG7N2ZA==",
       "license": "MIT",
       "dependencies": {
         "clsx": "^2.0.0"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-api-remotes": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-client-connection": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-client-locale": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-client-runtime": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-client-ui-settings": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.8"
+        "@deepseek-ai/dsh-api-remotes": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-connection": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-locale": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-runtime": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-ui-settings": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-client-ui-sidebar": {
-      "version": "0.1.0-rc.8",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-sidebar/-/dsh-client-ui-sidebar-0.1.0-rc.8.tgz",
-      "integrity": "sha512-7wcBnS27j8iIVDuai8BVifxcDZd5DIjlHgNHQKx8xQM+x92VKhiFOoMccjhXNaE6sExCUsER1OWRVp65MJvjqg==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-sidebar/-/dsh-client-ui-sidebar-0.1.1-rc.1.tgz",
+      "integrity": "sha512-5Osuq606H4ii76cBhlhZHk41uEhwGjtptg05GZcFGIfPAbS+8KeDp58kwFzgKUyGKRtiYb2ssG7YQagaeqO2Fg==",
       "license": "MIT",
       "dependencies": {
         "clsx": "^2.0.0"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-client-locale": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-client-runtime": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-client-ui-layout": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.8"
+        "@deepseek-ai/dsh-client-locale": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-runtime": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-ui-layout": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-client-ui-skill": {
-      "version": "0.1.0-rc.8",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-skill/-/dsh-client-ui-skill-0.1.0-rc.8.tgz",
-      "integrity": "sha512-s9tW3tDQ/82TzZcUHC/dZy5zmPppFKbSXnBotQDvjAU+rkS3/4k4Y6u9LffyZ813OjCoCfs7GOfWHAyZ0VmBag==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-skill/-/dsh-client-ui-skill-0.1.1-rc.1.tgz",
+      "integrity": "sha512-UXkfLRMLHvU29l/A39vdU628vCiRKce9Wa1R6fQK6PbryF1fHA4u2btxTQyX656YadkGfpoRNbKTrwuHwTT8jg==",
       "license": "MIT",
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-api-remotes": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-client-connection": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-client-locale": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-client-runtime": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-client-ui-input-trigger": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-client-ui-tool": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.8"
+        "@deepseek-ai/dsh-api-remotes": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-connection": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-locale": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-runtime": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-ui-input-trigger": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-ui-tool": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-client-ui-subagent": {
-      "version": "0.1.0-rc.8",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-subagent/-/dsh-client-ui-subagent-0.1.0-rc.8.tgz",
-      "integrity": "sha512-uK23jWwzFXbAELsnqS+7A4jL3Q/Ft8AI1hPrJE1ssldq535znexgdGAguZFC17fG+L0OWUtqwAKdXHmjyzqLiQ==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-subagent/-/dsh-client-ui-subagent-0.1.1-rc.1.tgz",
+      "integrity": "sha512-jtqR76/WVoFeuNFfHEEU/0lmw6ywECVRdNjNbr8xF4AFW7LNDGfIBjOW+r+c3VYs20uXe+KieKCE+hTtUcqYtA==",
       "license": "MIT",
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-client-locale": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-client-runtime": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-client-ui-conversation": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-client-ui-input-trigger": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-subagent": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-token-meter": "^0.1.0-rc.8"
+        "@deepseek-ai/dsh-client-locale": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-runtime": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-ui-conversation": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-ui-input-trigger": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-subagent": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-token-meter": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-client-ui-theme": {
-      "version": "0.1.0-rc.8",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-theme/-/dsh-client-ui-theme-0.1.0-rc.8.tgz",
-      "integrity": "sha512-orLl5eoWOnvjj76lI6xucE+lT+o+ouniRMSFsuYwF1DNH2pbyfVPQYJWL3iM55gE28yyZJGgmtmABnQBiEF5iA==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-theme/-/dsh-client-ui-theme-0.1.1-rc.1.tgz",
+      "integrity": "sha512-wjIkWDEzv3vvUnGtQi+bqQOrnDcuYszt/5S4e1hycctOYP2LloGTW8I7ehP8arnfPb2Du2eiPGXBy3dVGPa44w==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1",
@@ -1590,38 +1603,38 @@
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-api-remotes": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-client-connection": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-client-locale": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-client-runtime": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-client-ui-settings": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-host-webserver": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-settings": "^0.1.0-rc.8"
+        "@deepseek-ai/dsh-api-remotes": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-connection": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-locale": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-runtime": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-ui-settings": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-host-webserver": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-settings": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-client-ui-tool": {
-      "version": "0.1.0-rc.8",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-tool/-/dsh-client-ui-tool-0.1.0-rc.8.tgz",
-      "integrity": "sha512-+Mtgx56PptrtoN4Q36yISe3u0lnVazdqV9s+1cLU2C2sAw7bB7o2Y/J9PBPiuBSsK8rmCLbUPYK6QefenwFE7Q==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-tool/-/dsh-client-ui-tool-0.1.1-rc.1.tgz",
+      "integrity": "sha512-3s0w6rdRzaSfTEC3wJXhsSzT8GdIAkTeuwWLxPDGF5xQLVAvx8gAPNgnQ75PSJWF2H/jeZ8rfTNGHYF/AZ5p1Q==",
       "license": "MIT",
       "dependencies": {
         "clsx": "^2.0.0"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-api-remotes": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-client-connection": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-client-locale": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-client-runtime": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-client-ui-conversation": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.8"
+        "@deepseek-ai/dsh-api-remotes": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-connection": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-locale": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-runtime": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-ui-conversation": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-client-ui-trajectory": {
-      "version": "0.1.0-rc.8",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-trajectory/-/dsh-client-ui-trajectory-0.1.0-rc.8.tgz",
-      "integrity": "sha512-nEKtvkbNhk1Qau8jpyvGfcGLCL2Tfmw6Oi72i2oiZ/DHIcsBaeD0JVWOraEmQp3jYVjuuLSdjdCiPkuNU9nwgw==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-trajectory/-/dsh-client-ui-trajectory-0.1.1-rc.1.tgz",
+      "integrity": "sha512-fluiMLoPFtGnt8MBMoPFzEgjzGQJpUJkLbEC9OQSvBi6MXiZk5oOas8fwH4ZwuDgw0Ef6TIBFxOsbnhfLX6A+Q==",
       "license": "MIT",
       "dependencies": {
         "@tanstack/react-virtual": "^3.14.9",
@@ -1629,13 +1642,13 @@
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-client-locale": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-client-runtime": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-client-ui-conversation": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-compaction": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-tools": "^0.1.0-rc.8"
+        "@deepseek-ai/dsh-agent": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-locale": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-runtime": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-ui-conversation": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-compaction": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-tools": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-client-ui-trajectory/node_modules/@tanstack/react-virtual": {
@@ -1679,186 +1692,186 @@
       }
     },
     "node_modules/@deepseek-ai/dsh-client-ui-user-questions": {
-      "version": "0.1.0-rc.8",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-user-questions/-/dsh-client-ui-user-questions-0.1.0-rc.8.tgz",
-      "integrity": "sha512-zv2U7Ur1ovGSU7j5mwsiCHUK/L20IXRcSFBis3kDZ9nMMl9m0N+56bXrZtJD1U9kTU7gtJ4Xat+rDpr3uTn0JA==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-user-questions/-/dsh-client-ui-user-questions-0.1.1-rc.1.tgz",
+      "integrity": "sha512-dsWyiL5shUua/VdQ07p1m6pCNlMkC9Rqr40bjgvFYYqHHvBchqUV1uKWBKSuS6QYSw/yRdk8hJOPtGnXtVU33g==",
       "license": "MIT",
       "dependencies": {
         "clsx": "^2.0.0"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-api-remotes": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-client-locale": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-client-runtime": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-client-ui-conversation": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.8"
+        "@deepseek-ai/dsh-api-remotes": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-locale": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-runtime": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-ui-conversation": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-client-ui-workflow-run": {
-      "version": "0.1.0-rc.8",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-workflow-run/-/dsh-client-ui-workflow-run-0.1.0-rc.8.tgz",
-      "integrity": "sha512-lVvzaR66JwR2lgdURooLEyinUFu5cSaJLWBgdLetw0Z1B6N4RzBNwiIZxmIEZKwaVS7vhO9w6mphGV+4ujiypA==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-workflow-run/-/dsh-client-ui-workflow-run-0.1.1-rc.1.tgz",
+      "integrity": "sha512-fX1uEFVgArjfkmsBzYWbmg9bKYYlmF8UVH2QDp7AgyXc19TJF0I4kFMD1IH9it5hwUuZvPOIQynfnZnwT0YenQ==",
       "license": "MIT",
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-client-locale": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-client-runtime": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-client-ui-conversation": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-session": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-tool-workflow": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-workflow": "^0.1.0-rc.8"
+        "@deepseek-ai/dsh-client-locale": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-runtime": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-ui-conversation": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-tool-workflow": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-workflow": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-client-ui-workspace": {
-      "version": "0.1.0-rc.8",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-workspace/-/dsh-client-ui-workspace-0.1.0-rc.8.tgz",
-      "integrity": "sha512-Il4hRRV9cDXyZptVC/OKHHOPNd84SwtflHCJ6RP97+OYxnENftdKgHENX7Kqf1RsSXF8RwmOtEvZoHljvYD79A==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-workspace/-/dsh-client-ui-workspace-0.1.1-rc.1.tgz",
+      "integrity": "sha512-NHbAXB4JfQb3AWfzF/bcRp5aq2ETDx33oWALkW4mGWZi/amHap4WWibmkhXENc0oibJ8ji9AFj1k87CVgHsCVw==",
       "license": "MIT",
       "dependencies": {
         "clsx": "^2.0.0"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-client-connection": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-client-locale": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-client-runtime": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-client-ui-conversation": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-client-ui-sidebar": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.8"
+        "@deepseek-ai/dsh-client-connection": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-locale": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-runtime": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-ui-conversation": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-ui-sidebar": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-cmdline": {
-      "version": "0.1.0-rc.8",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-cmdline/-/dsh-cmdline-0.1.0-rc.8.tgz",
-      "integrity": "sha512-xsnNFm2XpMD9wpBBLq80x8yXTi664DHywkLwxgAhDsWyp9tB2aSWaWVKxugPWSWwrB3F4nfloWqaeUfgXRFtBQ==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-cmdline/-/dsh-cmdline-0.1.1-rc.1.tgz",
+      "integrity": "sha512-w/z8Ng+RRzRrrTodOU6/LjuOwaN7KYOiooxlfCfKqf3S3PsGWzUrvLTsenT9/SCa6W4K3OI74y/m1J2o4xAgWg==",
       "license": "MIT",
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
         "@deepseek-ai/cordis-plugin-loader": "^1.0.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.8"
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-code-runtime": {
-      "version": "0.1.0-rc.8",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-code-runtime/-/dsh-code-runtime-0.1.0-rc.8.tgz",
-      "integrity": "sha512-6ZKyEE7dHH1UkKe5b0lg18Byww/7ocZyrNMVjAoUWEWp5i96Brf9Eavu9q3zepBMDMZJErCfV0pyt7KDhBJSig==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-code-runtime/-/dsh-code-runtime-0.1.1-rc.1.tgz",
+      "integrity": "sha512-uha3FJobyShXIMfSuyGCHatbcfY3PA4mATS+hu3JoJy/+9w2Hbish89+eTZBysA4XEG+FRzVVdz9TbAHP3UR9Q==",
       "license": "MIT",
       "peer": true,
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.8"
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-code-runtime-worker-thread": {
-      "version": "0.1.0-rc.8",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-code-runtime-worker-thread/-/dsh-code-runtime-worker-thread-0.1.0-rc.8.tgz",
-      "integrity": "sha512-l9fsKYZN2qthnR8fbH8LrTbhWman8rjFCumIttahOKvQEjFMWImY1p8ypM3QtreAtUF8jyHdDnlV8xWQLfanmA==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-code-runtime-worker-thread/-/dsh-code-runtime-worker-thread-0.1.1-rc.1.tgz",
+      "integrity": "sha512-jVYt42fXeAgujQ64BznB8FUveil4D9u5cfYXCnTz/cMMpTLNlDIeF8Puj5b30w9Cn1B1AlL088DFxlE+Hk0F+Q==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-code-runtime": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-session": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-timeout": "^0.1.0-rc.8"
+        "@deepseek-ai/dsh-code-runtime": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-timeout": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-command-compact": {
-      "version": "0.1.0-rc.8",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-command-compact/-/dsh-command-compact-0.1.0-rc.8.tgz",
-      "integrity": "sha512-3Zlgw9ghDvj2/22/O7V4kvkxKRfknQw4t9ks5GtBEEVRuU9ullpFElAwq/EZ049zeCnmHnyskyJmwYZRIGaiRA==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-command-compact/-/dsh-command-compact-0.1.1-rc.1.tgz",
+      "integrity": "sha512-XETnZp1RAgLMM4oRJxFmIngQMJDT0Sm521GaUfdVLAXhu+BKJxXVcrf4WkhhR1zMZdKYl7aT6TU1IvTNH1H5uA==",
       "license": "MIT",
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-commands": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-compaction": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.8"
+        "@deepseek-ai/dsh-commands": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-compaction": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-command-feedback": {
-      "version": "0.1.0-rc.8",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-command-feedback/-/dsh-command-feedback-0.1.0-rc.8.tgz",
-      "integrity": "sha512-RqEcutd+nHVGND/JobUybb8HsgRigr5iEowDk0D7aZeXFJ3tN/0pW67w7DOxdhAVnODIpWg5tSnFpCT8fS78kQ==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-command-feedback/-/dsh-command-feedback-0.1.1-rc.1.tgz",
+      "integrity": "sha512-bSSh+Ac+z9JbIoK+guAvX+XUR5avWZrGA4/bTMv3zB1C63+CnAaeU1UgYEV4vDR+sPVZRexPXXx45uOIicQAwQ==",
       "license": "MIT",
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-anonymous-user-id": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-commands": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-session": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-session-telemetry": "^0.1.0-rc.8"
+        "@deepseek-ai/dsh-anonymous-user-id": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-commands": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-session-telemetry": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-command-goal": {
-      "version": "0.1.0-rc.8",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-command-goal/-/dsh-command-goal-0.1.0-rc.8.tgz",
-      "integrity": "sha512-kMjRuGJA79czVNzx//JEMrjAqDvYpiaOSH95NUu+Mome76S34jmnhCnIyzcg02GcXelDbk9epELAz5HR1Yti/Q==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-command-goal/-/dsh-command-goal-0.1.1-rc.1.tgz",
+      "integrity": "sha512-0L0vLmCnz17t+eQGMzq+SrYqBm8OWlnt2xOQKNKR4oe0w5HYaqqNuxEzz8bjVvrazjr+hv3PPQj26uCPctsaSA==",
       "license": "MIT",
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-commands": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-goal": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-llm": "^0.1.0-rc.8"
+        "@deepseek-ai/dsh-commands": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-goal": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-commands": {
-      "version": "0.1.0-rc.8",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-commands/-/dsh-commands-0.1.0-rc.8.tgz",
-      "integrity": "sha512-/i99EDLrUyd4bUVn4d7XS46vg09ZE0ervbE/aQaVUWLjDYKrarb7hPx9slADAg5/cUlJsN6L6CP544h9qlUo4g==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-commands/-/dsh-commands-0.1.1-rc.1.tgz",
+      "integrity": "sha512-jOtQNe5RBfyCQxUqCAhqJbrfM3iUZZp1H197SrhFDuZT8v4CbbnyjBWQTAeuztf66pM8VoCxnBik79kY6tN/KA==",
       "license": "MIT",
       "dependencies": {
         "zod": "^4.4.3"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-attachment": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-brand": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-llm": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-scope": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-session": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-typert-protocol": "^0.1.0-rc.8"
+        "@deepseek-ai/dsh-agent": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-attachment": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-brand": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-scope": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-typert-protocol": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-compaction": {
-      "version": "0.1.0-rc.8",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-compaction/-/dsh-compaction-0.1.0-rc.8.tgz",
-      "integrity": "sha512-sWNqZqejzpKsnEMPsNVA/WYK4S59XlYJtnWw8wCPushzQdUt5zhf+g7LVx0cStSozEfwurxRvaZdOmNaa4WhNQ==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-compaction/-/dsh-compaction-0.1.1-rc.1.tgz",
+      "integrity": "sha512-0aDCK6TDF2RXJTrgkmuh6KAGLA8jthR3JKNp0be5RS1U2IIEXwjOLwr5ol4gvSaNLerMlcyLyslkATrHj8hQVw==",
       "license": "MIT",
       "peer": true,
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-brand": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-commands": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-llm": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-session": "^0.1.0-rc.8"
+        "@deepseek-ai/dsh-brand": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-commands": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-compaction-basic": {
-      "version": "0.1.0-rc.8",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-compaction-basic/-/dsh-compaction-basic-0.1.0-rc.8.tgz",
-      "integrity": "sha512-UWAUbJbxFQTI3m4LnwZDlcYOfzWNFN1WLjy0qNONNcz3BBa5Nu9kcz4C9jioSp6pg3KMfUNUOtbBRySigTIt7g==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-compaction-basic/-/dsh-compaction-basic-0.1.1-rc.1.tgz",
+      "integrity": "sha512-dNi5IZg0nOUPckhOSgEltHpF8On+wEkMR4gMVF0YItYJifReqcj1qHDZ+8jjmDNFTT5lnOUXylMXyY08IM1a/Q==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-commands": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-compaction": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-compaction-tool-result-pruner": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-llm": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-session": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-token-meter": "^0.1.0-rc.8"
+        "@deepseek-ai/dsh-agent": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-commands": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-compaction": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-compaction-tool-result-pruner": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-token-meter": "^0.1.1-rc.1"
       },
       "peerDependenciesMeta": {
         "@deepseek-ai/dsh-compaction-tool-result-pruner": {
@@ -1867,42 +1880,42 @@
       }
     },
     "node_modules/@deepseek-ai/dsh-compaction-tool-result-pruner": {
-      "version": "0.1.0-rc.8",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-compaction-tool-result-pruner/-/dsh-compaction-tool-result-pruner-0.1.0-rc.8.tgz",
-      "integrity": "sha512-Mk1QE57HxCMScgQ9ury0o7AM14h6g41cDg1G2kiNqD4Z2LBwFTlZJJAgipyhts4mcr1hz2WZTc8Xgbl9067ONA==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-compaction-tool-result-pruner/-/dsh-compaction-tool-result-pruner-0.1.1-rc.1.tgz",
+      "integrity": "sha512-pRFLE04eJRkH46NMH4F6HvCz7lQMxdua2MifcyAdfuHLRCfGtmzJtlkNJkHd7936rJqHaRmVUz3+UMt86MbyBQ==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-compaction": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-llm": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-session": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-token-meter": "^0.1.0-rc.8"
+        "@deepseek-ai/dsh-compaction": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-token-meter": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-cordis-client-runner": {
-      "version": "0.1.0-rc.8",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-cordis-client-runner/-/dsh-cordis-client-runner-0.1.0-rc.8.tgz",
-      "integrity": "sha512-UbV2zFdOCubLAjQkmYi+6aPxxDfFTSshiyL4EHRbZyqQTdhrnDMfkY48SiVz8s026+E8xxGRPU4kNf3lg5DGeA==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-cordis-client-runner/-/dsh-cordis-client-runner-0.1.1-rc.1.tgz",
+      "integrity": "sha512-XunBtjdTo5chATPwwUDNLfz7lIkdGxn4OIEHZ6WQnXl6sCgd+xy2pCjBH0j6wdvWO/xo7m99FPnlOCW6cyiing==",
       "license": "MIT",
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
         "@deepseek-ai/cordis-plugin-loader": "^1.0.2",
-        "@deepseek-ai/dsh-api-remotes": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-client-connection": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-client-modules": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-client-runtime": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-client-ui-theme": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.8"
+        "@deepseek-ai/dsh-api-remotes": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-connection": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-modules": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-runtime": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-ui-theme": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-cordis-host-runner": {
-      "version": "0.1.0-rc.8",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-cordis-host-runner/-/dsh-cordis-host-runner-0.1.0-rc.8.tgz",
-      "integrity": "sha512-DCJr6INHCI0Dypr1JAJj/BnvN31tpIt3Y8+KQ3GDfHW6pUBsc9GnXHpKsuQ4sK/fTj80GjaDYPGdWeB/uKMMdw==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-cordis-host-runner/-/dsh-cordis-host-runner-0.1.1-rc.1.tgz",
+      "integrity": "sha512-PUyFU5PFleIvjxTZpA9v9Tq9wCsESzQnqwhMU/Ir+CKtSM5EcMsQPCRD4HHnFqrVCIsQYyDffBbWr1K4LziIEg==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1",
@@ -1910,31 +1923,31 @@
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-brand": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-llm": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-scope": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-session": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-tools": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-typert-protocol": "^0.1.0-rc.8"
+        "@deepseek-ai/dsh-agent": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-brand": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-scope": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-tools": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-typert-protocol": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-credentials": {
-      "version": "0.1.0-rc.8",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-credentials/-/dsh-credentials-0.1.0-rc.8.tgz",
-      "integrity": "sha512-VopOhtUEa/fSmJr3fyKbsEG043kX1oGuBrmELAbkhmuDigl1cN88g0VPb9rMG2/dJ1h08wg+h0RJP+Ex4LjRWw==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-credentials/-/dsh-credentials-0.1.1-rc.1.tgz",
+      "integrity": "sha512-oZPts8lYYstp9XE0N8jYziEQQcv1+8B/BkKfT2pr12/7SeQjAyduyIRlSOmc/UFWEz254BLDWI4vtnWXkJVazQ==",
       "license": "MIT",
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-brand": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.8"
+        "@deepseek-ai/dsh-brand": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-credentials-local": {
-      "version": "0.1.0-rc.8",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-credentials-local/-/dsh-credentials-local-0.1.0-rc.8.tgz",
-      "integrity": "sha512-Msbz/+xNIHFXLjcDy2hZFpfV1qduuyjLl35BJOUqNz9eCEYv8b0lfKDI7nirv5E/TdxzLkO75WQ4f+8nifeUpQ==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-credentials-local/-/dsh-credentials-local-0.1.1-rc.1.tgz",
+      "integrity": "sha512-q59hxIpWTHHrFmYS1k2h/d9aNEKrq0SA8At4sxM0Hpx6/JRBqvb2AwR+m61eOvwBu2HApSY/oHjrgrG9JukQSA==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1",
@@ -1943,63 +1956,63 @@
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-atomic-write": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-credentials": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-home-paths": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-launch-environment": "^0.1.0-rc.8"
+        "@deepseek-ai/dsh-atomic-write": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-credentials": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-home-paths": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-launch-environment": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-file-reference": {
-      "version": "0.1.0-rc.8",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-file-reference/-/dsh-file-reference-0.1.0-rc.8.tgz",
-      "integrity": "sha512-SoU4Zm7L8E9ud5nTs1tVAINFrgKvIKypCdOOMLBjJkjLUvXMYmKFxfCM7xaJjOmK/C5suEVUtpukZhZZvZALNA==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-file-reference/-/dsh-file-reference-0.1.1-rc.1.tgz",
+      "integrity": "sha512-TitE4FzwV4JPWmXpI6Rinn+oVt+0c6DtjJCXdapafNHaYKUnYqFE4Bydvn2hDzLKnkwEgEKEugSZLRno6P91bg==",
       "license": "MIT",
       "dependencies": {
         "zod": "^4.4.3"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-typert-protocol": "^0.1.0-rc.8"
+        "@deepseek-ai/dsh-agent": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-typert-protocol": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-file-reference-local": {
-      "version": "0.1.0-rc.8",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-file-reference-local/-/dsh-file-reference-local-0.1.0-rc.8.tgz",
-      "integrity": "sha512-dw3p1NmuDgJkse1J2RuLwgfiySEFiyRL40o3mo1ireGxXt85JfLns1FR2mdN6v7z6pBpIogGPKV//0U31BWTfg==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-file-reference-local/-/dsh-file-reference-local-0.1.1-rc.1.tgz",
+      "integrity": "sha512-+aLtZet2Al71eRKeFIhYXHyogYLvN2jIRcyxPF2BirhwIms5wIkRQsvXdJJPKr1/p/7wi4pS5FmQifDR1Tq6Lg==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-file-reference": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-system-prompt": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-tools": "^0.1.0-rc.8"
+        "@deepseek-ai/dsh-agent": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-file-reference": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-tools": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-fs": {
-      "version": "0.1.0-rc.8",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-fs/-/dsh-fs-0.1.0-rc.8.tgz",
-      "integrity": "sha512-ge5GW56+z20vYACQ2jqtevusdgMXa64laeU/Chql+VIA3+6xyJ8gLX+oj/1O5TlzhvmZ7ZPfZGBFBEVsEZzTQw==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-fs/-/dsh-fs-0.1.1-rc.1.tgz",
+      "integrity": "sha512-cf+F+spDreyKTFYPYZ5DshRJuq5+H1Wu5xD8078zjy5PO86ROZRIvQl1zc1D8EnWhGSL/8rw4uCuYkhIZNcicQ==",
       "license": "MIT",
       "peer": true,
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-brand": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-llm": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-sandbox": "^0.1.0-rc.8"
+        "@deepseek-ai/dsh-brand": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-sandbox": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-fs-local": {
-      "version": "0.1.0-rc.8",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-fs-local/-/dsh-fs-local-0.1.0-rc.8.tgz",
-      "integrity": "sha512-yWk6WrAHs8b6395XnZZOCf3wY90xYKjh/tyU3/rwFy4oU8zq9gzn/x8rdaZD0zUp+wE0XqfBf2AS4Jo03SKHyQ==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-fs-local/-/dsh-fs-local-0.1.1-rc.1.tgz",
+      "integrity": "sha512-1vKUUxl9gZ0xh/wniBs0e4/h8+BEBHuBrIhpgf4Jr1IuPJIQbzTDgJVvFM9657zWxdNzcmb+5QV3N25GWcayvQ==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1",
@@ -2007,39 +2020,39 @@
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-fs": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.8"
+        "@deepseek-ai/dsh-fs": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-fs-observation-policy": {
-      "version": "0.1.0-rc.8",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-fs-observation-policy/-/dsh-fs-observation-policy-0.1.0-rc.8.tgz",
-      "integrity": "sha512-iarNlz2QoEROJUOHPjy7OKOwXuGeEhzk6nWj95F+UHNvKKaquagBE8YE1gzFqbg2U1wFVmPGoHBYl8q7hb5Z8Q==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-fs-observation-policy/-/dsh-fs-observation-policy-0.1.1-rc.1.tgz",
+      "integrity": "sha512-CsECIJkcYcwfXpQa/8stxEdGifxa/2d2AJcUD/ILR9NcHTr1rR0UjyJ6dZREtEhclLz5HrMois6qdf0r+TCo7Q==",
       "license": "MIT",
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-fs": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.8"
+        "@deepseek-ai/dsh-fs": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-fs-sandbox": {
-      "version": "0.1.0-rc.8",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-fs-sandbox/-/dsh-fs-sandbox-0.1.0-rc.8.tgz",
-      "integrity": "sha512-JfNgZHFyUyqO5XV/KQ2msO9OQ+98WrGCyfQp34yqCbIXSGS2r471C35Sub+OyTlpCkavGFUjsxo3iT7PLGyVVw==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-fs-sandbox/-/dsh-fs-sandbox-0.1.1-rc.1.tgz",
+      "integrity": "sha512-tfWU1aVZRxW5j/A9zEaPQUcs//jf5XhnR4QAmAOXtY3EvgHXEXjaJnd9mfKquMZtvZEr+4JWVJo/aj6BERch7Q==",
       "license": "MIT",
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-fs": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-fs-local": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-sandbox": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-sandbox-policy": "^0.1.0-rc.8"
+        "@deepseek-ai/dsh-fs": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-fs-local": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-sandbox": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-sandbox-policy": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-goal": {
-      "version": "0.1.0-rc.8",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-goal/-/dsh-goal-0.1.0-rc.8.tgz",
-      "integrity": "sha512-PR/9JjRn2H/33eyAVbtYBxzRWQhFO5N0S/188eAV9gjUTtHe5oSOnPxYy8iNkkMXxr+VE8Nno25Sun8WYmS8lQ==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-goal/-/dsh-goal-0.1.1-rc.1.tgz",
+      "integrity": "sha512-kvrZVsyOe1ZDgYyFMKpdhOqn47lMMP88wac66suQrMPLI/zQeHPv7sTnQoV5BceQsWln/N2Txe2iBXnmDxgsQQ==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1",
@@ -2047,176 +2060,177 @@
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-brand": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-llm": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-scope": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-session": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-session-projection": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-typert-protocol": "^0.1.0-rc.8"
+        "@deepseek-ai/dsh-agent": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-brand": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-scope": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-session-projection": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-typert-protocol": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-goal-round-driver": {
-      "version": "0.1.0-rc.8",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-goal-round-driver/-/dsh-goal-round-driver-0.1.0-rc.8.tgz",
-      "integrity": "sha512-hCOOofSuqYxWo+Zc/vcF1C+qk38JEgzJ2ya4bBisWYiRwVFygHODquQllK5ffDjFM+SnX+CdmA+l2piiwCkzcA==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-goal-round-driver/-/dsh-goal-round-driver-0.1.1-rc.1.tgz",
+      "integrity": "sha512-BscFM96Ud1/txqIJD2t/atqTrUmlDLd29K5fGhGmm83pOB0lHqCJ6T1mfoLrT96KIU8+x04ubkfz/63xXjGllg==",
       "license": "MIT",
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-goal": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-llm": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-session": "^0.1.0-rc.8"
+        "@deepseek-ai/dsh-agent": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-goal": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-headless": {
-      "version": "0.1.0-rc.8",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-headless/-/dsh-headless-0.1.0-rc.8.tgz",
-      "integrity": "sha512-SfjPjyLeno7iScndgFI3s9s8focqXADLNgIxkFbsL0BdAY7v3A6TOe+iSxnYX0fMhDqFC1jT3FVYlEzbJBg0Kg==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-headless/-/dsh-headless-0.1.1-rc.1.tgz",
+      "integrity": "sha512-4ktB7lef5PXUXy94eylGwGCYwMOCGjsfj7WE3H/Zcg5yXs02rZZvE2P4PHYaNvlnizc4DDlwJpyNCc+TI6PtnA==",
       "license": "MIT",
       "dependencies": {
-        "@deepseek-ai/dsh-cmdline": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-code-runtime-worker-thread": "^0.1.0-rc.8",
+        "@deepseek-ai/dsh-cmdline": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-code-runtime-worker-thread": "^0.1.1-rc.1",
         "@deepseek-ai/schemastery": "^3.18.1",
         "commander": "^15.0.0"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
         "@deepseek-ai/cordis-plugin-loader": "^1.0.2",
-        "@deepseek-ai/dsh-agent": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-agent-default-model": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-llm": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-session": "^0.1.0-rc.8"
+        "@deepseek-ai/dsh-agent": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-agent-default-model": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-home-paths": {
-      "version": "0.1.0-rc.8",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-home-paths/-/dsh-home-paths-0.1.0-rc.8.tgz",
-      "integrity": "sha512-9cQhH9CZsw7Zi73VnZk7CcuEVA6yR/Ox+7lp3VHq53fFYSPi0RL+kMWmh5XCrZB4U1OM3+PVsWsA5II9tB+t0Q==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-home-paths/-/dsh-home-paths-0.1.1-rc.1.tgz",
+      "integrity": "sha512-C83S3PL+S0mEC66nJO/VFsdkG9x41tSGKmrZdanTCA5OEp/M8OJYRZNYmsUl48Xwe8wQfLhHOes7FVWtRDRcMw==",
       "license": "MIT",
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.8"
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-host-apiproxy": {
-      "version": "0.1.0-rc.8",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-host-apiproxy/-/dsh-host-apiproxy-0.1.0-rc.8.tgz",
-      "integrity": "sha512-viq2CoS6bRavSe1t9sLjgunykO+Vn/m83uSgONMH8O7QN0Pk3+FnZGHlPZ1lQ4auNJTwQjxFG6w372cGq9usWw==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-host-apiproxy/-/dsh-host-apiproxy-0.1.1-rc.1.tgz",
+      "integrity": "sha512-pVyVP82Ij14kniqMDHGm/0Z+DDpkwJ/qHbLGe/G3zh0fpONPznUnYc8Qy5S88S7LKJy5+lLv0T5C0P8w9GtmEA==",
       "license": "MIT",
       "dependencies": {
-        "@deepseek-ai/dsh-agent": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-agent-default-model": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-api-remotes": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-attachment": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-brand": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-commands": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-credentials": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-goal": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-host-directory-picker": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-jobs": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-llm": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-native-command": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-session": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-session-persistence": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-session-projection": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-session-projection-cache": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-session-query": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-session-title": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-settings": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-skill": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-subagent": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-tools": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-user-approval": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-user-questions": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-workspace": "^0.1.0-rc.8",
+        "@deepseek-ai/dsh-agent": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-agent-default-model": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-api-remotes": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-attachment": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-brand": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-commands": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-credentials": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-goal": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-host-directory-picker": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-jobs": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-native-command": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-session-persistence": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-session-projection": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-session-projection-cache": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-session-query": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-session-title": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-settings": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-skill": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-subagent": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-tools": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-user-approval": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-user-questions": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-workspace": "^0.1.1-rc.1",
         "@deepseek-ai/schemastery": "^3.18.1",
         "fflate": "^0.8.2",
         "zod": "^4.4.3"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent-presets": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-cordis-host-runner": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.8"
+        "@deepseek-ai/dsh-agent-presets": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-cordis-host-runner": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-permission-presets": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-host-directory-picker": {
-      "version": "0.1.0-rc.8",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-host-directory-picker/-/dsh-host-directory-picker-0.1.0-rc.8.tgz",
-      "integrity": "sha512-aOUaUX0MTl8oLIuL27OkATMm+x2oTANuhhHpeGizn7+kfOX5bRKB3tyi7h6lGZ9O7WDiDLl2JajRqzBXlIPAAg==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-host-directory-picker/-/dsh-host-directory-picker-0.1.1-rc.1.tgz",
+      "integrity": "sha512-PrlnIxKg6WqPP8WwBVQf5TNRIxhb0cuEEj7JX9eI/rycVzNSRmaeJ/vTyoOVnw3lUZeI66nFF7PAOgJz0Ojn9g==",
       "license": "MIT",
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.8"
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-host-directory-picker-auto": {
-      "version": "0.1.0-rc.8",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-host-directory-picker-auto/-/dsh-host-directory-picker-auto-0.1.0-rc.8.tgz",
-      "integrity": "sha512-t6sn3AlcAARVCOgYMNZS/Yneiw+/2mDM6QOGxR6bu5E7DYTT/tllHe0PlHF1Wgh/LtfOTeDtcSPPfXjmrd+Lqw==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-host-directory-picker-auto/-/dsh-host-directory-picker-auto-0.1.1-rc.1.tgz",
+      "integrity": "sha512-9WDce848S1mUkswZKiFGS2xqjWBDYakg8xJoTtGp11b0xcgjITJNYRJLTrffqZ/FgPMSu0Ij3nn/ypBBjv+Xag==",
       "license": "MIT",
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
         "@deepseek-ai/cordis-plugin-loader": "^1.0.2",
-        "@deepseek-ai/dsh-client-ui-directory-picker-browse": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-client-ui-directory-picker-native": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-host-directory-picker-browse": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-host-directory-picker-native": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-host-webserver": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.8"
+        "@deepseek-ai/dsh-client-ui-directory-picker-browse": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-ui-directory-picker-native": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-host-directory-picker-browse": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-host-directory-picker-native": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-host-webserver": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-host-directory-picker-browse": {
-      "version": "0.1.0-rc.8",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-host-directory-picker-browse/-/dsh-host-directory-picker-browse-0.1.0-rc.8.tgz",
-      "integrity": "sha512-zEQ7Wnz953GWiR3Y9GaqPGmhntEdjmcD+x6cbYKXWyeOtMHvv7Lu9EWGNneFHXFt50nMinDBT5kyGzElZ+cajA==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-host-directory-picker-browse/-/dsh-host-directory-picker-browse-0.1.1-rc.1.tgz",
+      "integrity": "sha512-6KfMYkD+XUSUXjGff/EGLjpPFjU3lDeWoFzyCde7g9aLy0RfEYCSAJtcXUCZID+Z3PPwIfssFCwPn1H5ptyFHA==",
       "license": "MIT",
       "dependencies": {
-        "@deepseek-ai/dsh-host-directory-picker": "^0.1.0-rc.8",
+        "@deepseek-ai/dsh-host-directory-picker": "^0.1.1-rc.1",
         "@deepseek-ai/schemastery": "^3.18.1"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.8"
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-host-directory-picker-native": {
-      "version": "0.1.0-rc.8",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-host-directory-picker-native/-/dsh-host-directory-picker-native-0.1.0-rc.8.tgz",
-      "integrity": "sha512-WUB4lW+ZmR743uH9LpFK0JrJU88601E7zvevffa93n7Bl4X7C5Y2yhbDK337H8W/brVlLNVgD2Fw2H/nIPZkDg==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-host-directory-picker-native/-/dsh-host-directory-picker-native-0.1.1-rc.1.tgz",
+      "integrity": "sha512-dZs60Hr6MNJGzroTrQ0I/FD6IDcHwBFiyYSoU2GRunWKz0tdKLWAADHl1eT4mfQay4VBrl/58E+9T5loYWtuFw==",
       "license": "MIT",
       "dependencies": {
-        "@deepseek-ai/dsh-host-directory-picker": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-native-command": "^0.1.0-rc.8",
+        "@deepseek-ai/dsh-host-directory-picker": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-native-command": "^0.1.1-rc.1",
         "koffi": "^3.1.0"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.8"
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-host-frontend-static": {
-      "version": "0.1.0-rc.8",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-host-frontend-static/-/dsh-host-frontend-static-0.1.0-rc.8.tgz",
-      "integrity": "sha512-/ef1xAygNL9hyGtSDzJ04nM5WSNzSxsloSUD2MQfM0FU3Y6b/CbHkUNFYaS0MnhS1YVSulDAGRQvXSgES8vZkg==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-host-frontend-static/-/dsh-host-frontend-static-0.1.1-rc.1.tgz",
+      "integrity": "sha512-efJSWiHOCPZYG+IAE8xR6Jm7x9rnO6HH3TYsBffL6T2vYlxwpPD7uifUDgHVvyVmPrgAMsPeYhI/0tAtZm+nJw==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-host-webserver": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.8"
+        "@deepseek-ai/dsh-host-webserver": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-host-plugin-inventory": {
-      "version": "0.1.0-rc.8",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-host-plugin-inventory/-/dsh-host-plugin-inventory-0.1.0-rc.8.tgz",
-      "integrity": "sha512-knPtxCDZn1jbwRfOUnskjaj8hSXUCfBcjD9LPFXnKffsM6TFOeQrFGhkNKlZteXAMSChtY6pV9bpJj17y3SPNg==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-host-plugin-inventory/-/dsh-host-plugin-inventory-0.1.1-rc.1.tgz",
+      "integrity": "sha512-VKQPlWcxQTKZIGDvf/yW36GGk1iwbMLFIyWYr8Q3iRCYSlGyL+JL6ejJClxboVNWiZvPM75Ywai6HgkpLbLgPA==",
       "license": "MIT",
       "dependencies": {
         "zod": "^4.4.3"
@@ -2224,28 +2238,28 @@
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
         "@deepseek-ai/cordis-plugin-loader": "^1.0.2",
-        "@deepseek-ai/dsh-brand": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-typert-protocol": "^0.1.0-rc.8"
+        "@deepseek-ai/dsh-brand": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-typert-protocol": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-host-webserver": {
-      "version": "0.1.0-rc.8",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-host-webserver/-/dsh-host-webserver-0.1.0-rc.8.tgz",
-      "integrity": "sha512-MEKFrhvsYfj970QHLaKPpF/sIBpCe8NuSA0HGiWYJctX6TM9N3rLRhXx5p3zATDmXZclu1rbYhIbsqWw/twPig==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-host-webserver/-/dsh-host-webserver-0.1.1-rc.1.tgz",
+      "integrity": "sha512-ugps/tmxbOLqbAf1s5sCIdfrlLpm4rHKm1OyCCNbKg3MB1YoZRqa+hH40Usf/VxzvjtP8AVDYzcYnF7vwAafLA==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.8"
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-invariants": {
-      "version": "0.1.0-rc.8",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-invariants/-/dsh-invariants-0.1.0-rc.8.tgz",
-      "integrity": "sha512-u0lYqyxOYwfsVnbsfGXZos5vFvA4cqFnBEW3/ezgljNwkYwzeUP/Y5wjPnQjP+ZzBn3CnVeIF6s2N2Vk3iA5mQ==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-invariants/-/dsh-invariants-0.1.1-rc.1.tgz",
+      "integrity": "sha512-tRsr9Qynl3qnFAHE460uALI9jncaD0pr4+hufWTSY73MbOswd6V3KDYy3wWQb9ttDm5XE5GTkB/a56KNnO28XA==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -2256,65 +2270,65 @@
       }
     },
     "node_modules/@deepseek-ai/dsh-jobs": {
-      "version": "0.1.0-rc.8",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-jobs/-/dsh-jobs-0.1.0-rc.8.tgz",
-      "integrity": "sha512-HqQudOA4VkjCMpxWiqTCMmuiTa/pehW6yG7dDsctO1vW5K48hWQ/h7czdJKgrh4SMuK4kchv3IipS1KaJmdaog==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-jobs/-/dsh-jobs-0.1.1-rc.1.tgz",
+      "integrity": "sha512-LbETHkXkI92vTQCAnOqsmt+W2pagu0PlVw15vGTBgks9xi7YweFQtGPfsiCJ0EHWaiKARvqtT+dN/n0KkDyicg==",
       "license": "MIT",
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-brand": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-session": "^0.1.0-rc.8"
+        "@deepseek-ai/dsh-agent": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-brand": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-jobs-local": {
-      "version": "0.1.0-rc.8",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-jobs-local/-/dsh-jobs-local-0.1.0-rc.8.tgz",
-      "integrity": "sha512-8/cr4rYVS2sLB/Z4lL/ERUn14iBqT9T85rJFxxhEKuT3gMcAkiJuKP7t+ZFWPYSSmcNqDPmMI1ExG+GzjxsLVQ==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-jobs-local/-/dsh-jobs-local-0.1.1-rc.1.tgz",
+      "integrity": "sha512-xjzJy3yhqdUDTo/IRr7cGpnE1wzVRF7ZABcTiCg2cNeYGY5SzGoUn/XyE7kOsPEulHbnvpr2pddHMJvwbBcGPw==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-jobs": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-scope": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-timeout": "^0.1.0-rc.8"
+        "@deepseek-ai/dsh-agent": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-jobs": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-scope": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-timeout": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-launch-environment": {
-      "version": "0.1.0-rc.8",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-launch-environment/-/dsh-launch-environment-0.1.0-rc.8.tgz",
-      "integrity": "sha512-VvYo5R7tu4QhX/dsNpuBy3AaauizU6yPCeWQUNzI3ZjGA0VHkkZhInilcgxVJkPA1lwEXYB+OoCAo07PUy6D/w==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-launch-environment/-/dsh-launch-environment-0.1.1-rc.1.tgz",
+      "integrity": "sha512-TKrXFGcAibVAWoqjlc+M7xRfr8IVdkzMpemmSkNpXOxaqLVr5KLVwAOL+Fp05knp/riV2WX5POucWJ5L3P3gaw==",
       "license": "MIT",
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.8"
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-llm": {
-      "version": "0.1.0-rc.8",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-llm/-/dsh-llm-0.1.0-rc.8.tgz",
-      "integrity": "sha512-hf6RmX2Stn1UtzpktSHQLkIktQkBm9i/3yFfJlbGSkwyw5Cv9sTYJbyoHzsSnnh6i8nRRcMcBhvMgm23I00oIw==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-llm/-/dsh-llm-0.1.1-rc.1.tgz",
+      "integrity": "sha512-SzZ0WHjxyfcB1j/aEkZM/P5Sd11qw58AgB7TFcRC0iHwZtAqlKMgaptx/Rz1olNyerGpjii2mmUoinF5p1MYwA==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-attachment": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-brand": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-timeout": "^0.1.0-rc.8"
+        "@deepseek-ai/dsh-attachment": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-brand": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-timeout": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-llm-deepseek": {
-      "version": "0.1.0-rc.8",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-llm-deepseek/-/dsh-llm-deepseek-0.1.0-rc.8.tgz",
-      "integrity": "sha512-s4LatnGbHwPJhcWGulO/7RsJBPHHBDB+2+1iRTJEn6vYPB0lOSRWtr91qdmAkUxBZmK5mwrf21IbuW+kWwtAZQ==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-llm-deepseek/-/dsh-llm-deepseek-0.1.1-rc.1.tgz",
+      "integrity": "sha512-qCtJgnvY6ix3hXX6tRcVozoi+JL8re4PjpNnCGYz3Az4csqdIkL+a9DqnV8JOIMi20NTjeOrktaOFgUd7rdsDg==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1",
@@ -2322,20 +2336,20 @@
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-anonymous-user-id": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-attachment": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-credentials": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-launch-environment": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-llm": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-settings": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-timeout": "^0.1.0-rc.8"
+        "@deepseek-ai/dsh-anonymous-user-id": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-attachment": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-credentials": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-launch-environment": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-settings": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-timeout": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-llm-pi-ai": {
-      "version": "0.1.0-rc.8",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-llm-pi-ai/-/dsh-llm-pi-ai-0.1.0-rc.8.tgz",
-      "integrity": "sha512-r9dmHYy759gKtAG0S96wTCS6O8WFDqGLQu8t+zGY6LnfdT4qUJdmWtJ+GwCn+BGwq1AglBzjabvyRBp6BxXcMQ==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-llm-pi-ai/-/dsh-llm-pi-ai-0.1.1-rc.1.tgz",
+      "integrity": "sha512-lExsZIY7PeL7yEwgglTGLb1Tbg4soANFpuePOONIrn1ZP51DwENw1SrU/0RK9ps9ksMHyl9J1ie5FIYS/YCY0w==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1",
@@ -2343,37 +2357,38 @@
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-attachment": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-credentials": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-launch-environment": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-llm": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-settings": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-timeout": "^0.1.0-rc.8"
+        "@deepseek-ai/dsh-attachment": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-authorization": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-credentials": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-launch-environment": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-settings": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-timeout": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-llm-retry": {
-      "version": "0.1.0-rc.8",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-llm-retry/-/dsh-llm-retry-0.1.0-rc.8.tgz",
-      "integrity": "sha512-DmcOajgiku5l7aa5hU9DtwnIZu+i/XCGdb+Wego5W9bAswYeBAwbceloRNE3O6+jdRzy+K5U7KQ9V+olBsNqRQ==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-llm-retry/-/dsh-llm-retry-0.1.1-rc.1.tgz",
+      "integrity": "sha512-9bluPgwdzU7HIteYvwmLThzcT40nUBWDCrUkn7WjckuWnlx6qCIz5cFKeh3iyPPIHvcD3jidMB2ReOxKTEy4VQ==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-brand": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-llm": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-session": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-timeout": "^0.1.0-rc.8"
+        "@deepseek-ai/dsh-agent": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-brand": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-timeout": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-mcp-client": {
-      "version": "0.1.0-rc.8",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-mcp-client/-/dsh-mcp-client-0.1.0-rc.8.tgz",
-      "integrity": "sha512-pcqXawjq9jRJQNHZTLN7pswJFMWjxCsEOdHUI9BdJqb9lRDsMi2cul1Hizfi51oKkcNo1u/K9Toqgh8o/ScAXg==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-mcp-client/-/dsh-mcp-client-0.1.1-rc.1.tgz",
+      "integrity": "sha512-GXifDFUgiWcm3dr2Cbnpi9mbQgzP3GtIpGSX+7RlXlCHIHuavXCdgvGHSbq/KGPM5vAwrkZS+xcLwTSqpQL47A==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1",
@@ -2382,18 +2397,18 @@
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-attachment": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-llm": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-subprocess": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-timeout": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-tools": "^0.1.0-rc.8"
+        "@deepseek-ai/dsh-attachment": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-subprocess": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-timeout": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-tools": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-message-feedback": {
-      "version": "0.1.0-rc.8",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-message-feedback/-/dsh-message-feedback-0.1.0-rc.8.tgz",
-      "integrity": "sha512-5DYXVLcnvTRs74Att52LGNR+x+RCf1X5s5+gOSUddsjnQ0wn4f3pzfc0o4F+91aE2zX3xzQ3/LhlW5UOJdkB0Q==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-message-feedback/-/dsh-message-feedback-0.1.1-rc.1.tgz",
+      "integrity": "sha512-uG1+QqnlA7pTLj9ZffQRfIbZDrp7kHnquWotqZkc4EjLF2sCwWDB7YHYhhszjTbfOY4QAWk3tWvcszC0bV1H5Q==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1",
@@ -2401,40 +2416,40 @@
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-brand": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-llm": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-session": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-session-persistence": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-storage-domain": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-typert-protocol": "^0.1.0-rc.8"
+        "@deepseek-ai/dsh-brand": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-session-persistence": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-storage-domain": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-typert-protocol": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-native-command": {
-      "version": "0.1.0-rc.8",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-native-command/-/dsh-native-command-0.1.0-rc.8.tgz",
-      "integrity": "sha512-bRaT8LOb2xmWQ88oSzM4+Y3N4Yy4J0tf15/kQTP53PY1FnOA5hGYWoRglQgfxIcJCrw4fEdUPie8Fff0dCOwdQ==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-native-command/-/dsh-native-command-0.1.1-rc.1.tgz",
+      "integrity": "sha512-maVhsVwhIyGuqcMpJWMv4BPc/UaIIdAT4aZmdv9bHzbj3vzRALjAKOEAdhIXtdxtuTKcYbimg402bbEwe/u2OA==",
       "license": "MIT",
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.8"
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-output-retention": {
-      "version": "0.1.0-rc.8",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-output-retention/-/dsh-output-retention-0.1.0-rc.8.tgz",
-      "integrity": "sha512-DeVjqZ9TtH2AEG57GBsHYT68274VygzuP9EqQLL01Ht1TrdK75xlVet1l3jdEbA7Eik4aSGDjAZD9/MsnlUIXg==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-output-retention/-/dsh-output-retention-0.1.1-rc.1.tgz",
+      "integrity": "sha512-FapYBIWVzcXioH/lTaBSJlbEM9VQKzSy4fQgzRDLAVP8pMAHAvTaF/tBGQMooP582sPe+XpGh0xwWSJ5X72h6A==",
       "license": "MIT",
       "peer": true,
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.8"
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-permission-presets": {
-      "version": "0.1.0-rc.8",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-permission-presets/-/dsh-permission-presets-0.1.0-rc.8.tgz",
-      "integrity": "sha512-EeTn8Av5kmb1Qj53D7myRnKcNQrrupGrM2m9LVUO8ieWvlIaYX7n2g0y8kg14SUpcD2YzaT40oGJ6VeDuhTZAA==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-permission-presets/-/dsh-permission-presets-0.1.1-rc.1.tgz",
+      "integrity": "sha512-TSWcoxXBD1PQg2btZ7cMscQSHBLAz480oE0PV3ka/kgrvBgppwtppQbMoF1owPek+cJ3EraXthXnUk6IlcuPoQ==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1",
@@ -2442,50 +2457,50 @@
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-commands": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-sandbox": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-sandbox-policy": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-session": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-session-projection": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-settings": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-shell": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-user-approval": "^0.1.0-rc.8"
+        "@deepseek-ai/dsh-commands": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-sandbox": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-sandbox-policy": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-session-projection": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-settings": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-shell": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-user-approval": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-persona": {
-      "version": "0.1.0-rc.8",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-persona/-/dsh-persona-0.1.0-rc.8.tgz",
-      "integrity": "sha512-3COzIzZ5kBd+txuH418h9HG4feuVFyhdh02HWvzsWgaPsxjatuFS0OfS6qsejUTZrFDODQSr1WIOeSt80bDBtA==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-persona/-/dsh-persona-0.1.1-rc.1.tgz",
+      "integrity": "sha512-RrP0ABGoVvy2G5i8B5nssDpgpFIwNGvdT7wPPN5ID+wnRe1TD8PwfM6L7ZsTpNHKlbpmZmNfRxlEE1cRm89XVw==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-system-prompt": "^0.1.0-rc.8"
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-plan-mode": {
-      "version": "0.1.0-rc.8",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-plan-mode/-/dsh-plan-mode-0.1.0-rc.8.tgz",
-      "integrity": "sha512-/SY/iil7KLDvveqKRUZxO4HiADwDlOX9u3xyG/93h785mWSfRXooiv4Zp2tiBjU+pJB0tJXMsQNAXDdg7DWtwA==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-plan-mode/-/dsh-plan-mode-0.1.1-rc.1.tgz",
+      "integrity": "sha512-VtmkzVxwYShRNrkN/1cdLIFaph2vQbm7o5/8hK3elXVYOTd4Y0q3H3LduPMmu1Ejnj5trDYqUTZ2A+vPob5ZzQ==",
       "license": "MIT",
       "dependencies": {
         "zod": "^4.4.3"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-commands": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-llm": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-session": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-session-projection": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-system-prompt": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-tools": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-user-questions": "^0.1.0-rc.8"
+        "@deepseek-ai/dsh-agent": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-commands": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-session-projection": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-tools": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-user-questions": "^0.1.1-rc.1"
       },
       "peerDependenciesMeta": {
         "@deepseek-ai/dsh-commands": {
@@ -2494,200 +2509,200 @@
       }
     },
     "node_modules/@deepseek-ai/dsh-pwsh-local": {
-      "version": "0.1.0-rc.8",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-pwsh-local/-/dsh-pwsh-local-0.1.0-rc.8.tgz",
-      "integrity": "sha512-lHAEwC4pL5bVSKgwaeO2dMM9s/jnpDBRuTeVD2HkunpFfT1Kq4lFi+/YXj00L7mW9DBP6FMfwRRV/0Wgo1FtdA==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-pwsh-local/-/dsh-pwsh-local-0.1.1-rc.1.tgz",
+      "integrity": "sha512-Wl60ol6xE51HXjrQznD2dlvU7aH/mkKjKwaL5rQ7M/1bfmqOEM9cCFVAGw4uFH1UIwoBF7Z6lDTfdgpum8eFjA==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-settings": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-shell": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-subprocess": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-timeout": "^0.1.0-rc.8"
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-settings": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-shell": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-subprocess": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-timeout": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-pwsh-sandbox": {
-      "version": "0.1.0-rc.8",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-pwsh-sandbox/-/dsh-pwsh-sandbox-0.1.0-rc.8.tgz",
-      "integrity": "sha512-GVvj4zqpC/lwCGaRmIXIhFqOqewgoGOuokGFuv0QcjQUY3v9FnPor2dqDZr5pav8KFGb5GeGUzLoUbedmsWyZg==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-pwsh-sandbox/-/dsh-pwsh-sandbox-0.1.1-rc.1.tgz",
+      "integrity": "sha512-Sh1M2I98i3bPmLmQdhmcbjOTJltRL1ygr1bSx46XR94Dqwa1DvmCx6P/ZPtI9I5KQ05u0Lq4omyfTJ3R0twhIA==",
       "license": "MIT",
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-pwsh-local": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-sandbox": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-sandbox-policy": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-shell": "^0.1.0-rc.8"
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-pwsh-local": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-sandbox": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-sandbox-policy": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-shell": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-repeat-tool-reminder": {
-      "version": "0.1.0-rc.8",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-repeat-tool-reminder/-/dsh-repeat-tool-reminder-0.1.0-rc.8.tgz",
-      "integrity": "sha512-p7/g+NH6JJ0BnLx2V5o0hCm4wZr+dXQ9/Ev8LU6YyFRlcnma8TJuATL0wsA01xWfvvGLRxbe/tH41TRS1NVrJg==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-repeat-tool-reminder/-/dsh-repeat-tool-reminder-0.1.1-rc.1.tgz",
+      "integrity": "sha512-b5DPzJPJTKACT2RNmdTBRvo8ajkJ1n+UttlH5tULaKepr6AdTxxvq31a7HFWMwmHJ6aftXGyui+g7a2PSCW9bw==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-tools": "^0.1.0-rc.8"
+        "@deepseek-ai/dsh-agent": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-tools": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-sandbox": {
-      "version": "0.1.0-rc.8",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-sandbox/-/dsh-sandbox-0.1.0-rc.8.tgz",
-      "integrity": "sha512-dJpy5p/KjKkHG9AnMKU4+/ilj/4DCglsq3kof/jhIwtsZJCix07TEXP9vV8LCv4fU8af7cK3antXw4eVMqkwuQ==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-sandbox/-/dsh-sandbox-0.1.1-rc.1.tgz",
+      "integrity": "sha512-+2udF/TLxmZTgNC3RFA7ydN2sD/LIAjkao1bUiU372uOTttGrt31kKbeEqXL9yzfdiLjjuXWhRlbtmvmrf5PKA==",
       "license": "MIT",
       "peer": true,
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-llm": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-session": "^0.1.0-rc.8"
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-sandbox-local": {
-      "version": "0.1.0-rc.8",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-sandbox-local/-/dsh-sandbox-local-0.1.0-rc.8.tgz",
-      "integrity": "sha512-sTrKDXD74yG6B24uhCyN9DuGSpX0SCelN4o5DZylKxt56WRRyywAGdLN0Xt8enqiKCxrq+PJBi+hDh2GtXBj6w==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-sandbox-local/-/dsh-sandbox-local-0.1.1-rc.1.tgz",
+      "integrity": "sha512-GEFDzS1sRs1ISeWa97jtr3s868WlqEnP8S1w6y7stXIBm4GHzrLizjF1IvYlxh+WyE0rBC5wa0kVSZsjRQT2tw==",
       "license": "MIT",
       "dependencies": {
-        "@deepseek-ai/dsh-sandbox-windows-acl": "^0.1.0-rc.8",
+        "@deepseek-ai/dsh-sandbox-windows-acl": "^0.1.1-rc.1",
         "@deepseek-ai/node-addon-landlock-run": "^0.1.1",
         "@deepseek-ai/schemastery": "^3.18.1"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-llm": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-sandbox": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-session": "^0.1.0-rc.8"
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-sandbox": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-sandbox-policy": {
-      "version": "0.1.0-rc.8",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-sandbox-policy/-/dsh-sandbox-policy-0.1.0-rc.8.tgz",
-      "integrity": "sha512-xQOlYWbUr1Oj6cnRd5aHZIz52EOEAdSO1HJIfeDkQrVaOgohFsiiCIp6PNFumuGNWdCEnf4Q18ebafLNtazYlA==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-sandbox-policy/-/dsh-sandbox-policy-0.1.1-rc.1.tgz",
+      "integrity": "sha512-0CxwofljyZEAwrP5DboMZdm3NfekF+bDu2A28IWLTkTQKgF4DCekQ4bMf+Nqsc0gxBiLfo1ZcUUFICQj8m6mMw==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-sandbox": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-session": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-system-prompt": "^0.1.0-rc.8"
+        "@deepseek-ai/dsh-agent": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-sandbox": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-sandbox-windows-acl": {
-      "version": "0.1.0-rc.8",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-sandbox-windows-acl/-/dsh-sandbox-windows-acl-0.1.0-rc.8.tgz",
-      "integrity": "sha512-3DeFPD+laUbXrzVpEJ0FrF5pMQCqeu7YCJAWgORGj1aju7sIjpineEnKpE6EXhbc8C9Jqu2y5S7B9z6ydOL/Zg==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-sandbox-windows-acl/-/dsh-sandbox-windows-acl-0.1.1-rc.1.tgz",
+      "integrity": "sha512-FG6dJCb37vcuujAK1E906v08jtWTV6+54ShftCjqauHXWk7YKtIAsYRwMIkXg32aPD11EvQGtoJE45Rs3XBEdw==",
       "license": "MIT",
       "dependencies": {
         "koffi": "^3.1.0"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.8"
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-schedule": {
-      "version": "0.1.0-rc.8",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-schedule/-/dsh-schedule-0.1.0-rc.8.tgz",
-      "integrity": "sha512-L4GO1Bv3+SHIXafjGQcf0sJI9eTf9whxVmYlBxYHw7h7StOZJPMhG9HpsKz4mO9FZ7J4zhBtpYlFbhOQaJheqA==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-schedule/-/dsh-schedule-0.1.1-rc.1.tgz",
+      "integrity": "sha512-MvX5rP21/K0RqHTYdyMJIUqpM90En3A2CQiCiIc8BDzFqNJQgEE/+PDeHsxXnaPatmLhC2Sw0fQnZaoJxZ3/WQ==",
       "license": "MIT",
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-brand": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-llm": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-session": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-session-persistence": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-tools": "^0.1.0-rc.8"
+        "@deepseek-ai/dsh-agent": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-brand": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-session-persistence": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-tools": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-scope": {
-      "version": "0.1.0-rc.8",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-scope/-/dsh-scope-0.1.0-rc.8.tgz",
-      "integrity": "sha512-/o+PxkVV2zUy9lYlMFr4TWSb+ESW4DE+fI891yIbsLzOJdFgfbmmLpGrlWgnz8/unIGJZxjeXdwyppV04Z277Q==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-scope/-/dsh-scope-0.1.1-rc.1.tgz",
+      "integrity": "sha512-1Zt+tWDSCoSTAzbaJdSiWHe3pJTpyIqnsCEP3SOyxLIKclsj378rhsrkw+5O6oCRxjDCf0u8BJ+Q5liXREedBg==",
       "license": "MIT",
       "peer": true,
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.8"
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-session": {
-      "version": "0.1.0-rc.8",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-session/-/dsh-session-0.1.0-rc.8.tgz",
-      "integrity": "sha512-Qs5Mgn32WPPVB4rKHjsZBgLOkh0TQurUAcc9GaDVudK4dUkpno2HDh++qu/PrwRA3CZ/iwPAoFHCpB3AMMaoLg==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-session/-/dsh-session-0.1.1-rc.1.tgz",
+      "integrity": "sha512-TypXRsDxHQzms8H44DYFOs3sD/1fVvpFcyPMtOSP0SY+u/e+P/xg/0PgCvEt1epigHkBXtHddjHNLMlhzy9mbQ==",
       "license": "MIT",
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-brand": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-llm": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-scope": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-typert-protocol": "^0.1.0-rc.8"
+        "@deepseek-ai/dsh-brand": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-scope": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-typert-protocol": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-session-checkpoint-policy": {
-      "version": "0.1.0-rc.8",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-session-checkpoint-policy/-/dsh-session-checkpoint-policy-0.1.0-rc.8.tgz",
-      "integrity": "sha512-9DpZhQN4MExSjbjBSmaH08DmFS/GHRrsVhO5e3WgTVuH13ugdl5yxc4MEb8qvOhEJUUtOx3fXHuMpSTa0Dxa7w==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-session-checkpoint-policy/-/dsh-session-checkpoint-policy-0.1.1-rc.1.tgz",
+      "integrity": "sha512-RC4X+QWL+mYIEYmkUrd/Jca6y/qgqL8saXm+v9pDU+lhjZ757qpUc+2WNUo168cT3umTLEYOcDnLty203C4HeQ==",
       "license": "MIT",
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-llm": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-session": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-session-persistence": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-tools": "^0.1.0-rc.8"
+        "@deepseek-ai/dsh-agent": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-session-persistence": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-tools": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-session-log-export": {
-      "version": "0.1.0-rc.8",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-session-log-export/-/dsh-session-log-export-0.1.0-rc.8.tgz",
-      "integrity": "sha512-6vDC7uH0WZkwmlj/iql6AmSL9Uifiqi28OIZSDIi8/KRHDHnt5hvjobJecuIxhV9hQSDmNsstErHGx4ng2GJFQ==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-session-log-export/-/dsh-session-log-export-0.1.1-rc.1.tgz",
+      "integrity": "sha512-ZrVUSq29taKCbpaD5crG+2XRWyJvNQhFtbdxSqwaroWEsYdQHINVqn5Zjf/Vm40n4MWiZLWDbsNf8ba+CWE3Nw==",
       "license": "MIT",
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-client-locale": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-client-runtime": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-client-ui-commands": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-client-ui-conversation": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-commands": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.8"
+        "@deepseek-ai/dsh-client-locale": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-runtime": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-ui-commands": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-ui-conversation": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-commands": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-session-persistence": {
-      "version": "0.1.0-rc.8",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-session-persistence/-/dsh-session-persistence-0.1.0-rc.8.tgz",
-      "integrity": "sha512-JujorG/UCern0+zxJzNswyWl2tFG9sLzfVNvA5YkTLaRLZt7ZsEhxG4DxWZ6uj+3RJ8sf4bqdKqvpIn9t1pwUw==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-session-persistence/-/dsh-session-persistence-0.1.1-rc.1.tgz",
+      "integrity": "sha512-EsgGSWPEt+pLBamWbICgISNOpw0f1FVdECOnkbHVL47weOTz04S9SVdLcZv4aMo3xSONbdBAThhhh8DBf6Q6sQ==",
       "license": "MIT",
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-brand": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-session": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-timeout": "^0.1.0-rc.8"
+        "@deepseek-ai/dsh-brand": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-timeout": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-session-persistence-jsonl": {
-      "version": "0.1.0-rc.8",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-session-persistence-jsonl/-/dsh-session-persistence-jsonl-0.1.0-rc.8.tgz",
-      "integrity": "sha512-T/Lvh76O2tpVw04FAhgLF3Qovq3SrUnzaywIbB+Uw67a2DD63Qg+cJY9WO6Pu/UowPxbpuUOd12c6iPY5x8d7Q==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-session-persistence-jsonl/-/dsh-session-persistence-jsonl-0.1.1-rc.1.tgz",
+      "integrity": "sha512-FvK6nBwFk+tBUIvxL6QVpck9TVEG73HC9VlVvc9VeskD/74/J5FinubqjtER2S5QMVHBrocDy0EkGYqHrJlTgA==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1",
@@ -2695,29 +2710,29 @@
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-session": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-session-persistence": "^0.1.0-rc.8"
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-session-persistence": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-session-projection": {
-      "version": "0.1.0-rc.8",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-session-projection/-/dsh-session-projection-0.1.0-rc.8.tgz",
-      "integrity": "sha512-q00B+rl7WAuK0Bgh93SY2+ZpqaH2kJhfJ9n6Jg6R/m4plnH0Ip4oCAHl6u8rBzDgb1mniQGEQDz/7BN5Q3It8Q==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-session-projection/-/dsh-session-projection-0.1.1-rc.1.tgz",
+      "integrity": "sha512-RXDAUdfi3CqTQGQhMyIDZ5u4nURmN0ChkWwoX5Ph5rITa1zelnQsskYc93s+FTtB9Ituac3Uynk0rKGw/bS4fw==",
       "license": "MIT",
       "dependencies": {
         "zod": "^4.4.3"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-session": "^0.1.0-rc.8"
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-session-projection-cache": {
-      "version": "0.1.0-rc.8",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-session-projection-cache/-/dsh-session-projection-cache-0.1.0-rc.8.tgz",
-      "integrity": "sha512-IPvO7k9FlekOJXn4XLWUwU5+JDQn7khu8Oa04GFDystU3c1CnOwoa7SGMHOfJau3r177M4ncXApwN5Ra6uhyXw==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-session-projection-cache/-/dsh-session-projection-cache-0.1.1-rc.1.tgz",
+      "integrity": "sha512-eWdgco1blIb+hCGPx0bWy+cc8nebhifLm8FsXrguIJFgK499HZEhDpf8D0veRgmpjV0HhNVMinB0egdXNeg0nA==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1",
@@ -2725,26 +2740,26 @@
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-session": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-session-persistence": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-session-projection": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-storage-domain": "^0.1.0-rc.8"
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-session-persistence": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-session-projection": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-storage-domain": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-session-query": {
-      "version": "0.1.0-rc.8",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-session-query/-/dsh-session-query-0.1.0-rc.8.tgz",
-      "integrity": "sha512-q8eyfpgPuJx24l1fEevDkc3Dux3lNp/yDzVkDL4nSTGNaDx/h9Y6iG7SZdqWM5nxOET3iwxi4AkPM7lYyLg3cQ==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-session-query/-/dsh-session-query-0.1.1-rc.1.tgz",
+      "integrity": "sha512-5FX2RunFkHNY75mCK1wrJ+uJkETWzV+p9tbao+L9V23Q6njIYQ6cMZ7QxvCHcMpqZIUvD1muZweau1e3UIB8hw==",
       "license": "MIT",
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-brand": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-llm": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-session": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-session-persistence": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-session-title": "^0.1.0-rc.8"
+        "@deepseek-ai/dsh-brand": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-session-persistence": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-session-title": "^0.1.1-rc.1"
       },
       "peerDependenciesMeta": {
         "@deepseek-ai/dsh-session-persistence": {
@@ -2753,19 +2768,19 @@
       }
     },
     "node_modules/@deepseek-ai/dsh-session-query-sqlite": {
-      "version": "0.1.0-rc.8",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-session-query-sqlite/-/dsh-session-query-sqlite-0.1.0-rc.8.tgz",
-      "integrity": "sha512-jrNq2vgWIH7OzNMHXrKEjEMwy86I36I94a8X5u937xo2B2JD8ZIWfuWHC9YyLqabRwNf7VcQ6VZ6ruSgESRE7A==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-session-query-sqlite/-/dsh-session-query-sqlite-0.1.1-rc.1.tgz",
+      "integrity": "sha512-0qQdWu3n6UPSmOe3FgdELbqOa0aohbcD0TSEu75Cba2e7I5XHQzeKsFas552zKiHmI7f0BconaLKDiHnp7aHgg==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-session": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-session-persistence": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-session-query": "^0.1.0-rc.8"
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-session-persistence": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-session-query": "^0.1.1-rc.1"
       },
       "peerDependenciesMeta": {
         "@deepseek-ai/dsh-session-persistence": {
@@ -2774,9 +2789,9 @@
       }
     },
     "node_modules/@deepseek-ai/dsh-session-reference": {
-      "version": "0.1.0-rc.8",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-session-reference/-/dsh-session-reference-0.1.0-rc.8.tgz",
-      "integrity": "sha512-meNS02BOkLc2SnF2qWvl5X1Psk59t0Q1vvwjfCkczD29g4nm7Y02EZ089HJKii0VAsSB39RYA2rf6MCSl6vhow==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-session-reference/-/dsh-session-reference-0.1.1-rc.1.tgz",
+      "integrity": "sha512-deO+kFcK/ZOvcOwp5wd0tCPL5/yiv8TeE3Pmvd5NqaMr/0vKm8ePeoXwqJmQ+T3cHtbUhukGNvFKiP94IdQaHQ==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1",
@@ -2784,49 +2799,49 @@
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-compaction": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-llm": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-output-retention": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-session": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-session-query": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-typert-protocol": "^0.1.0-rc.8"
+        "@deepseek-ai/dsh-agent": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-compaction": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-output-retention": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-session-query": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-typert-protocol": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-session-stats": {
-      "version": "0.1.0-rc.8",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-session-stats/-/dsh-session-stats-0.1.0-rc.8.tgz",
-      "integrity": "sha512-T+SEzBkMxZpQ31MaeJCjaLN3/xu8yyZ3Va5u6osfq0nsJz1tvuZ53MHMbApdwERHVV0t/1eILTUo1J6XdksUEA==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-session-stats/-/dsh-session-stats-0.1.1-rc.1.tgz",
+      "integrity": "sha512-H+JqPsq69nnoNPTJBQVQzG8EIVb4UZyyN4teLhEal79LG3XvYn9s/ZWTus3z02//KdwGhetCzvPZ+E1PVaUFIQ==",
       "license": "MIT",
       "dependencies": {
         "zod": "^4.4.3"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-llm": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-session": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-session-projection": "^0.1.0-rc.8"
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-session-projection": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-session-telemetry": {
-      "version": "0.1.0-rc.8",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-session-telemetry/-/dsh-session-telemetry-0.1.0-rc.8.tgz",
-      "integrity": "sha512-Rs7w+PP/uuOaa34RFY4q6Xjes/C32H0gPvZe/gV9M87y1EcJs+mFBzhnc/zyKeaAdT25RWIwO3KATmKlT/D0Dg==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-session-telemetry/-/dsh-session-telemetry-0.1.1-rc.1.tgz",
+      "integrity": "sha512-sZVe8bnMZK38J9pZWrObXOFKArV3aKo4cQJ9TgSmo9C1oAY2Mv0HA8rOodUCBX2u74zQ+LuB455iM9V+SCHBXA==",
       "license": "MIT",
       "peer": true,
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-session": "^0.1.0-rc.8"
+        "@deepseek-ai/dsh-agent": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-session-telemetry-otel": {
-      "version": "0.1.0-rc.8",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-session-telemetry-otel/-/dsh-session-telemetry-otel-0.1.0-rc.8.tgz",
-      "integrity": "sha512-rpPwidBwKV53WM2bYW/eYOZ6j5U9VHOIVrITQkQtGDMAzD9UaqfAXfXfUlsw9vsfjED2gKmSf7vn+bVfy8Tjaw==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-session-telemetry-otel/-/dsh-session-telemetry-otel-0.1.1-rc.1.tgz",
+      "integrity": "sha512-GMWUdtmqGOakCbx0af2umlrHzduqypxSp3ozYi1OA1KOqxKX3aiTMilcaOQL79/e+/Z0zG4v2PvXKCsa2grAzA==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1",
@@ -2839,18 +2854,18 @@
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-anonymous-user-id": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-command-feedback": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-llm": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-session": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-session-telemetry": "^0.1.0-rc.8"
+        "@deepseek-ai/dsh-anonymous-user-id": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-command-feedback": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-session-telemetry": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-session-title": {
-      "version": "0.1.0-rc.8",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-session-title/-/dsh-session-title-0.1.0-rc.8.tgz",
-      "integrity": "sha512-OFG9kHFGnM5ND4LCkqg8oZr57qgF6xMkBxR/4MRaJJ42QrPI9QKzoZVRpNpXEl3v3uw8oR7Jj0jbc7WClNl3ow==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-session-title/-/dsh-session-title-0.1.1-rc.1.tgz",
+      "integrity": "sha512-hPtDxVSktufWJdZKE5c1tWRl+lb1NCRcjdXi+Pm8Iq8a0D/yx4YDKiv/aLhklDFybyV8FmtlVUPdJS0teyRyHQ==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1",
@@ -2858,34 +2873,34 @@
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-brand": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-llm": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-session": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-session-projection": "^0.1.0-rc.8"
+        "@deepseek-ai/dsh-brand": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-session-projection": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-session-title-first-prompt-llm": {
-      "version": "0.1.0-rc.8",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-session-title-first-prompt-llm/-/dsh-session-title-first-prompt-llm-0.1.0-rc.8.tgz",
-      "integrity": "sha512-pFx2hPVYyRCRcbd4WJZVapVekLLEGMAG1KAcrixf3XOGDNaqVEPF8LWatx8iKQRfVSQlvIOwDO8uEsC0NZiPNA==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-session-title-first-prompt-llm/-/dsh-session-title-first-prompt-llm-0.1.1-rc.1.tgz",
+      "integrity": "sha512-BUGmy8sT1IjP0S7slcfBbbjNUxcbSTN/iPPO3itSu9Gvwe6we9PwMEdVQgKozNsaUeax95aunl1KRxG7LbVKUw==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-llm": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-session": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-session-title": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-session-title-llm": "^0.1.0-rc.8"
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-session-title": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-session-title-llm": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-session-title-llm": {
-      "version": "0.1.0-rc.8",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-session-title-llm/-/dsh-session-title-llm-0.1.0-rc.8.tgz",
-      "integrity": "sha512-6xz3umGBtGmM+t5O5wwlCwbH9gmBOlQBfg7qGnPJftWc4VWHG7l2VUYqd3DNTQVTHIA/hSN4qg/LXTm79rADGQ==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-session-title-llm/-/dsh-session-title-llm-0.1.1-rc.1.tgz",
+      "integrity": "sha512-vROiHtfX8VBeRKfDsnFufP23iZHjxMKUC2Fvct9QbWG4iohaAYT8fAfkzyVcZTE3Mgr1AuSzIiRtiwUUheiZtg==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -2893,29 +2908,29 @@
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-llm": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-session": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-session-title": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-timeout": "^0.1.0-rc.8"
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-session-title": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-timeout": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-settings": {
-      "version": "0.1.0-rc.8",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-settings/-/dsh-settings-0.1.0-rc.8.tgz",
-      "integrity": "sha512-pqbMoiSP+Ieww9/4gcHYXcBCDlno1zYDu2OPq+5xdZ+McnK+5YBtHsiRpnR9cHQxGTH7lkfIv+adkOueQW0utg==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-settings/-/dsh-settings-0.1.1-rc.1.tgz",
+      "integrity": "sha512-Q7dr2mQQlaAOgZR9UGUQprOQ0iI/NyrsfSWO612/teUawfXaf6k1nO8w90ExDD483wengXp1bnZ1JT7bal9WTg==",
       "license": "MIT",
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-brand": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.8",
+        "@deepseek-ai/dsh-brand": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
         "@deepseek-ai/schemastery": "^3.18.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-settings-file": {
-      "version": "0.1.0-rc.8",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-settings-file/-/dsh-settings-file-0.1.0-rc.8.tgz",
-      "integrity": "sha512-2mCyAPkxA5r7Ezgt41XtJxRBsj5Dkl21e5v7w+6YE3C8/n9zRRlN4X5oInHcUKEmgoTrNLCBCgOs5DNrl+pErw==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-settings-file/-/dsh-settings-file-0.1.1-rc.1.tgz",
+      "integrity": "sha512-2W85eA92YLsSNBuQHDcmrK3ycWqz//Kke60vlZ1Yo7rCLjxLhCLttEPxLdpmNsmwOOxAQo0KWst0tIpzglmvOA==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1",
@@ -2924,73 +2939,73 @@
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-atomic-write": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-home-paths": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-settings": "^0.1.0-rc.8"
+        "@deepseek-ai/dsh-atomic-write": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-home-paths": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-settings": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-shell": {
-      "version": "0.1.0-rc.8",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-shell/-/dsh-shell-0.1.0-rc.8.tgz",
-      "integrity": "sha512-RNhp7Y25DXUH7o36X4GcN0lnOLg6NXTlWZpYNURT7aDj3UHcLLajRsyddiAh1EbwQnl0GRKRZhLaZHrrG6gMIw==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-shell/-/dsh-shell-0.1.1-rc.1.tgz",
+      "integrity": "sha512-3D92e9P6qEfLipJvTSzg5voTLydjxiC5glLJpW/1Jg2HZ3OFJ/sr/2GOIjSNNYViRYOXK9HsfvYURUAFHmQGTg==",
       "license": "MIT",
       "peer": true,
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-sandbox": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-settings": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-subprocess": "^0.1.0-rc.8"
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-sandbox": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-settings": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-subprocess": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-shell-env": {
-      "version": "0.1.0-rc.8",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-shell-env/-/dsh-shell-env-0.1.0-rc.8.tgz",
-      "integrity": "sha512-E/Rlka8BnpB7GM67ZJPjvZyp0O9L5x28giyJhHWZcPHN4rsEQFVVqk0cH6iDT5STy+dMc9BAUW+im18kATIxsA==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-shell-env/-/dsh-shell-env-0.1.1-rc.1.tgz",
+      "integrity": "sha512-wDBqqaXbUggc8mxhmlO3aWoQcZ+VCOIY715L1NhKBi3FmEpmDm4XOoArs8udH1IBUKYIQzp0GtDtLpTccPohOQ==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-home-paths": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-session-persistence": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-shell": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-tools": "^0.1.0-rc.8"
+        "@deepseek-ai/dsh-home-paths": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-session-persistence": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-shell": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-tools": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-skill": {
-      "version": "0.1.0-rc.8",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-skill/-/dsh-skill-0.1.0-rc.8.tgz",
-      "integrity": "sha512-MqcOzl4Y5pQEvFBNVAi5w0IZWH5kVbXmp1RYScrl+8HpVATZbgumDhztVnEc2kUrZu+o6LKb1hnbunK6JHUE5g==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-skill/-/dsh-skill-0.1.1-rc.1.tgz",
+      "integrity": "sha512-jc/z3QEYGuGlnh0w/kVv08B0vkiCVmXhX62MppSuzK6yGKQQJAYtvw3Trk9q/hYutL3KwFpAK4FnJ8dtmiPB/A==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-llm": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-scope": "^0.1.0-rc.8"
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-scope": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-skill-badge": {
-      "version": "0.1.0-rc.8",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-skill-badge/-/dsh-skill-badge-0.1.0-rc.8.tgz",
-      "integrity": "sha512-VjISwf5qDpkD+bxLuVXYL7IakhPoZudIOwWCFjTD++Tj8VQTN9ORCq1uCOatFLi5v/an8MzdZ91O2pXfQtb7dQ==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-skill-badge/-/dsh-skill-badge-0.1.1-rc.1.tgz",
+      "integrity": "sha512-7evQ5D6krRUbf1FVt1HutKDMecZDQqmGbZBe9ohhGrIQHU12U4Bewb5LE4Tl6A6hKKstnCoY5SbovQIbm8V5lw==",
       "license": "MIT",
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-skill": "^0.1.0-rc.8"
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-skill": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-skill-filesystem": {
-      "version": "0.1.0-rc.8",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-skill-filesystem/-/dsh-skill-filesystem-0.1.0-rc.8.tgz",
-      "integrity": "sha512-A87t/1+wxPiMkUXWVdf4DfgxA8rp1eLmStMvzfdthR/WxtGPzuEv2L5oyNDzKiCBwIcxBN6Fy2THNa2Xba2kQQ==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-skill-filesystem/-/dsh-skill-filesystem-0.1.1-rc.1.tgz",
+      "integrity": "sha512-ReGxRVmlVJ0S23lEPWlADnPie4Sff0vUdjt5/W4h1o1wZLyXG4STrCoa4Nkm4Rhx3ES5WfLa0Wr9TPzTkLEieg==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1",
@@ -2999,10 +3014,10 @@
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-fs": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-home-paths": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-skill": "^0.1.0-rc.8"
+        "@deepseek-ai/dsh-fs": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-home-paths": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-skill": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-skill-filesystem/node_modules/chokidar": {
@@ -3034,65 +3049,65 @@
       }
     },
     "node_modules/@deepseek-ai/dsh-spill": {
-      "version": "0.1.0-rc.8",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-spill/-/dsh-spill-0.1.0-rc.8.tgz",
-      "integrity": "sha512-LDfyBuRS/yfc+JYvSicEXYJDj5PFBfWN6vJ5G3wy14eMrq3OKoYip8lyIjEdR4qwCVh0s+oSi28AlcvkPuyOdw==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-spill/-/dsh-spill-0.1.1-rc.1.tgz",
+      "integrity": "sha512-PK1A1YxQVgisWacljbHAyL2z3MGXE+GWeXzNf2hHElzmtAkv412a3TXtMTL5XLZ1m0laLZxstEcf8L+S4zxvPQ==",
       "license": "MIT",
       "peer": true,
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-brand": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-llm": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-session": "^0.1.0-rc.8"
+        "@deepseek-ai/dsh-brand": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-spill-local": {
-      "version": "0.1.0-rc.8",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-spill-local/-/dsh-spill-local-0.1.0-rc.8.tgz",
-      "integrity": "sha512-4Ew3cBOQxW6wA4U8svXCjUyhX00+h0W/bK9CzTy/HoYrNJhP85euJVV7SfNlq6OfTeQBWn3U0wKwNlcc3gAyAg==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-spill-local/-/dsh-spill-local-0.1.1-rc.1.tgz",
+      "integrity": "sha512-YquagM4ZY6p1+03BSJxfp/rK9yy/ZkfZ0yNumiL5juF0drte6OqUj6YvrR2/RVhV88Id85fv6ik0As70x9l+Ww==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-spill": "^0.1.0-rc.8"
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-spill": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-spill-policy": {
-      "version": "0.1.0-rc.8",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-spill-policy/-/dsh-spill-policy-0.1.0-rc.8.tgz",
-      "integrity": "sha512-9y2IHaKowtqGxhYd59R3OfWv1sonIDv2h9WX/jhxbagMvORfRkhjWJP4YAxp+l4Ba1LhVLcuG/nb2p8hqGdO4g==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-spill-policy/-/dsh-spill-policy-0.1.1-rc.1.tgz",
+      "integrity": "sha512-shbTUw8Cpq+X5XZlM3G8q5pPDmXnNgyW8NRDUg2l/bPLipdejIivs7T5dLLXKRtxhaD9GB6Z7jqFuy+dlV8iIg==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-llm": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-output-retention": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-session": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-spill": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-tools": "^0.1.0-rc.8"
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-output-retention": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-spill": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-tools": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-storage": {
-      "version": "0.1.0-rc.8",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-storage/-/dsh-storage-0.1.0-rc.8.tgz",
-      "integrity": "sha512-KcxiNFAC1X0GhbS9yWGo7FLARBNsxoyU9JatxQtA23MuqOZaN4Nzy3bsMViK4/snzpPGwm//I+wfUywSjM6uBA==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-storage/-/dsh-storage-0.1.1-rc.1.tgz",
+      "integrity": "sha512-22Hg7hTTbr5fBYRXJ+5O3aBSHHfBLw7jKAPFWjp4HYziG6xXbnIa93QqgaNxz4rdpjTN9ihPP5Rc/zef+HwKOA==",
       "license": "MIT",
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.8"
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-storage-domain": {
-      "version": "0.1.0-rc.8",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-storage-domain/-/dsh-storage-domain-0.1.0-rc.8.tgz",
-      "integrity": "sha512-rHphQ0jveKoCurwh9TX+VAVFsMQivBgghQBOAsWdVDZ3W6boeXNhMZWuGWZ7WjMPD3iJKgiFCx+650hhsao+LQ==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-storage-domain/-/dsh-storage-domain-0.1.1-rc.1.tgz",
+      "integrity": "sha512-7p5qTSxunIQzzKOq1mVIwGh/USHuSuphHEHx3TTu6c+4Iumd6njZ4ijLsw4QrHDUhlGxWaTy9d9Ga/x6Wu4mAA==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1",
@@ -3100,49 +3115,49 @@
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-storage": "^0.1.0-rc.8"
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-storage": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-storage-json": {
-      "version": "0.1.0-rc.8",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-storage-json/-/dsh-storage-json-0.1.0-rc.8.tgz",
-      "integrity": "sha512-cTlqy+5bQH7/UOFqRoWSaY9DaaDpcx4jmvWcwY8ciMUBse8BXcEtchVr5zqqss+xA/+Z/l9VraH+diwwRuAWbg==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-storage-json/-/dsh-storage-json-0.1.1-rc.1.tgz",
+      "integrity": "sha512-MopZ2No4pWKV00BRQjBuGzaphx3YuNxQ4dCKF8ktDkGYdw/SOEjsurl2ejr2YoXUSLTPWpImEquhkOdRWDqAeg==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-storage": "^0.1.0-rc.8"
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-storage": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-subagent": {
-      "version": "0.1.0-rc.8",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-subagent/-/dsh-subagent-0.1.0-rc.8.tgz",
-      "integrity": "sha512-EI94+hYMfAe8BQkkH/FTcciGxajFfAdQe66Jhy2/eyR3dssRAZ+oJsV6SzU20x3m2yd0gmMaXzO1iV3gwYhY+g==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-subagent/-/dsh-subagent-0.1.1-rc.1.tgz",
+      "integrity": "sha512-MhsAoQc0KFvZyNzEsnrWRX1DwMlgPZ6KeTRUPdMwfpqmCcLgNmz36dl2OdiuUr71kbQyeF6HHO06EvrGhH1Qhg==",
       "license": "MIT",
       "dependencies": {
         "zod": "^4.4.3"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-agent-presets": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-brand": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-jobs": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-llm": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-sandbox": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-sandbox-policy": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-scope": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-session": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-session-persistence": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-session-projection": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-session-projection-cache": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-tools": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-user-approval": "^0.1.0-rc.8"
+        "@deepseek-ai/dsh-agent": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-agent-presets": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-brand": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-jobs": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-sandbox": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-sandbox-policy": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-scope": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-session-persistence": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-session-projection": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-session-projection-cache": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-tools": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-user-approval": "^0.1.1-rc.1"
       },
       "peerDependenciesMeta": {
         "@deepseek-ai/dsh-agent-presets": {
@@ -3172,68 +3187,68 @@
       }
     },
     "node_modules/@deepseek-ai/dsh-subagent-fork-in-process": {
-      "version": "0.1.0-rc.8",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-subagent-fork-in-process/-/dsh-subagent-fork-in-process-0.1.0-rc.8.tgz",
-      "integrity": "sha512-CVen9Fu0TwiwuyTHmZeankN/v0EwdMwOAcq8fSTIyFGPG4ngtqQNSRMxwYTrz39kKyHv0VBW+r8tRd1LBdTAWA==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-subagent-fork-in-process/-/dsh-subagent-fork-in-process-0.1.1-rc.1.tgz",
+      "integrity": "sha512-UHuipiCfXPHrdcwy+Ck+2BzzW4l9IH5HsiWDDVrURsIvCaceFq6jWlaR1Fv3/1iylEl8FmOS3u5fHlLrBYo9qQ==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-session": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-subagent": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-subagent-in-process-driver": "^0.1.0-rc.8"
+        "@deepseek-ai/dsh-agent": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-subagent": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-subagent-in-process-driver": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-subagent-in-process-driver": {
-      "version": "0.1.0-rc.8",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-subagent-in-process-driver/-/dsh-subagent-in-process-driver-0.1.0-rc.8.tgz",
-      "integrity": "sha512-UJXwh484V/rEmRrvf5l0IWg2ceVOaSOU7Z6DEBq++bKOuFQ2BVkMm+Uj3dk4qFngeb10+/GXlRkbe3mqPwQDSA==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-subagent-in-process-driver/-/dsh-subagent-in-process-driver-0.1.1-rc.1.tgz",
+      "integrity": "sha512-zp3HCvf8EPz6Ey0tD0d9+q6FeA0eVTvlBo3+N6m21+SrF8fp47Fb6kFgJ9zoBh4vNGXZ7bDZ/LOhYg4TlotBQg==",
       "license": "MIT",
       "peer": true,
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-llm": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-session": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-subagent": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-system-prompt": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-tools": "^0.1.0-rc.8"
+        "@deepseek-ai/dsh-agent": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-subagent": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-tools": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-subagent-spawn-in-process": {
-      "version": "0.1.0-rc.8",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-subagent-spawn-in-process/-/dsh-subagent-spawn-in-process-0.1.0-rc.8.tgz",
-      "integrity": "sha512-+ZratMZJiNg0vDmaEauJpiNI9IzVwCWisbidow6AV8O5CLC9/XlcMTjFGxmxcbnPdNlVM9i8OLK8gY7/kZ7tTA==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-subagent-spawn-in-process/-/dsh-subagent-spawn-in-process-0.1.1-rc.1.tgz",
+      "integrity": "sha512-KPC3gU/gc2Oxh0pdzOL3Y1czTeZLu34jJo0YVaFFToQweiDwCUL/6nBLWq3S7nEiDL73hTG+u2lca1/ShaWg+g==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-subagent": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-subagent-in-process-driver": "^0.1.0-rc.8"
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-subagent": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-subagent-in-process-driver": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-subprocess": {
-      "version": "0.1.0-rc.8",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-subprocess/-/dsh-subprocess-0.1.0-rc.8.tgz",
-      "integrity": "sha512-rTWwWCq/WrBTjaXhApu7gaho6UHwMZq0+l7nZ06YMUreNZoCHfg67pAXopMqTgr/iotphmXQdChrLgBabzL1gA==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-subprocess/-/dsh-subprocess-0.1.1-rc.1.tgz",
+      "integrity": "sha512-SXd/WT2SddMYUhCno518bmOdv6SqH9OX4X/u2uVzgT793UJ1bNtx5UZiTIox3jZFZXeSj+snthuzCiZfnA2j+A==",
       "license": "MIT",
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.8"
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-subprocess-local": {
-      "version": "0.1.0-rc.8",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-subprocess-local/-/dsh-subprocess-local-0.1.0-rc.8.tgz",
-      "integrity": "sha512-2QMd6Nwjd+ARor4g+GSZ3dNyTvEf2IPOje47nQwa3UCmltLxn8K8gjDAN/5sGr/IF56P14FeF4xFag7tMK+Zdg==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-subprocess-local/-/dsh-subprocess-local-0.1.1-rc.1.tgz",
+      "integrity": "sha512-y3omlRw0rE8v9VrSp+QQwzVca7fXp6UbSuW0klsYsC9QxEMx6iOSXsZyu8ZKLwd2hh38uY8GspzB8oTdXqpiHQ==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -3242,104 +3257,104 @@
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-subprocess": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-timeout": "^0.1.0-rc.8"
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-subprocess": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-timeout": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-system-prompt": {
-      "version": "0.1.0-rc.8",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-system-prompt/-/dsh-system-prompt-0.1.0-rc.8.tgz",
-      "integrity": "sha512-yk8Z85rzX2EwpKNWA5i+K3I3mqsIIUc9niwbDpXO8vlHvpC2qR3RNHjJIJN2EZYDqfSzTVtkbxHFsuMzDXIbew==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-system-prompt/-/dsh-system-prompt-0.1.1-rc.1.tgz",
+      "integrity": "sha512-YILPMh2sfwhcK1ijr9ll7TKVQPwhhfrxIFl/Kdi+LIeLiTlOOnt6krpGnlXfzRPu7SzpNnwcetKljKOrHtY2YQ==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-llm": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-scope": "^0.1.0-rc.8"
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-scope": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-terminal": {
-      "version": "0.1.0-rc.8",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-terminal/-/dsh-terminal-0.1.0-rc.8.tgz",
-      "integrity": "sha512-Vu73FrQGx8h7Mqq0QdKtzAiZ3xgVM4fB9wmf3fEl6OiJTcqfc8t4lgug3gE7uBeDVRaLn+aq7kHbEUOY0fsm1Q==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-terminal/-/dsh-terminal-0.1.1-rc.1.tgz",
+      "integrity": "sha512-34Ef13Gt5NG+W+u5Z41tt/TPBNFwMfjXBCy3ySSpZw/8b6KXDs2KwgLtrfBBBOSB9wV8ONtC5DCCEsOvRr+u9A==",
       "license": "MIT",
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-brand": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.8"
+        "@deepseek-ai/dsh-agent": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-brand": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-terminal-bash": {
-      "version": "0.1.0-rc.8",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-terminal-bash/-/dsh-terminal-bash-0.1.0-rc.8.tgz",
-      "integrity": "sha512-ehBMVr/0kZ15Vud7uE6PLobukwJi/BqGDbI1oonPPTOoTjDvuCqlKotNEQtS/G4NsvGshEABv+m5X5ELcRCWUA==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-terminal-bash/-/dsh-terminal-bash-0.1.1-rc.1.tgz",
+      "integrity": "sha512-m9ADv/ZAMI1uubj3zihD1G67Ql2pzrc5HeOUPx32Iwq8autKqj5/Jef8QnbUgQsqNAlLHodhuLroTJbKPv42+A==",
       "license": "MIT",
       "dependencies": {
-        "@deepseek-ai/dsh-pwsh-local": "^0.1.0-rc.8",
+        "@deepseek-ai/dsh-pwsh-local": "^0.1.1-rc.1",
         "@deepseek-ai/schemastery": "^3.18.1"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-sandbox": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-sandbox-policy": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-session": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-subprocess": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-terminal": "^0.1.0-rc.8"
+        "@deepseek-ai/dsh-agent": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-sandbox": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-sandbox-policy": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-subprocess": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-terminal": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-time-context": {
-      "version": "0.1.0-rc.8",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-time-context/-/dsh-time-context-0.1.0-rc.8.tgz",
-      "integrity": "sha512-9Rdse95S6Uk8OAHf78AQN/pxV6+29fCkIbF4ONP/F/6YBciKDORypRyMbHNSY81fBMHQPhW1xvZecGISdIHHiQ==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-time-context/-/dsh-time-context-0.1.1-rc.1.tgz",
+      "integrity": "sha512-MIk6ID6LDDaP0NstVY0D36+qIzB1X35fC85PXsTr/b8g9ccu4GVod6ohunnhD6RcHQ76qHtVcKhtu+AoiFpebQ==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-session": "^0.1.0-rc.8"
+        "@deepseek-ai/dsh-agent": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-timeout": {
-      "version": "0.1.0-rc.8",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-timeout/-/dsh-timeout-0.1.0-rc.8.tgz",
-      "integrity": "sha512-RwOC/qHribE6b+LStAO7aAgweefLE5sqDO7Uz6/mnTDyJxCt7HNQnE/Op8sAvRa33d752aUkPfO9S0mgzVAoFQ==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-timeout/-/dsh-timeout-0.1.1-rc.1.tgz",
+      "integrity": "sha512-9JURjw8lFbSAQogQiN7KvNAJc7WdUMdrj1PkcZEs3y0rMuTb4Z0+l0QS628+BzmKzB2ndZs8QO8VJSMTSdpaIQ==",
       "license": "MIT",
       "peer": true,
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.8"
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-tmux-context": {
-      "version": "0.1.0-rc.8",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tmux-context/-/dsh-tmux-context-0.1.0-rc.8.tgz",
-      "integrity": "sha512-ezhL3Wjpn4TqqvgSuKrJgNVG7jrWGekEWRYimqD1SvmAHQAS+Xr9q7DBl1uSFfJDWUOAPlAB8VAuo3k/CLUwKA==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tmux-context/-/dsh-tmux-context-0.1.1-rc.1.tgz",
+      "integrity": "sha512-KvAviVyFybH1Gh08PLBDMV2VFUqVy1Pf1w8I8tI/EyiuHiZ3R8WXfYs4qp/oGN+n/atCHmJwkicR67xpG3LHFQ==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-session": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-shell": "^0.1.0-rc.8"
+        "@deepseek-ai/dsh-agent": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-shell": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-token-meter": {
-      "version": "0.1.0-rc.8",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-token-meter/-/dsh-token-meter-0.1.0-rc.8.tgz",
-      "integrity": "sha512-ZcS6vuuJhoqjUrbyROuiiYk4nrvChkkYEfIoj7CjGbNArWOhbStmBaiPyahtcB1kThcnUKdu7vv7DaZJdLw8Lg==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-token-meter/-/dsh-token-meter-0.1.1-rc.1.tgz",
+      "integrity": "sha512-P5CIwXRbGUO8AquJIuoZaLlBY7NZ/OqGM7BRM9Qps+vNaC3lmwa/Dq/I+fhmckXjPMYLA20X4kVVn/SDUG422Q==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1",
@@ -3347,100 +3362,100 @@
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-compaction": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-llm": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-session": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-session-projection": "^0.1.0-rc.8"
+        "@deepseek-ai/dsh-compaction": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-session-projection": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-tool-ask-user": {
-      "version": "0.1.0-rc.8",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tool-ask-user/-/dsh-tool-ask-user-0.1.0-rc.8.tgz",
-      "integrity": "sha512-PQVcuvNvTI18B2jSvgS20wX0GRnpom+6X6iNBL/WPLiicJeoxvDYj+M7SjdSsqBNv5t0i9VlYhO4NYicmluy+g==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tool-ask-user/-/dsh-tool-ask-user-0.1.1-rc.1.tgz",
+      "integrity": "sha512-MUXpZ6BYy/rAY8Yp+NXXwbH9Cxlria4GGq+nbnYaTHpc8xM76X1hpp3n2iOzV/ef9V+IDCWmW3Z3gnljbDFWRw==",
       "license": "MIT",
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-tools": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-user-questions": "^0.1.0-rc.8"
+        "@deepseek-ai/dsh-agent": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-tools": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-user-questions": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-tool-bash": {
-      "version": "0.1.0-rc.8",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tool-bash/-/dsh-tool-bash-0.1.0-rc.8.tgz",
-      "integrity": "sha512-VvP8Ky8ifqS7Iy7XUxc6cWB7sse3X6gqr92m0hBuodwQblzrZq2b6IyzfTzXKZKLqt5mMUaLRt7IPIDOOG+WEQ==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tool-bash/-/dsh-tool-bash-0.1.1-rc.1.tgz",
+      "integrity": "sha512-e083Qn7V8oESrvMU+7oC7wpj16PgU8/fXErgEsSyxFIY8e5qU/+K1jWX1B2SvVS/bpE7+nm3Lq2jNDFpXZ6+Sw==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-jobs": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-llm": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-sandbox": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-sandbox-policy": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-shell": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-shell-env": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-system-prompt": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-tools": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-user-approval": "^0.1.0-rc.8"
+        "@deepseek-ai/dsh-agent": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-jobs": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-sandbox": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-sandbox-policy": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-shell": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-shell-env": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-tools": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-user-approval": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-tool-bash-persistent": {
-      "version": "0.1.0-rc.8",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tool-bash-persistent/-/dsh-tool-bash-persistent-0.1.0-rc.8.tgz",
-      "integrity": "sha512-GySj2Nr7y4ewYTH0miD5DzfLEZNxAmWfSyJ5oOYVtzIbqkcU5WOjpsjQvDg0kuERXAq4MYcdc2QfrPet1/MkIQ==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tool-bash-persistent/-/dsh-tool-bash-persistent-0.1.1-rc.1.tgz",
+      "integrity": "sha512-nbEyHaldIFH0XSZwGGqTL5TC9Rw8EsdN/Yy3ONxu4Leo6evMP0FhwND2zOD2ORTrp5R2lqLaLWcz2c3RZWF8Nw==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-terminal": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-timeout": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-tools": "^0.1.0-rc.8"
+        "@deepseek-ai/dsh-agent": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-terminal": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-timeout": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-tools": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-tool-call-timeout-policy": {
-      "version": "0.1.0-rc.8",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tool-call-timeout-policy/-/dsh-tool-call-timeout-policy-0.1.0-rc.8.tgz",
-      "integrity": "sha512-Z6M/nkcz40DisaOIHqUOjjjW4wCi+JqQNoUhOu+VAoBDWHl7SDmEvdWSQUwkyOETjcfdRSG4RTJ5z/rBUVCPHQ==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tool-call-timeout-policy/-/dsh-tool-call-timeout-policy-0.1.1-rc.1.tgz",
+      "integrity": "sha512-lAd+eRth7mhr/SRb8CFz9OhS5arF3VQgnrWxfeftE+oofytj8juiwppSBXPfjl1lP6a2D5jVsQ0G6pd3pdZCXQ==",
       "license": "MIT",
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-llm": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-timeout": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-tools": "^0.1.0-rc.8"
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-timeout": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-tools": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-tool-cordis": {
-      "version": "0.1.0-rc.8",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tool-cordis/-/dsh-tool-cordis-0.1.0-rc.8.tgz",
-      "integrity": "sha512-bIbkazp5xasqtJBFljOGVIdxyAAWIcKoxMuhDoUpfPFuEqZaXJumYJJ9+ugqr+KKkddjuf2SvlpE5XB4zWcNvg==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tool-cordis/-/dsh-tool-cordis-0.1.1-rc.1.tgz",
+      "integrity": "sha512-NvBKLiR/mqLP+pLulayPH8t1bmOYFGoUGUR/V5hUP4GjUpS7sCrR+PH519N0lSRgxghx9Q1YrvC05M2wcfV5vQ==",
       "license": "MIT",
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-cordis-host-runner": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-llm": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-scope": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-session": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-system-prompt": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-tools": "^0.1.0-rc.8"
+        "@deepseek-ai/dsh-agent": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-cordis-host-runner": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-scope": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-tools": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-tool-fs": {
-      "version": "0.1.0-rc.8",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tool-fs/-/dsh-tool-fs-0.1.0-rc.8.tgz",
-      "integrity": "sha512-pxo2YfVlqcw0sCA2+4DtqaaYsuxkx1QfvjT3VO+ckZMWn/UnGOUuzjJtKhVynwjm8prttGqK2LBXUTBZPlKTWg==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tool-fs/-/dsh-tool-fs-0.1.1-rc.1.tgz",
+      "integrity": "sha512-T9teZZdjshbc/J+nsQV7o6Jdp+q/A8tYSx3FHP5BbN14T8tlyd9F7FWccicyNe4uni3e6ZlUfXjE3Qx6c1epGA==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1",
@@ -3448,22 +3463,22 @@
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-attachment": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-fs": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-llm": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-sandbox": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-sandbox-policy": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-session": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-system-prompt": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-tools": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-user-approval": "^0.1.0-rc.8"
+        "@deepseek-ai/dsh-attachment": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-fs": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-sandbox": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-sandbox-policy": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-tools": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-user-approval": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-tool-fs-search": {
-      "version": "0.1.0-rc.8",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tool-fs-search/-/dsh-tool-fs-search-0.1.0-rc.8.tgz",
-      "integrity": "sha512-AZvESByrPbBIYIGDoTgVOHH48antHy2ZSaLfsVfz1Rw/jQIeiBKwt2LYIPhRGGvev6TXw95qWKt5cyv6WDXHlg==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tool-fs-search/-/dsh-tool-fs-search-0.1.1-rc.1.tgz",
+      "integrity": "sha512-aMSfkvvrvXI7uLcLb06J+WR+ZjdAD7ROswC3g/l4lpMV7h8WuRcEp5uCpdxuMrgQ6bqNrpDD5QT/KDU8d7VE3A==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1",
@@ -3471,202 +3486,202 @@
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-llm": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-output-retention": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-session": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-spill": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-subprocess": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-system-prompt": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-timeout": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-tools": "^0.1.0-rc.8"
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-output-retention": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-spill": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-subprocess": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-timeout": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-tools": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-tool-goal": {
-      "version": "0.1.0-rc.8",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tool-goal/-/dsh-tool-goal-0.1.0-rc.8.tgz",
-      "integrity": "sha512-EO8iqRV3R8YgdMGUVAp/20XCKbegdwZ7fqr7+oSg11lGHuTnXDz4im4HBXri/wmL9XHeBjmcAQ0BXESbhX2VOQ==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tool-goal/-/dsh-tool-goal-0.1.1-rc.1.tgz",
+      "integrity": "sha512-3SRUmWx3Q7TYlg3ySDiWII58Df6RivxkF2OHQUxJRpjHboJJsoO2YwOAFFoaNij92OHvXKhB914w/FKbIVqz4Q==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-goal": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-llm": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-session": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-system-prompt": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-tools": "^0.1.0-rc.8"
+        "@deepseek-ai/dsh-agent": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-goal": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-tools": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-tool-jobs": {
-      "version": "0.1.0-rc.8",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tool-jobs/-/dsh-tool-jobs-0.1.0-rc.8.tgz",
-      "integrity": "sha512-p3gWi38ryJFRes1lTAdVkdZrUBB8RYPpy4XqZ9DgC2qcrLOJZnnsprIUxyDDmhbyargOgTGc3hEeRU5g8OQAIA==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tool-jobs/-/dsh-tool-jobs-0.1.1-rc.1.tgz",
+      "integrity": "sha512-yW+4977eNR/ZjYlEMhA2XgY6pFR+Rj8DBoZV4bG+NKWGWXec2gxML4UzdC/EVg5qJ/b08P07/3MpdjfEBCs6Uw==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-jobs": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-llm": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-output-retention": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-system-prompt": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-tools": "^0.1.0-rc.8"
+        "@deepseek-ai/dsh-agent": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-jobs": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-output-retention": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-tools": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-tool-pwsh": {
-      "version": "0.1.0-rc.8",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tool-pwsh/-/dsh-tool-pwsh-0.1.0-rc.8.tgz",
-      "integrity": "sha512-B5F08tsSD7DHqXDXjn/Q11FavHw1U8/WAEqp8AC47vDRymPJIgTM8zSlJ0Lx7aZaKPTW4zQYtSmwUhy93q6zfw==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tool-pwsh/-/dsh-tool-pwsh-0.1.1-rc.1.tgz",
+      "integrity": "sha512-dyKAw1z960cfqIMaZwXSCDY4LIZ9w7RlWxBcanVtCNXUzqac8qCVvYNoXGnJ5u9KTjdfYyxp9uAmlvdQIoe9eA==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-jobs": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-llm": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-sandbox": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-sandbox-policy": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-shell": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-shell-env": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-system-prompt": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-tools": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-user-approval": "^0.1.0-rc.8"
+        "@deepseek-ai/dsh-agent": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-jobs": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-sandbox": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-sandbox-policy": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-shell": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-shell-env": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-tools": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-user-approval": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-tool-pwsh-persistent": {
-      "version": "0.1.0-rc.8",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tool-pwsh-persistent/-/dsh-tool-pwsh-persistent-0.1.0-rc.8.tgz",
-      "integrity": "sha512-OxQhywkvUTuGj26yaE1LyoADsCKttaIdiq2dJd+Xcbjc+tnI1gfoVrBj+Sta3/uT7x66kKjXZ1+gnw6gK5qISQ==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tool-pwsh-persistent/-/dsh-tool-pwsh-persistent-0.1.1-rc.1.tgz",
+      "integrity": "sha512-9+LWvtD5fucgNF2QzJJgFFcBHa/hvtQvPqGy+N31w2BE2lXogtFZBwWRdfH1L4Fye3F0+37l88xs3coZY4RONA==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-terminal": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-timeout": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-tools": "^0.1.0-rc.8"
+        "@deepseek-ai/dsh-agent": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-terminal": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-timeout": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-tools": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-tool-ralph": {
-      "version": "0.1.0-rc.8",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tool-ralph/-/dsh-tool-ralph-0.1.0-rc.8.tgz",
-      "integrity": "sha512-+kVCbLEBDxOCCHPdR5+hgQFbkTvTaJ3D7zTNxNEtS5Tr/7eGAU7/VmwNMMSZ4Z+eyHQQEm4vgT+O1pMTvLmb7g==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tool-ralph/-/dsh-tool-ralph-0.1.1-rc.1.tgz",
+      "integrity": "sha512-qJMzBfmljqpm1BiedNwdfBnuvWH3+5N2duC/x1hGA3IodHQ1Rc03hVtWJnbB6GYctshJbLRft7yLnNTO6ghgNw==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-llm": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-subagent": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-system-prompt": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-tools": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-workflow": "^0.1.0-rc.8"
+        "@deepseek-ai/dsh-agent": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-subagent": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-tools": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-workflow": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-tool-skill": {
-      "version": "0.1.0-rc.8",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tool-skill/-/dsh-tool-skill-0.1.0-rc.8.tgz",
-      "integrity": "sha512-oQAPyXiQDDZ73rZwST7KqwUAr0Al3U1dxWdtzETsMzvNSQE9fmMBz5jUObFIEjxxJcA07Pp1DFzuJdpkCIDeCw==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tool-skill/-/dsh-tool-skill-0.1.1-rc.1.tgz",
+      "integrity": "sha512-1VDrgqj3I+I+LmqD+B1RTb0zU7uZuajjPmczCNQAV0zuLjTIbwiHne7G4gIxm5CE7uXlxsSzZnF7ZSuYKF1m/A==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-llm": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-skill": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-tools": "^0.1.0-rc.8"
+        "@deepseek-ai/dsh-agent": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-skill": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-tools": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-tool-str-replace-editor": {
-      "version": "0.1.0-rc.8",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tool-str-replace-editor/-/dsh-tool-str-replace-editor-0.1.0-rc.8.tgz",
-      "integrity": "sha512-2gyO5a5xNvBo9I5vmVSvgXRfxUfKGDu3WjjdK0aDWx/Y+C1r1mGVC7R5mN/oJstcUCIyKm483ux1pT9/O1QD8w==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tool-str-replace-editor/-/dsh-tool-str-replace-editor-0.1.1-rc.1.tgz",
+      "integrity": "sha512-4P4SKqMUeEq39Dcw7oXenIMKlkyp3lwvchnmP9shf/fRAs5nAxDPMja4Wb7sEXQkVaBF9pUUp7GZPhfqhFIGWQ==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-fs": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-sandbox": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-sandbox-policy": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-tools": "^0.1.0-rc.8"
+        "@deepseek-ai/dsh-fs": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-sandbox": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-sandbox-policy": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-tools": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-tool-subagent": {
-      "version": "0.1.0-rc.8",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tool-subagent/-/dsh-tool-subagent-0.1.0-rc.8.tgz",
-      "integrity": "sha512-mwNV8M7hsy9+OsSFCluv87FiDHaXO91m83xF/o34Ip9xrgkGs7LOCjvUdCpwjxFTJenWEcvEU90aa7vv3aT/Iw==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tool-subagent/-/dsh-tool-subagent-0.1.1-rc.1.tgz",
+      "integrity": "sha512-N2FSHL+IsjBUTKsOeVuu4IrERuLJ32h8Zp5TWWQ7ONy+yISnFZqkmGrx6BB55HsnM4OM1fzVcBME7+tVqQ1tdg==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-jobs": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-llm": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-subagent": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-system-prompt": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-tools": "^0.1.0-rc.8"
+        "@deepseek-ai/dsh-agent": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-jobs": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-subagent": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-tools": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-tool-subagent-control": {
-      "version": "0.1.0-rc.8",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tool-subagent-control/-/dsh-tool-subagent-control-0.1.0-rc.8.tgz",
-      "integrity": "sha512-zXF9iIzr96w/S3jNxkRcyV1ouwA1eUCSmvqhlSDkkcA8RH5jt5vWkTia8fwRs1pFS9m7OpbLtvbDxjC8D3nedw==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tool-subagent-control/-/dsh-tool-subagent-control-0.1.1-rc.1.tgz",
+      "integrity": "sha512-3Y4G1s4ebdAwln41Jike3Rnp4k4d/v47PQVFlk9hVJvbrt2C6LGLM1Id2C4+30Hi6JPE4EaO3wIutkX5ar4aLw==",
       "license": "MIT",
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-llm": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-session": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-subagent": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-tools": "^0.1.0-rc.8"
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-subagent": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-tools": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-tool-subagent-report": {
-      "version": "0.1.0-rc.8",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tool-subagent-report/-/dsh-tool-subagent-report-0.1.0-rc.8.tgz",
-      "integrity": "sha512-u0CzoSu7O1YyOpGyHfmT/P2hCfnepSzVKrs6MHFrzjbuiRFEcVme6/iLrc7QdLtg484Q1kcnqG2z0OZS24AnWQ==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tool-subagent-report/-/dsh-tool-subagent-report-0.1.1-rc.1.tgz",
+      "integrity": "sha512-TbtTJEZcE0K3UU7tbkgpTy3T6bJrn3SGyzpSiguiPkqYSh2i3qi4kHKMgI2fH5NlmznyKI2EmWb9Tjw53zxgQw==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-llm": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-subagent": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-system-prompt": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-tools": "^0.1.0-rc.8"
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-subagent": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-tools": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-tool-todo": {
-      "version": "0.1.0-rc.8",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tool-todo/-/dsh-tool-todo-0.1.0-rc.8.tgz",
-      "integrity": "sha512-eWxwTeX5WsQPSsz1qyJq+UMiASYB5UHLdObVd4vFLYKbFOoglUK0X+Ie5OjlAkFTP+OzCQMAzUl2gJMwJPWKig==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tool-todo/-/dsh-tool-todo-0.1.1-rc.1.tgz",
+      "integrity": "sha512-j3gZX+p1vJYrJpPFaXiyYSEQf8rpWbQ7sNJASRCFR2Q3a3rGHXrcFVr4A7WXH7zgIHwcNKK4FHv7aDAk2JuMrQ==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1",
@@ -3674,17 +3689,17 @@
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-session": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-session-projection": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-tools": "^0.1.0-rc.8"
+        "@deepseek-ai/dsh-agent": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-session-projection": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-tools": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-tool-web": {
-      "version": "0.1.0-rc.8",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tool-web/-/dsh-tool-web-0.1.0-rc.8.tgz",
-      "integrity": "sha512-MrTkQ2L52A13ysTM94bSW+5sXq3AyVNoo5q3bK47bsl+hg9Kga5gDgGAZ+SGVSQZAUEHXfuYGHaErdUp50bncw==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tool-web/-/dsh-tool-web-0.1.1-rc.1.tgz",
+      "integrity": "sha512-d3/9NJQc2Vcv4m6Q94POCRZ0conqjAeqUobNwIpMiWrSL4U8jZYzXwFVBw0Sw+cwYVBi2Og5Vv9aJmWANTX3Mw==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1",
@@ -3693,56 +3708,56 @@
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-llm": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-system-prompt": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-tools": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-web": "^0.1.0-rc.8"
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-tools": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-web": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-tool-workflow": {
-      "version": "0.1.0-rc.8",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tool-workflow/-/dsh-tool-workflow-0.1.0-rc.8.tgz",
-      "integrity": "sha512-Z3MCCLM28J/nqiqwHG9roGVUzwMKEADRsSNLPYNemXq5vVEYjm5sBwC+QcWtiQ7NxKXf5ViUu3eKXTe1Fh5TNg==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tool-workflow/-/dsh-tool-workflow-0.1.1-rc.1.tgz",
+      "integrity": "sha512-KS7BF1W6fGFgatMQ7daCRxSDH3zG14ob3s2b0Qzb0chZAIbxVe/DcQi2xTcK0MpXr77RKikdHUgU6n/+arC+pw==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-llm": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-session": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-system-prompt": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-tools": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-workflow": "^0.1.0-rc.8"
+        "@deepseek-ai/dsh-agent": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-tools": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-workflow": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-tools": {
-      "version": "0.1.0-rc.8",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tools/-/dsh-tools-0.1.0-rc.8.tgz",
-      "integrity": "sha512-tvuGAVUS4yoPW9zH7CGWJgMlAzGjfu2UlRiricldlcwSKAaJZPZx/K/YfTivUyDTER6aK1DJUnIpVG7RD/DoHQ==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tools/-/dsh-tools-0.1.1-rc.1.tgz",
+      "integrity": "sha512-vvb7G/DR/guhL1B5pMRdmi44YQedeefp02Q6pkHS+MgjNl8N//CZFCPSxSX9kX/a8R5/tDQZxxGsZdj6vcC6zA==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-code-runtime": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-llm": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-scope": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-session": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-system-prompt": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-user-approval": "^0.1.0-rc.8"
+        "@deepseek-ai/dsh-agent": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-code-runtime": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-scope": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-user-approval": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-typert-loader": {
-      "version": "0.1.0-rc.8",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-typert-loader/-/dsh-typert-loader-0.1.0-rc.8.tgz",
-      "integrity": "sha512-IB2Bkv7UglS0y/Dt7buFq87bbUkD/njvuCp4/bRxlbb/8U02b7v18UXnYFoZjCusfzeYxaCBZihImv7aDMBhCA==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-typert-loader/-/dsh-typert-loader-0.1.1-rc.1.tgz",
+      "integrity": "sha512-8NKYGmopkroNhPtMbTc1Xdx5twz8VxlV1fVie22LgxmS5c8eP2Q5DQc8jV5A/5tePYchsC+FpeNSPMKUgzkO4Q==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1"
@@ -3750,151 +3765,151 @@
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
         "@deepseek-ai/cordis-plugin-loader": "^1.0.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-typert-registry": "^0.1.0-rc.8"
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-typert-registry": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-typert-protocol": {
-      "version": "0.1.0-rc.8",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-typert-protocol/-/dsh-typert-protocol-0.1.0-rc.8.tgz",
-      "integrity": "sha512-scwEAefRBL7gRpaXiEdiHRMvlr8dLmUbiEvy0LOAX/8X3FZBd/5tHQ/8lCppAQNTDZMI/LSiSMpu5XrFId+7cQ==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-typert-protocol/-/dsh-typert-protocol-0.1.1-rc.1.tgz",
+      "integrity": "sha512-bdPYdYDNYgTGgEkHCIEB/QUUTXo0r5hkEyWlh+v95Qe34B0ZO3KhYTPSPaoYDwP0kEaOwtmmxNGZd8HFJ8VQnA==",
       "license": "MIT",
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.8"
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-typert-registry": {
-      "version": "0.1.0-rc.8",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-typert-registry/-/dsh-typert-registry-0.1.0-rc.8.tgz",
-      "integrity": "sha512-pxfRE5f1y81h2lNqj0uooYrErTVgpzKfYm4W+ppRafN5s/+1jlLIYWiG3wWD3bnxyoD2NLcTEhi/GXoaqiwdaw==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-typert-registry/-/dsh-typert-registry-0.1.1-rc.1.tgz",
+      "integrity": "sha512-9kavDx4n2dxtDNU8uPpoaB604uVBST2aA0TvcR5d+GTA7/vFgqmT2JjQv5PG+GwM+JAO08MsP2ldWMB+FPo/Zg==",
       "license": "MIT",
       "dependencies": {
-        "@deepseek-ai/dsh-typert-protocol": "^0.1.0-rc.8",
+        "@deepseek-ai/dsh-typert-protocol": "^0.1.1-rc.1",
         "zod": "^4.4.3"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.8"
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-user-approval": {
-      "version": "0.1.0-rc.8",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-user-approval/-/dsh-user-approval-0.1.0-rc.8.tgz",
-      "integrity": "sha512-6SFCxp7dgNFEyzQIcs5i9C+5djgXsAeV0iKmZUCLlcIeVM1chcCMHyGcoXlw8yyB14qFMrMs+TPvhvpu2WWxAw==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-user-approval/-/dsh-user-approval-0.1.1-rc.1.tgz",
+      "integrity": "sha512-r2TkC0JJGQ8EOyTH8DXafbcj080NdNbVzoNERA1pRTrH7+ZE0PHU6MZU7xGy7cwAKmAUGnm1DjF8UHOQN6ns2Q==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-brand": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-llm": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-scope": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-session": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-system-prompt": "^0.1.0-rc.8"
+        "@deepseek-ai/dsh-agent": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-brand": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-scope": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-user-questions": {
-      "version": "0.1.0-rc.8",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-user-questions/-/dsh-user-questions-0.1.0-rc.8.tgz",
-      "integrity": "sha512-kiOAlpKKfB89iObWiiVpueD4XCaday203LGUs7+eGb2isolY6VppoGb7ZmcJQqsW63bjbAA7wZeJuN3CoxcvSQ==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-user-questions/-/dsh-user-questions-0.1.1-rc.1.tgz",
+      "integrity": "sha512-q5RZczXTNzSC/fas+qIno5jCqH/jotz0OpBzRCTNMPV1ID4YcGroaUKsLxzaGXP5bbiaVlX5Tqt5FUYO6rYStQ==",
       "license": "MIT",
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-llm": "^0.1.0-rc.8"
+        "@deepseek-ai/dsh-agent": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-web": {
-      "version": "0.1.0-rc.8",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-web/-/dsh-web-0.1.0-rc.8.tgz",
-      "integrity": "sha512-YLraDwZTx0Y3Jqw2cu4eClv9ZgEJYoeSFzTe7c9JZ4Z3ThaNCCwEaXWEPMBiPKU6QlR8ahkPPj6xoU9+nPO66g==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-web/-/dsh-web-0.1.1-rc.1.tgz",
+      "integrity": "sha512-fYJ3epKwpY0zO61a9SshY/gKmrcfP7N9EX7/VUGWdpE89jKg52LkioZ5QQ2cKYatbPUHLWx3H+llCGmqOf4bAA==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-llm": "^0.1.0-rc.8"
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-web-app": {
-      "version": "0.1.0-rc.8",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-web-app/-/dsh-web-app-0.1.0-rc.8.tgz",
-      "integrity": "sha512-Te/N+AxFmQF2267yMqama5Lp2evsBJeFsqhnEZPfvFhquLBBWgtO5DNZ2cxto5NhGGNNCk/JV25vHRxd7bZl8g==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-web-app/-/dsh-web-app-0.1.1-rc.1.tgz",
+      "integrity": "sha512-qV0Djh/9lhdBMlkwry8x3Fu3pckiNur8OiQN8cIRvGqyDrJ3yWBjJYga491OeFEmCw/QF9DbfKgmU/O8r4gzlg==",
       "license": "MIT",
       "dependencies": {
-        "@deepseek-ai/dsh-agent-presets": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-api-remotes": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-app-boot": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-client-connection": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-client-hmr": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-client-locale": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-client-modules": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-client-runtime": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-client-ui-agent-preset": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-client-ui-attachment": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-client-ui-brand-official": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-client-ui-commands": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-client-ui-conversation": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-client-ui-cordis": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-client-ui-deliverables": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-client-ui-directory-picker-browse": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-client-ui-directory-picker-native": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-client-ui-goal": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-client-ui-input-trigger": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-client-ui-jobs": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-client-ui-layout": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-client-ui-message-feedback": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-client-ui-model-selection": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-client-ui-permission-presets": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-client-ui-plan": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-client-ui-reference": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-client-ui-renderer": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-client-ui-settings": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-client-ui-settings-general": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-client-ui-settings-models": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-client-ui-settings-plugin-inventory": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-client-ui-settings-plugins": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-client-ui-sidebar": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-client-ui-skill": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-client-ui-subagent": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-client-ui-theme": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-client-ui-tool": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-client-ui-trajectory": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-client-ui-user-questions": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-client-ui-workflow-run": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-client-ui-workspace": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-cmdline": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-code-runtime-worker-thread": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-cordis-client-runner": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-cordis-host-runner": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-file-reference": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-file-reference-local": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-host-apiproxy": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-host-directory-picker-auto": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-host-directory-picker-browse": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-host-directory-picker-native": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-host-frontend-static": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-host-plugin-inventory": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-host-webserver": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-launch-environment": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-message-feedback": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-session-log-export": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-session-projection-cache": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-session-reference": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-session-stats": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-storage": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-storage-domain": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-storage-json": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-subprocess": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-web-frontend": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-workspace": "^0.1.0-rc.8",
+        "@deepseek-ai/dsh-agent-presets": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-api-remotes": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-app-boot": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-connection": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-hmr": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-locale": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-modules": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-runtime": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-ui-agent-preset": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-ui-attachment": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-ui-brand-official": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-ui-commands": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-ui-conversation": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-ui-cordis": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-ui-deliverables": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-ui-directory-picker-browse": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-ui-directory-picker-native": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-ui-goal": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-ui-input-trigger": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-ui-jobs": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-ui-layout": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-ui-message-feedback": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-ui-model-selection": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-ui-permission-presets": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-ui-plan": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-ui-reference": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-ui-renderer": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-ui-settings": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-ui-settings-general": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-ui-settings-models": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-ui-settings-plugin-inventory": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-ui-settings-plugins": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-ui-sidebar": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-ui-skill": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-ui-subagent": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-ui-theme": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-ui-tool": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-ui-trajectory": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-ui-user-questions": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-ui-workflow-run": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-ui-workspace": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-cmdline": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-code-runtime-worker-thread": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-cordis-client-runner": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-cordis-host-runner": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-file-reference": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-file-reference-local": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-host-apiproxy": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-host-directory-picker-auto": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-host-directory-picker-browse": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-host-directory-picker-native": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-host-frontend-static": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-host-plugin-inventory": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-host-webserver": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-launch-environment": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-message-feedback": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-session-log-export": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-session-projection-cache": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-session-reference": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-session-stats": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-storage": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-storage-domain": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-storage-json": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-subprocess": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-web-frontend": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-workspace": "^0.1.1-rc.1",
         "@deepseek-ai/schemastery": "^3.18.1",
         "commander": "^15.0.0",
         "open": "^11.0.0"
@@ -3902,87 +3917,87 @@
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
         "@deepseek-ai/cordis-plugin-loader": "^1.0.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-shell-env": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-system-prompt": "^0.1.0-rc.8"
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-shell-env": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-web-frontend": {
-      "version": "0.1.0-rc.8",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-web-frontend/-/dsh-web-frontend-0.1.0-rc.8.tgz",
-      "integrity": "sha512-GxWJtkNEniYtSH19XWIJvMO2RSP2bMAZvs3Z6m9cEr9OFbngCY5XCXwqsJMYqOJIao0eSePp/eRCPeXNvqeGXA==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-web-frontend/-/dsh-web-frontend-0.1.1-rc.1.tgz",
+      "integrity": "sha512-LxKEcBy6npgLXqrg1utA4/OZocXrx1tTQaIK1VH1l2vNs0vN6fOKSMpbvbUB0mW0RKxXmHg8NfJ4JkdliMtIsw==",
       "license": "MIT"
     },
     "node_modules/@deepseek-ai/dsh-web-search-deepseek": {
-      "version": "0.1.0-rc.8",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-web-search-deepseek/-/dsh-web-search-deepseek-0.1.0-rc.8.tgz",
-      "integrity": "sha512-ifaFw+Cil3yte/9r//3wwMWWPIMuYhvYAB0Hk56IVf+8RDbnRkTJY2foFNNgD91dq1ZL2gBijkdxv1c7wDt+EA==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-web-search-deepseek/-/dsh-web-search-deepseek-0.1.1-rc.1.tgz",
+      "integrity": "sha512-3iQHtGsPYEi0r2Zd34XO+FayTPrE9PfPpwnHSdvKy0MdfGqjEvJyujh0V4X9tA8EhW1eGXzoOXIIKzVOxxdmTw==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-credentials": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-launch-environment": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-session": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-settings": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-web": "^0.1.0-rc.8"
+        "@deepseek-ai/dsh-agent": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-credentials": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-launch-environment": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-settings": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-web": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-workflow": {
-      "version": "0.1.0-rc.8",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-workflow/-/dsh-workflow-0.1.0-rc.8.tgz",
-      "integrity": "sha512-a4UJKJAFOPQgVaWegk8MIh8BQjqerkGhHu2+uGF4wyGanzI7FHHY/OUmH4hHTVEx2qFcWh732Od/T8LgL6gcbg==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-workflow/-/dsh-workflow-0.1.1-rc.1.tgz",
+      "integrity": "sha512-Q7Vq+oqklhlM9XeQp+LmOZDWXCvxSQHdFjY1p5DxUOgJgLCcoNe+0QsOwH7VHm99ZfTtGisH/t7oWx+m7fbcHA==",
       "license": "MIT",
       "peer": true,
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-brand": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-llm": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-session": "^0.1.0-rc.8"
+        "@deepseek-ai/dsh-agent": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-brand": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-workflow-worker-thread": {
-      "version": "0.1.0-rc.8",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-workflow-worker-thread/-/dsh-workflow-worker-thread-0.1.0-rc.8.tgz",
-      "integrity": "sha512-QBkHJ8l174U3VqHRi2KyJIFey+Uxzo/OOFbTFx7TP5f761lPvqYiXlILuQJ9QvT7WJTyZO3QRLIIU6ZEBwxTIA==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-workflow-worker-thread/-/dsh-workflow-worker-thread-0.1.1-rc.1.tgz",
+      "integrity": "sha512-i569BFPdkc7OU/kfcJvRH59GGz9wXmUR5pc6pPVZLNkpPvaqiOgThnK3D4wSfq9SkxuzK4026IwITsUJF2poig==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-brand": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-llm": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-session": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-subagent": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-tools": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-workflow": "^0.1.0-rc.8"
+        "@deepseek-ai/dsh-agent": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-brand": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-subagent": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-tools": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-workflow": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-workspace": {
-      "version": "0.1.0-rc.8",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-workspace/-/dsh-workspace-0.1.0-rc.8.tgz",
-      "integrity": "sha512-Uyw44WcYvXRQjb0kUstTEJmL83hkGQbWnJzglaGWcAvsZBjQHeBgKuLzOZin1yc/dRX2pKuk1InFwxKXpaHjBA==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-workspace/-/dsh-workspace-0.1.1-rc.1.tgz",
+      "integrity": "sha512-rdw8ovh2C3DlE1UyQUUFv+U5b0JoNveypWlldslEjkwLQTO8zKeZE0HGPEGnIwHPz3wYOr/jQKe+mbKnFQ94nQ==",
       "license": "MIT",
       "dependencies": {
         "zod": "^4.4.3"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-brand": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-session": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-session-persistence": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-storage": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-storage-domain": "^0.1.0-rc.8"
+        "@deepseek-ai/dsh-brand": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-session-persistence": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-storage": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-storage-domain": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/node-addon-landlock-run": {

--- a/runtime/package.json
+++ b/runtime/package.json
@@ -4,7 +4,7 @@
   "version": "0.1.0",
   "description": "Bundled DeepSeek Harness runtime for the desktop packaging. Pin exactly; upgrades happen only through prepare-harness + CI smoke.",
   "dependencies": {
-    "@deepseek-ai/dsh": "0.1.0-rc.8",
+    "@deepseek-ai/dsh": "0.1.1-rc.1",
     "pnpm": "11.21.0"
   }
 }

--- a/runtime/runtime-manifest.json
+++ b/runtime/runtime-manifest.json
@@ -1,6 +1,6 @@
 {
   "desktopVersion": "0.2.11",
-  "harnessVersion": "0.1.0-rc.8",
+  "harnessVersion": "0.1.1-rc.1",
   "nodeVersion": "24.19.0",
   "sidecarVersion": "0.2.4",
   "nodeSha256": {

--- a/scripts/lib/release-artifacts.test.ts
+++ b/scripts/lib/release-artifacts.test.ts
@@ -151,12 +151,18 @@ test("Windows installer smoke can safely reuse one completed Release run", () =>
     workflow,
     /github\.event\.inputs\.windows_smoke_installer != 'nsis'/,
   );
-  assert.equal(
-    workflow.split(
-      "if: github.event_name != 'workflow_dispatch' || github.event.inputs.windows_smoke_source_run_id == ''",
-    ).length - 1,
-    3,
+  const readOnlySourceRunGate =
+    "if: github.event_name != 'workflow_dispatch' || github.event.inputs.windows_smoke_source_run_id == ''";
+  const presetContract = workflow.slice(
+    workflow.indexOf("  preset-download-contract:"),
+    workflow.indexOf("\n  quality:"),
   );
+  const quality = workflow.slice(
+    workflow.indexOf("  quality:"),
+    workflow.indexOf("\n  # Refuse to spend two platform builds"),
+  );
+  assert.ok(presetContract.includes(readOnlySourceRunGate));
+  assert.ok(quality.includes(readOnlySourceRunGate));
 });
 
 test("tag publication tolerates only the intentional transitive smoke-source skip", () => {
@@ -199,6 +205,77 @@ test("release shell never interpolates the attacker-controlled ref name", () => 
   assert.match(workflow, /\^v\(0\|\[1-9\]\[0-9\]\*\)\\\./);
   assert.match(workflow, /--expect-tag "\$RELEASE_TAG"/);
   assert.match(workflow, /--tag "\$RELEASE_TAG"/);
+});
+
+test("release matrix treats workflow native_target as data, not shell source", () => {
+  const workflow = readFileSync(
+    new URL("../../.github/workflows/release.yml", import.meta.url),
+    "utf8",
+  );
+  const start = workflow.indexOf("      - name: Emit reviewed native, notarization, and Store matrices");
+  const end = workflow.indexOf("\n  # The desktop deliberately refuses redirects", start);
+  assert.ok(start >= 0 && end > start, "release matrix step missing");
+  const step = workflow.slice(start, end);
+  const shell = step.slice(step.indexOf("        run: |"));
+
+  assert.match(
+    step,
+    /NATIVE_TARGET: \$\{\{ github\.event\.inputs\.native_target \|\| 'all' \}\}/,
+  );
+  assert.doesNotMatch(shell, /\$\{\{/);
+  assert.equal(
+    shell.split('--target "$NATIVE_TARGET"').length - 1,
+    2,
+    "both target-dependent matrices must use the quoted environment value",
+  );
+  assert.equal(
+    shell.includes("--target '${{ github.event.inputs.native_target"),
+    false,
+  );
+});
+
+test("manual Release always builds reviewed main, never a dispatch-selected source ref", () => {
+  const workflow = readFileSync(
+    new URL("../../.github/workflows/release.yml", import.meta.url),
+    "utf8",
+  );
+  const safeRef =
+    "ref: ${{ github.event_name == 'workflow_dispatch' && 'refs/heads/main' || github.ref }}";
+  const releasePlanStart = workflow.indexOf("  release-plan:");
+  const releasePlanEnd = workflow.indexOf("\n  # The desktop deliberately refuses redirects", releasePlanStart);
+  const releasePlan = workflow.slice(releasePlanStart, releasePlanEnd);
+  const checkoutCount = workflow.split("uses: actions/checkout@").length - 1;
+  const checkoutRefs = [
+    ...workflow.matchAll(
+      /uses: actions\/checkout@[^\n]+\n\s+with:\n\s+ref: ([^\n]+)/g,
+    ),
+  ].map((match) => `ref: ${match[1]}`);
+
+  assert.ok(checkoutCount > 0, "Release must retain explicit pinned checkouts");
+  assert.match(
+    releasePlan,
+    /if: github\.event_name != 'workflow_dispatch' \|\| \(github\.ref == 'refs\/heads\/main' && github\.event\.inputs\.windows_smoke_source_run_id == ''\)/,
+    "manual dispatches outside main must not enter the signing/build dependency graph",
+  );
+  assert.equal(
+    workflow.includes("github.event.inputs.tag"),
+    false,
+    "a dispatch input must never choose source executed with release credentials",
+  );
+  assert.equal(
+    checkoutRefs.length,
+    checkoutCount,
+    "every checkout step must declare an explicit ref",
+  );
+  assert.deepEqual(
+    checkoutRefs,
+    Array.from({ length: checkoutCount }, () => safeRef),
+    "every Release checkout must bind dispatches to main and tags to their tag ref",
+  );
+  assert.match(
+    workflow,
+    /checkout_ref: \$\{\{ github\.event_name == 'workflow_dispatch' && 'refs\/heads\/main' \|\| github\.ref \}\}/,
+  );
 });
 
 test("dependency review is blocking with a graph-unavailable fallback", () => {


### PR DESCRIPTION
## Summary

- pin the bundled official `@deepseek-ai/dsh` runtime to `0.1.1-rc.1`, with the lockfile regenerated from the verified registry integrity
- make manual Release builds execute only reviewed `main`; remove arbitrary source-ref selection and keep dispatch target input as quoted data
- document the main-only manual release policy and add focused workflow regression coverage

## Verification

- `pnpm check:scripts`
- `pnpm test:scripts` (79/79)
- `pnpm test:frontend` (5/5)
- `pnpm release:preflight`
- rc.1 staged-runtime smoke, heartbeat, plugins, presets, bundle, signing, and command/capability checks
- Rust nextest, coverage, fmt, clippy, cargo deny, and cargo vet
- Cordis production preset + market contract probes

No Desktop version bump or tag is included; this must merge and pass CI before `v0.2.11` is created.