### PR TITLE
fix: harden plugin install, activation, and removal

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Harness 的技能、工具、模型路由、MCP、预设——**全部是 Cordis
 
 **发现**：设置页「资源」一键打开插件市场 [cordis.run](https://cordis.run)。
 
-**安装**：设置页「插件（用户安装）」输入 npm 包名即装即卸——桌面层调用官方 `dsh plugin --profile web add/remove`，pinned CLI 与 pnpm 均随包携带（**无需系统 pnpm**），带实时安装日志与取消（整棵 node → dsh → pnpm 进程树一并清理）。
+**安装**：设置页「插件（用户安装）」输入 npm 包名即可安装、卸载。安装复用官方 `dsh plugin --profile web add`；卸载先精确 pre-disable 目标，再用随包 pnpm 关闭 lifecycle script 后直接移除，避免上游全局 reconcile 意外启用另一个仍处于 pending 的市场插件。CLI 与 pnpm 均随包携带（**无需系统 pnpm**），带实时日志与取消（整棵 node → dsh/pnpm 进程树一并清理）。
 
 从 cordis.run 插件详情页点「安装到桌面版」会用 `dsharness://plugin/install?v=1&name=<包名>&source=<插件页>` 唤起桌面版；桌面版在 Rust 侧严格校验协议后，仅将链接定位到对应市场 slug，并重新拉取详情、核对当前 `entryRevision` 与嵌套 source，再由用户确认安装（旧版本桌面版或不支持的市场页仍可复制包名粘贴安装）。命令行等价路径（高级用法）：
 
@@ -121,8 +121,9 @@ shape（仍不安装）：
 CORDIS_MARKET_PROBE_SLUG=<reviewed-public-slug> pnpm verify:cordis-market
 ```
 
-Microsoft Store 构建仍只允许 `src-tauri/store-curated-plugins.json` 的审核快照；
-通过生产 probe 不等于获得 Store allowlist 权限。
+Microsoft Store 构建要求插件同时通过生产 API 的实时安装门禁与
+`src-tauri/store-curated-plugins.json` 本地审核快照；快照不是离线安装授权，
+通过生产 probe 也不等于获得 Store allowlist 权限。
 
 > `~/.cargo` 不可写时：`export CARGO_HOME=<repo>/.tmp/cargo-home`。
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -24,12 +24,14 @@ DSH Desktop 是社区桌面打包层：Tauri 2 壳 + Rust `dsh-sidecar`
   语义：任意非空值即禁用 session-telemetry）。如需开启，修改
   `src-tauri/src/harness/mod.rs` 的 `start_harness` env 并重新构建。
 - **子进程环境消毒**：sidecar 在 spawn 前**黑名单过滤**继承环境中的
-  `NODE_OPTIONS`、`NODE_PATH`、`ELECTRON_RUN_AS_NODE`、动态链接器注入原语
+  `NODE_OPTIONS`、`NODE_PATH`、`NODE_TLS_REJECT_UNAUTHORIZED`、
+  `ELECTRON_RUN_AS_NODE`、动态链接器注入原语
   （`DYLD_INSERT_LIBRARIES`/`DYLD_LIBRARY_PATH`/`LD_PRELOAD`/`LD_LIBRARY_PATH`）
-  与 `npm_config_*` 前缀（其余键值全部透传——如需隔离更多变量请在升级时
+  与 `npm_config_*`/`pnpm_config_*` 前缀（其余键值全部透传——如需隔离更多变量请在升级时
   复核本清单）；unix 先 `env_clear` 再回填过滤快照，Windows 在 UTF-16
   环境块层过滤；两端均以 OsString/UTF-16 原样透传，非 UTF-8 值不会触发
-  任何编码往返或 panic。
+  任何编码往返或 panic。Windows 的上游插件安装还会用系统目录 API 固定
+  `ComSpec=cmd.exe` 与标准 `PATHEXT`，避免 `shell:true` 被继承环境重定向。
 - **进程树保证**：unix 进程组 + sigaction；Windows Job Object
   （KILL_ON_JOB_CLOSE）+ 私有隐藏控制台。sidecar 消失（任何原因）即整树
   消失；存活性心跳在进程挂死（活着但无响应）时杀树并交由壳按退避上限重启。
@@ -73,20 +75,27 @@ DSH Desktop 是社区桌面打包层：Tauri 2 壳 + Rust `dsh-sidecar`
   校验器拦截的是恶意构造的压缩包，拦不住一个「内容本身有害」的可信包。
 - **插件（dsh plugin）**：运行在 Harness 进程内，等同任意代码执行。桌面版
   的安装入口（手动输入包名、市场安装或 cordis.run 的 deep link）都只生成
-  安装请求，必须经用户显式确认后才调用 `dsh plugin add`；安全边界仍是
+  安装请求。手动/侧载安装复用 `dsh plugin add`；市场安装重新拉取详情后以
+  关闭 lifecycle script 的随包 pnpm 安装、核验并保持 pending，只有用户显式
+  **Activate** 才写入 bundles。卸载先精确 pre-disable 目标，再以同样关闭脚本
+  的 pnpm 直接移除，不调用会全局 reconcile 的上游 remove。所有手动重启与
+  崩溃自动重启都和插件 mutation 共用单飞门，并在启动前修复 pending/active
+  边界，避免 Harness 在 pnpm 写入中途或未确认状态下加载插件。安全边界仍是
   「仅安装可信插件」——包名/来源校验拦截的是恶意构造的请求，拦不住内容
   本身有害的可信包。
 - **插件市场**：bootstrap 窗口 CSP 不放宽，市场网络请求全部由 Rust 侧
   `market.rs` 发起，只允许 `https://cordis.run` 主机；图片仅 https、
-  `image/*`、2 MiB 上限；搜索/详情响应 1 MiB 上限并走内存缓存。
+  固定 raster MIME + magic-byte、2 MiB 上限；搜索/详情响应 1 MiB 上限，首页
+  支持有界磁盘缓存与 ETag/304 重验。
 - **离线侧载**：`.tgz` 必须绝对路径、非常规文件/符号链接拒绝、≤64 MiB；
   确认后复制到 `<dshHome>/.desktop-tools/sideload/` 的应用生成 ASCII 文件名，
   再以 `file:` spec 交给插件执行器，用户文件名不进入 shell。已知限制：
   Windows 上若 `DSH_HOME` 路径含空格或 cmd 元字符，侧载会 fail-closed 拒绝，
   请改用市场在线安装。
 - **Microsoft Store 版**：`STORE_BUILD=1` 编译。应用内更新关闭（由 Store
-  管理），插件安装在后端强制校验 `src-tauri/store-curated-plugins.json`
-  白名单；UI 不提供任意包名输入或离线侧载，deep link 亦不能绕过该校验。
+  管理），插件安装必须同时通过生产 API 的实时候选门禁与
+  `src-tauri/store-curated-plugins.json` 本地审核快照；UI 不提供任意包名输入
+  或离线侧载，deep link 与 IPC 均不能绕过这两层校验。
 
 ## 报告漏洞
 

--- a/crates/dsh-sidecar/src/lib.rs
+++ b/crates/dsh-sidecar/src/lib.rs
@@ -129,29 +129,35 @@ pub fn quote_arg(arg: &str) -> String {
 // ---------------------------------------------------------------------------
 // Child environment hygiene: the sidecar inherits the parent's (Tauri shell's)
 // environment and forwards it to the bundled Node. A user launching the app
-// from a shell with NODE_OPTIONS / NODE_PATH / npm_config_* set would otherwise
-// inject code (`--require=…`) or config into the Harness process. These keys
-// are stripped before spawn. The `env` overrides carried by the start command
-// are applied AFTER the filter and are NOT filtered — they are the app's own
-// contract (DSH_HOME etc.). Also scrubbed: ELECTRON_RUN_AS_NODE, which would
-// turn a bundled Electron's node into a Harness host if one is ever reused,
-// and the dynamic-linker injection primitives (DYLD_*/LD_*).
+// from a shell with NODE_OPTIONS / NODE_PATH / npm_config_* / pnpm_config_*
+// set would otherwise inject code (`--require=…`) or config into the Harness
+// process. NODE_TLS_REJECT_UNAUTHORIZED is also stripped so inherited shell
+// state cannot silently disable TLS verification. The `env` overrides carried
+// by the start command are applied AFTER the filter and are NOT filtered —
+// they are the app's own contract (DSH_HOME etc.). Also scrubbed:
+// ELECTRON_RUN_AS_NODE, which would turn a bundled Electron's node into a
+// Harness host if one is ever reused, and the dynamic-linker injection
+// primitives (DYLD_*/LD_*).
 // ---------------------------------------------------------------------------
 
-const FORBIDDEN_ENV_KEYS: [&str; 7] = [
+const FORBIDDEN_ENV_KEYS: [&str; 8] = [
     "node_options",
     "node_path",
+    "node_tls_reject_unauthorized",
     "electron_run_as_node",
     "dyld_insert_libraries",
     "dyld_library_path",
     "ld_preload",
     "ld_library_path",
 ];
-const FORBIDDEN_ENV_PREFIX: &str = "npm_config_";
+const FORBIDDEN_ENV_PREFIXES: [&str; 2] = ["npm_config_", "pnpm_config_"];
 
 fn env_key_forbidden(key: &str) -> bool {
     let folded = key.to_ascii_lowercase();
-    FORBIDDEN_ENV_KEYS.contains(&folded.as_str()) || folded.starts_with(FORBIDDEN_ENV_PREFIX)
+    FORBIDDEN_ENV_KEYS.contains(&folded.as_str())
+        || FORBIDDEN_ENV_PREFIXES
+            .iter()
+            .any(|prefix| folded.starts_with(prefix))
 }
 
 /// Filter an inherited environment snapshot (the unix path).
@@ -187,7 +193,10 @@ pub fn fold_ascii_u16(w: u16) -> u16 {
 /// surrogates — are forwarded verbatim. Entries without '=' and entries with
 /// an empty key (the `=C:=…` per-drive entries) are never filter targets.
 pub fn sanitize_env_lines(lines: Vec<Vec<u16>>) -> Vec<Vec<u16>> {
-    let prefix: Vec<u16> = FORBIDDEN_ENV_PREFIX.encode_utf16().collect();
+    let prefixes: Vec<Vec<u16>> = FORBIDDEN_ENV_PREFIXES
+        .iter()
+        .map(|prefix| prefix.encode_utf16().collect())
+        .collect();
     lines
         .into_iter()
         .filter(|line| {
@@ -201,7 +210,7 @@ pub fn sanitize_env_lines(lines: Vec<Vec<u16>>) -> Vec<Vec<u16>> {
             !FORBIDDEN_ENV_KEYS
                 .iter()
                 .any(|k| folded == k.encode_utf16().collect::<Vec<u16>>())
-                && !folded.starts_with(&prefix)
+                && !prefixes.iter().any(|prefix| folded.starts_with(prefix))
         })
         .collect()
 }

--- a/crates/dsh-sidecar/src/lib.rs
+++ b/crates/dsh-sidecar/src/lib.rs
@@ -131,19 +131,24 @@ pub fn quote_arg(arg: &str) -> String {
 // environment and forwards it to the bundled Node. A user launching the app
 // from a shell with NODE_OPTIONS / NODE_PATH / npm_config_* / pnpm_config_*
 // set would otherwise inject code (`--require=…`) or config into the Harness
-// process. NODE_TLS_REJECT_UNAUTHORIZED is also stripped so inherited shell
-// state cannot silently disable TLS verification. The `env` overrides carried
-// by the start command are applied AFTER the filter and are NOT filtered —
+// process. Node TLS controls are also stripped: NODE_TLS_REJECT_UNAUTHORIZED
+// can silently disable verification, while NODE_EXTRA_CA_CERTS can append an
+// attacker-controlled certificate authority. The `env` overrides carried by
+// the start command are applied AFTER the filter and are NOT filtered —
 // they are the app's own contract (DSH_HOME etc.). Also scrubbed:
 // ELECTRON_RUN_AS_NODE, which would turn a bundled Electron's node into a
 // Harness host if one is ever reused, and the dynamic-linker injection
 // primitives (DYLD_*/LD_*).
 // ---------------------------------------------------------------------------
 
-const FORBIDDEN_ENV_KEYS: [&str; 8] = [
+const FORBIDDEN_ENV_KEYS: [&str; 10] = [
     "node_options",
     "node_path",
     "node_tls_reject_unauthorized",
+    "node_extra_ca_certs",
+    // npm/pnpm use this self-referential control value when spawning helpers;
+    // Desktop always supplies its own bundled entrypoint instead.
+    "npm_execpath",
     "electron_run_as_node",
     "dyld_insert_libraries",
     "dyld_library_path",

--- a/crates/dsh-sidecar/src/main.rs
+++ b/crates/dsh-sidecar/src/main.rs
@@ -1164,7 +1164,9 @@ mod tests {
             // removed while ordinary keys (PATH) still flow through.
             let inherited = vec![
                 ("NODE_OPTIONS".into(), "--require=/evil.js".into()),
+                ("NODE_TLS_REJECT_UNAUTHORIZED".into(), "0".into()),
                 ("npm_config_cache".into(), "/tmp/evil-cache".into()),
+                ("pnpm_config_store_dir".into(), "/tmp/evil-store".into()),
                 (
                     "PATH".into(),
                     std::env::var_os("PATH").expect("PATH set in test env"),
@@ -1172,7 +1174,7 @@ mod tests {
             ];
             let child = PlatformChild::spawn(
                 &spec(
-                    "test -z \"${NODE_OPTIONS}\" && test -z \"${npm_config_cache}\" && test -n \"${PATH}\"",
+                    "test -z \"${NODE_OPTIONS}\" && test -z \"${NODE_TLS_REJECT_UNAUTHORIZED}\" && test -z \"${npm_config_cache}\" && test -z \"${pnpm_config_store_dir}\" && test -n \"${PATH}\"",
                 ),
                 &inherited,
             );
@@ -1287,8 +1289,11 @@ mod tests {
             ("PATH".into(), "/usr/bin".into()),
             ("NODE_OPTIONS".into(), "--require=/evil".into()),
             ("node_path".into(), "/evil".into()),
+            ("Node_Tls_Reject_Unauthorized".into(), "0".into()),
             ("npm_config_cache".into(), "/c".into()),
             ("Npm_Config_Foo".into(), "1".into()),
+            ("pnpm_config_store_dir".into(), "/store".into()),
+            ("PnPm_CoNfIg_Registry".into(), "https://evil.invalid".into()),
             ("ELECTRON_RUN_AS_NODE".into(), "1".into()),
             ("HOME".into(), "/home/u".into()),
         ];
@@ -1334,7 +1339,10 @@ mod tests {
         let lines = vec![
             u("NODE_OPTIONS=--require=x"),
             u("npm_config_foo=1"),
+            u("pnpm_config_store_dir=C:\\evil"),
+            u("PnPm_CoNfIg_Registry=https://evil.invalid"),
             u("Node_Path=/evil"),
+            u("NODE_TLS_REJECT_UNAUTHORIZED=0"),
             u("DYLD_INSERT_LIBRARIES=/evil.dylib"),
             u("LD_PRELOAD=/evil.so"),
             path_line,

--- a/crates/dsh-sidecar/src/main.rs
+++ b/crates/dsh-sidecar/src/main.rs
@@ -1165,6 +1165,8 @@ mod tests {
             let inherited = vec![
                 ("NODE_OPTIONS".into(), "--require=/evil.js".into()),
                 ("NODE_TLS_REJECT_UNAUTHORIZED".into(), "0".into()),
+                ("NODE_EXTRA_CA_CERTS".into(), "/tmp/evil-ca.pem".into()),
+                ("npm_execpath".into(), "/tmp/evil-npm-cli.js".into()),
                 ("npm_config_cache".into(), "/tmp/evil-cache".into()),
                 ("pnpm_config_store_dir".into(), "/tmp/evil-store".into()),
                 (
@@ -1174,7 +1176,7 @@ mod tests {
             ];
             let child = PlatformChild::spawn(
                 &spec(
-                    "test -z \"${NODE_OPTIONS}\" && test -z \"${NODE_TLS_REJECT_UNAUTHORIZED}\" && test -z \"${npm_config_cache}\" && test -z \"${pnpm_config_store_dir}\" && test -n \"${PATH}\"",
+                    "test -z \"${NODE_OPTIONS}\" && test -z \"${NODE_TLS_REJECT_UNAUTHORIZED}\" && test -z \"${NODE_EXTRA_CA_CERTS}\" && test -z \"${npm_execpath}\" && test -z \"${npm_config_cache}\" && test -z \"${pnpm_config_store_dir}\" && test -n \"${PATH}\"",
                 ),
                 &inherited,
             );
@@ -1290,6 +1292,8 @@ mod tests {
             ("NODE_OPTIONS".into(), "--require=/evil".into()),
             ("node_path".into(), "/evil".into()),
             ("Node_Tls_Reject_Unauthorized".into(), "0".into()),
+            ("NODE_EXTRA_CA_CERTS".into(), "/evil-ca.pem".into()),
+            ("Npm_ExecPath".into(), "/evil-npm-cli.js".into()),
             ("npm_config_cache".into(), "/c".into()),
             ("Npm_Config_Foo".into(), "1".into()),
             ("pnpm_config_store_dir".into(), "/store".into()),
@@ -1343,6 +1347,8 @@ mod tests {
             u("PnPm_CoNfIg_Registry=https://evil.invalid"),
             u("Node_Path=/evil"),
             u("NODE_TLS_REJECT_UNAUTHORIZED=0"),
+            u("node_extra_ca_certs=C:\\evil-ca.pem"),
+            u("NPM_EXECPATH=C:\\evil-npm-cli.js"),
             u("DYLD_INSERT_LIBRARIES=/evil.dylib"),
             u("LD_PRELOAD=/evil.so"),
             path_line,

--- a/crates/dsh-sidecar/src/platform.rs
+++ b/crates/dsh-sidecar/src/platform.rs
@@ -124,7 +124,7 @@ kill -KILL "-$pgid" 2>/dev/null || :"#,
             // Injection-safe environment: Command inherits the FULL parent
             // env by default and `.envs()` only overlays — so a key omitted
             // from the overlay would still leak through. env_clear() first,
-            // then re-add the sanitized snapshot (parent env minus node/npm
+            // then re-add the sanitized snapshot (parent env minus node/npm/pnpm
             // control keys), then the start command's own overrides (DSH_HOME
             // etc.) which are exempt from the filter by design.
             cmd.env_clear()
@@ -469,7 +469,7 @@ mod imp {
         }
         unsafe { FreeEnvironmentStringsW(raw) };
 
-        // Injection-safe environment: strip node/npm control keys at the
+        // Injection-safe environment: strip node/npm/pnpm control keys at the
         // UTF-16 level (no lossy round-trip), then apply the overrides —
         // overrides come last, so they win and are exempt from the filter.
         let mut lines = crate::sanitize_env_lines(lines);

--- a/scripts/lib/plugin-shim.test.ts
+++ b/scripts/lib/plugin-shim.test.ts
@@ -1,0 +1,72 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { delimiter } from "node:path";
+import {
+  pluginPath,
+  pluginMarketAddArgs,
+  pluginRemoveArgs,
+  pluginShimCmd,
+  pluginShimScript,
+} from "./plugin-shim.ts";
+
+test("plugin smoke shim matches the production quoting contract", () => {
+  assert.equal(
+    pluginShimScript("/tmp/a'b/$node", "/tmp/$(touch nope)/pnpm.cjs"),
+    `#!/bin/sh\nexec '/tmp/a'"'"'b/$node' '/tmp/$(touch nope)/pnpm.cjs' "$@"\n`,
+  );
+  assert.equal(
+    pluginShimCmd("C:\\100%\\node.exe", "C:\\bang!\\pnpm.cjs"),
+    '@echo off\nsetlocal DisableDelayedExpansion\n"C:\\100%%\\node.exe" "C:\\bang!\\pnpm.cjs" %*\n',
+  );
+});
+
+test("plugin smoke PATH preserves every inherited segment", () => {
+  const inherited = ["parent-one", "parent-two"].join(delimiter);
+  assert.deepEqual(pluginPath("desktop-shim", inherited).split(delimiter), [
+    "desktop-shim",
+    "parent-one",
+    "parent-two",
+  ]);
+  assert.equal(pluginPath("desktop-shim", undefined), "desktop-shim");
+});
+
+test("plugin smoke uninstall mirrors the direct safe pnpm contract", () => {
+  const args = pluginRemoveArgs("fixture-plugin", "/private/config", "/existing/store");
+  assert.deepEqual(args.slice(0, 2), ["remove", "fixture-plugin"]);
+  for (const required of [
+    "--config.ignore-scripts=true",
+    "--config.ignore-pnpmfile=true",
+    "--config.enable-global-virtual-store=false",
+    "--config.verify-store-integrity=true",
+    "--config.strict-store-pkg-content-check=true",
+    "--config.config-dir=/private/config",
+    "--config.userconfig=/private/config/.npmrc",
+    "--config.globalconfig=/private/config/.npmrc",
+    "--store-dir=/existing/store",
+  ]) {
+    assert.ok(args.includes(required), `missing ${required}`);
+  }
+  assert.ok(!args.includes("--ignore-scripts"));
+});
+
+test("plugin smoke market install keeps scripts disabled and source exact", () => {
+  const args = pluginMarketAddArgs(
+    "https://registry.npmjs.org/fixture/-/fixture-1.0.0.tgz",
+    "https://registry.npmjs.org",
+    "/private/config",
+    "/existing/store",
+  );
+  assert.deepEqual(args.slice(0, 2), [
+    "add",
+    "https://registry.npmjs.org/fixture/-/fixture-1.0.0.tgz",
+  ]);
+  for (const required of [
+    "--ignore-scripts",
+    "--config.ignore-pnpmfile=true",
+    "--save-exact",
+    "--registry=https://registry.npmjs.org",
+    "--store-dir=/existing/store",
+  ]) {
+    assert.ok(args.includes(required), `missing ${required}`);
+  }
+});

--- a/scripts/lib/plugin-shim.ts
+++ b/scripts/lib/plugin-shim.ts
@@ -1,0 +1,95 @@
+import { chmodSync, mkdirSync, writeFileSync } from "node:fs";
+import { delimiter, join } from "node:path";
+
+function posixShellQuote(value: string): string {
+  return `'${value.replaceAll("'", `'"'"'`)}'`;
+}
+
+/** Mirrors `plugins::pnpm_shim_script` for runtime smoke fixtures. */
+export function pluginShimScript(node: string, pnpmCjs: string): string {
+  return `#!/bin/sh\nexec ${posixShellQuote(node)} ${posixShellQuote(pnpmCjs)} "$@"\n`;
+}
+
+/** Mirrors `plugins::pnpm_shim_cmd` for runtime smoke fixtures. */
+export function pluginShimCmd(node: string, pnpmCjs: string): string {
+  const escapedNode = node.replaceAll("%", "%%");
+  const escapedPnpm = pnpmCjs.replaceAll("%", "%%");
+  return `@echo off\nsetlocal DisableDelayedExpansion\n"${escapedNode}" "${escapedPnpm}" %*\n`;
+}
+
+export function pluginPath(toolsDir: string, inheritedPath: string | undefined): string {
+  return inheritedPath ? `${toolsDir}${delimiter}${inheritedPath}` : toolsDir;
+}
+
+/** Mirrors the direct, scripts-disabled Desktop uninstall invocation. */
+export function pluginRemoveArgs(
+  packageName: string,
+  configHome: string,
+  storeDir: string | undefined,
+): string[] {
+  const npmrc = join(configHome, ".npmrc");
+  const args = [
+    "remove",
+    packageName,
+    "--ignore-workspace",
+    "--global=false",
+    "--node-linker=hoisted",
+    "--config.auto-install-peers=false",
+    "--package-import-method=copy",
+    "--virtual-store-dir=node_modules/.pnpm",
+    "--yes",
+    "--reporter=append-only",
+    "--config.ignore-scripts=true",
+    "--config.ignore-pnpmfile=true",
+    "--config.enable-global-virtual-store=false",
+    "--config.verify-store-integrity=true",
+    "--config.strict-store-pkg-content-check=true",
+    `--config.config-dir=${configHome}`,
+    `--config.userconfig=${npmrc}`,
+    `--config.globalconfig=${npmrc}`,
+  ];
+  if (storeDir) args.push(`--store-dir=${storeDir}`);
+  return args;
+}
+
+/** Mirrors the direct, pending-only Desktop market installation invocation. */
+export function pluginMarketAddArgs(
+  tarball: string,
+  registry: string,
+  configHome: string,
+  storeDir: string | undefined,
+): string[] {
+  const npmrc = join(configHome, ".npmrc");
+  const args = [
+    "add",
+    tarball,
+    "--ignore-workspace",
+    "--global=false",
+    "--node-linker=hoisted",
+    "--config.auto-install-peers=false",
+    "--package-import-method=copy",
+    "--virtual-store-dir=node_modules/.pnpm",
+    "--yes",
+    "--reporter=append-only",
+    "--ignore-scripts",
+    "--config.ignore-pnpmfile=true",
+    "--config.enable-global-virtual-store=false",
+    "--verify-store-integrity",
+    "--config.strict-store-pkg-content-check=true",
+    `--config.config-dir=${configHome}`,
+    `--config.userconfig=${npmrc}`,
+    `--config.globalconfig=${npmrc}`,
+    "--save-exact",
+    `--registry=${registry}`,
+  ];
+  if (storeDir) args.push(`--store-dir=${storeDir}`);
+  return args;
+}
+
+export function writePluginShims(toolsDir: string, node: string, pnpmCjs: string): void {
+  mkdirSync(toolsDir, { recursive: true });
+  const unix = join(toolsDir, "pnpm");
+  writeFileSync(unix, pluginShimScript(node, pnpmCjs));
+  writeFileSync(join(toolsDir, "pnpm.cmd"), pluginShimCmd(node, pnpmCjs));
+  if (process.platform !== "win32") chmodSync(unix, 0o700);
+}

--- a/scripts/verify-plugins.ts
+++ b/scripts/verify-plugins.ts
@@ -277,8 +277,8 @@ async function main(): Promise<void> {
   info(`isolated DSH_HOME ${home} · store ${storeDir}`);
 
   // --- add -------------------------------------------------------------
-  const addOut = await runPlugin(["add", "is-odd"], "dsh plugin add is-odd");
-  ok("dsh plugin add is-odd exited 0");
+  const addOut = await runPlugin(["add", "is-odd@3.0.1"], "dsh plugin add is-odd@3.0.1");
+  ok("dsh plugin add is-odd@3.0.1 exited 0");
   if (!existsSync(join(profileDir, "package.json"))) fail("initProfile did not write profiles/web/package.json");
   ok("upstream initProfile wrote profiles/web/package.json");
   if (!existsSync(join(profileDir, "cordis.patch.yml"))) fail("initProfile did not write cordis.patch.yml");
@@ -303,7 +303,7 @@ async function main(): Promise<void> {
   const installedVersion = JSON.parse(
     readFileSync(join(profileDir, "node_modules", "is-odd", "package.json"), "utf8"),
   ) as { version?: string };
-  if (typeof installedVersion.version !== "string" || !installedVersion.version.startsWith("3.")) {
+  if (installedVersion.version !== "3.0.1") {
     fail(`unexpected installed is-odd version: ${JSON.stringify(installedVersion.version)}`);
   }
   ok(`installed version readable from node_modules/is-odd/package.json (v${installedVersion.version})`);

--- a/scripts/verify-plugins.ts
+++ b/scripts/verify-plugins.ts
@@ -1,7 +1,8 @@
-// Plugin installation e2e: drives the REAL `dsh plugin` chain the desktop
-// shell spawns — bundled node → dsh lib/bin.js `plugin --profile web
-// add/remove` → shim-resolved bundled pnpm → upstream initProfile +
-// reconcilePlugins — against a fresh, isolated DSH_HOME.
+// Plugin installation e2e: drives both REAL chains the desktop shell spawns
+// against a fresh, isolated DSH_HOME — bundled node → dsh lib/bin.js
+// `plugin --profile web add` → shim-resolved bundled pnpm → upstream
+// initProfile/reconcilePlugins, plus Desktop's direct bundled-pnpm market-add
+// and removal paths.
 //
 // What this proves:
 //   - the shim + PATH setup lets upstream's `spawnSync("pnpm", …)` find the
@@ -13,9 +14,11 @@
 //     source `list_plugins` reads);
 //   - reconcilePlugins runs (is-odd declares no dsh.bundle → warning +
 //     in-box bundles list untouched);
-//   - `remove is-odd` drops the dependency again.
+//   - Desktop's direct, scripts-disabled pnpm removal drops the dependency
+//     without invoking upstream's global bundle reconciliation;
 //   - the reported dsh-plugin-pkgseek@0.1.1 active-bundle uninstall path
-//     removes both its dependency and dsh.profile.bundles entry.
+//     removes both its dependency and dsh.profile.bundles entry;
+//   - removing another package cannot reactivate a pending bundle.
 //
 // Store isolation (plan S5): `pnpm_config_store_dir` pins the pnpm content
 // store inside the temp home, so nothing touches the user's real store.
@@ -23,20 +26,20 @@
 // the bundled pnpm 11.21.0; `npm_config_*` is NOT honored for this key.)
 // NOTE: requires network access to registry.npmjs.org (CI runners have it).
 //
-// The Rust side of the shim text/exec is covered by plugins.rs tests; the
-// text below mirrors it verbatim and is asserted against the same golden
-// strings here so a drift breaks this run.
+// The Rust side of the shim text/exec is covered by plugins.rs tests. Both
+// plugin smoke programs share scripts/lib/plugin-shim.ts, whose quoting and
+// multi-segment PATH contract has its own Node test; this avoids the two e2e
+// paths silently carrying different, stale shim copies.
 
 import { spawn } from "node:child_process";
 import {
-  chmodSync,
   existsSync,
   mkdirSync,
   readFileSync,
   rmSync,
   writeFileSync,
 } from "node:fs";
-import { delimiter, join, resolve } from "node:path";
+import { dirname, join, resolve } from "node:path";
 import {
   runtimeDir as defaultRuntimeDir,
   tmpDir,
@@ -44,6 +47,12 @@ import {
   ok,
   info,
 } from "./lib/common.ts";
+import {
+  pluginMarketAddArgs,
+  pluginPath,
+  pluginRemoveArgs,
+  writePluginShims,
+} from "./lib/plugin-shim.ts";
 
 const verbose = process.argv.includes("--verbose");
 const runtimeDirArg = process.argv.indexOf("--runtime-dir");
@@ -70,17 +79,12 @@ const home = join(tmpDir, `plugin-e2e-home-${Date.now()}`);
 const profileDir = join(home, "profiles", "web");
 const toolsDir = join(home, ".desktop-tools");
 const storeDir = join(home, "pnpm-store");
-
-// Same golden texts as src-tauri/src/plugins.rs (asserted there by unit
-// tests; asserted HERE so a silent drift between the two never ships).
-const SHIM_SCRIPT = `#!/bin/sh\nexec "${node}" "${pnpmCjs}" "$@"\n`;
-const SHIM_CMD = `@echo off\n"${node}" "${pnpmCjs}" %*\n`;
+const configDir = join(toolsDir, "pnpm-config");
 
 function writeShims(): void {
-  mkdirSync(toolsDir, { recursive: true });
-  writeFileSync(join(toolsDir, "pnpm"), SHIM_SCRIPT);
-  writeFileSync(join(toolsDir, "pnpm.cmd"), SHIM_CMD);
-  if (process.platform !== "win32") chmodSync(join(toolsDir, "pnpm"), 0o755);
+  writePluginShims(toolsDir, node, pnpmCjs);
+  mkdirSync(configDir, { recursive: true });
+  writeFileSync(join(configDir, ".npmrc"), "");
 }
 
 function pluginEnv(): NodeJS.ProcessEnv {
@@ -88,8 +92,16 @@ function pluginEnv(): NodeJS.ProcessEnv {
     ...process.env,
     DSH_HOME: home,
     DSH_TELEMETRY_DISABLED: "1",
-    PATH: `${toolsDir}${delimiter}${process.env.PATH ?? ""}`,
+    PATH: pluginPath(toolsDir, process.env.PATH),
     pnpm_config_store_dir: storeDir,
+  };
+}
+
+function directPnpmEnv(): NodeJS.ProcessEnv {
+  return {
+    ...pluginEnv(),
+    XDG_CONFIG_HOME: configDir,
+    NPM_CONFIG_USERCONFIG: join(configDir, ".npmrc"),
   };
 }
 
@@ -135,6 +147,75 @@ function runPlugin(args: string[], label: string): Promise<string> {
   });
 }
 
+function boundStoreBase(): string {
+  const modulesState = JSON.parse(
+    readFileSync(join(profileDir, "node_modules", ".modules.yaml"), "utf8"),
+  ) as { storeDir?: unknown };
+  if (typeof modulesState.storeDir !== "string") {
+    fail("pnpm .modules.yaml did not record a string storeDir");
+  }
+  return dirname(modulesState.storeDir);
+}
+
+function runDirectPnpm(args: string[], label: string): Promise<string> {
+  return new Promise((resolvePromise, reject) => {
+    const child = spawn(
+      node,
+      [pnpmCjs, ...args],
+      {
+        cwd: profileDir,
+        env: directPnpmEnv(),
+        stdio: ["ignore", "pipe", "pipe"],
+        detached: process.platform !== "win32",
+      },
+    );
+    let output = "";
+    const collect = (chunk: Buffer): void => {
+      output += chunk.toString("utf8");
+      if (verbose) process.stdout.write(chunk);
+    };
+    child.stdout.on("data", collect);
+    child.stderr.on("data", collect);
+    const timer = setTimeout(() => {
+      if (process.platform === "win32") {
+        spawn("taskkill", ["/pid", String(child.pid), "/T", "/F"]);
+      } else {
+        try {
+          process.kill(-(child.pid as number), "SIGKILL");
+        } catch {
+          /* already exited */
+        }
+      }
+      reject(new Error(`timeout running ${label}:\n${output.slice(-4000)}`));
+    }, 300_000);
+    child.on("error", (error) => {
+      clearTimeout(timer);
+      reject(new Error(`cannot spawn ${label}: ${error.message}`));
+    });
+    child.on("exit", (code) => {
+      clearTimeout(timer);
+      if (code !== 0) reject(new Error(`${label} exited ${code}:\n${output.slice(-4000)}`));
+      else resolvePromise(output);
+    });
+  });
+}
+
+function runPnpmRemove(name: string, label: string): Promise<string> {
+  return runDirectPnpm(pluginRemoveArgs(name, configDir, boundStoreBase()), label);
+}
+
+function runPnpmMarketAdd(tarball: string, label: string): Promise<string> {
+  return runDirectPnpm(
+    pluginMarketAddArgs(
+      tarball,
+      "https://registry.npmjs.org",
+      configDir,
+      boundStoreBase(),
+    ),
+    label,
+  );
+}
+
 interface ProfileManifest {
   dependencies?: Record<string, string>;
   dsh?: { profile?: { bundles?: string[] } };
@@ -142,6 +223,51 @@ interface ProfileManifest {
 
 function readProfileManifest(): ProfileManifest {
   return JSON.parse(readFileSync(join(profileDir, "package.json"), "utf8")) as ProfileManifest;
+}
+
+function exactLockfileIntegrity(packageName: string, version: string): string | null {
+  const expected = `${packageName}@${version}`;
+  const lines = readFileSync(join(profileDir, "pnpm-lock.yaml"), "utf8").split(/\r?\n/);
+  let inPackages = false;
+  let inTarget = false;
+  for (const line of lines) {
+    if (line === "packages:") {
+      inPackages = true;
+      continue;
+    }
+    if (!inPackages) continue;
+    if (line === "snapshots:") break;
+    const keyMatch = /^  (.+):$/.exec(line);
+    if (keyMatch) {
+      const raw = keyMatch[1];
+      const key =
+        raw.length >= 2 &&
+        ((raw.startsWith("'") && raw.endsWith("'")) ||
+          (raw.startsWith('"') && raw.endsWith('"')))
+          ? raw.slice(1, -1)
+          : raw;
+      inTarget = key === expected || key.startsWith(`${expected}(`);
+      continue;
+    }
+    if (!inTarget) continue;
+    const integrity = /(?:^|[,{]\s*)integrity:\s*([^,}\s]+)/.exec(line)?.[1];
+    if (integrity) return integrity.replace(/^['"]|['"]$/g, "");
+  }
+  return null;
+}
+
+function preDisable(name: string): void {
+  const manifest = readProfileManifest();
+  const bundles = manifest.dsh?.profile?.bundles;
+  if (!Array.isArray(bundles)) fail("profile bundle list is missing before pre-disable");
+  manifest.dsh = {
+    ...manifest.dsh,
+    profile: {
+      ...manifest.dsh?.profile,
+      bundles: bundles.filter((bundle) => bundle !== name),
+    },
+  };
+  writeFileSync(join(profileDir, "package.json"), JSON.stringify(manifest, null, 2) + "\n");
 }
 
 async function main(): Promise<void> {
@@ -185,22 +311,35 @@ async function main(): Promise<void> {
   if (!existsSync(storeDir)) fail("pnpm_config_store_dir was not respected: store dir not created");
   ok("pnpm store isolated via pnpm_config_store_dir");
 
-  // --- remove ----------------------------------------------------------
-  const removeOut = await runPlugin(["remove", "is-odd"], "dsh plugin remove is-odd");
-  if (removeOut.includes("declares no dsh.bundle")) {
-    // Removal must not re-warn: the package left the dependency list, so
-    // reconcile has nothing newly-added to report.
-    fail("reconcilePlugins warned about a removed package");
+  const pkgseekTarball =
+    "https://registry.npmjs.org/dsh-plugin-pkgseek/-/dsh-plugin-pkgseek-0.1.1.tgz";
+  const pkgseekIntegrity =
+    "sha512-CdpaMsTQBGgpRfgDLT1+FV0JWlOTJUGed3JEzYYz5IVMwjjncWQ3qj/lgd6NIvoV9YMBHF9p+7ZAyt09f8Q5uA==";
+  const pnpmfileMarker = join(home, "pnpmfile-was-loaded");
+  writeFileSync(
+    join(profileDir, ".pnpmfile.cjs"),
+    `require("node:fs").writeFileSync(${JSON.stringify(pnpmfileMarker)}, "unsafe"); module.exports = { hooks: {} };\n`,
+  );
+  await runPnpmMarketAdd(pkgseekTarball, "direct market pnpm add dsh-plugin-pkgseek@0.1.1");
+  if (existsSync(pnpmfileMarker)) {
+    fail("direct market install executed the profile-local pnpmfile");
   }
-  ok("dsh plugin remove is-odd exited 0 (no spurious reconcile warning)");
-  const after = readProfileManifest().dependencies ?? {};
-  if (typeof after["is-odd"] === "string") fail(`is-odd still in dependencies after remove: ${JSON.stringify(after)}`);
-  if (existsSync(join(profileDir, "node_modules", "is-odd"))) fail("node_modules/is-odd still present after remove");
-  ok("remove dropped the dependency and the installed tree entry");
+  rmSync(join(profileDir, ".pnpmfile.cjs"), { force: true });
+  const pendingPkgseek = readProfileManifest();
+  if (pendingPkgseek.dependencies?.["dsh-plugin-pkgseek"] !== pkgseekTarball) {
+    fail("direct market install did not retain the exact reviewed tarball source");
+  }
+  if (pendingPkgseek.dsh?.profile?.bundles?.includes("dsh-plugin-pkgseek")) {
+    fail("direct market install activated dsh-plugin-pkgseek before confirmation");
+  }
+  const installedIntegrity = exactLockfileIntegrity("dsh-plugin-pkgseek", "0.1.1");
+  if (installedIntegrity !== pkgseekIntegrity) {
+    fail(`direct market lockfile integrity mismatch: ${installedIntegrity}`);
+  }
+  ok("direct market pnpm install preserved exact source/integrity and remained inactive");
 
   // Regression for the real package reported by Desktop users. Unlike
-  // is-odd it declares dsh.bundle, so this covers the active-layer removal
-  // and not only pnpm's dependency deletion path.
+  // is-odd it declares dsh.bundle.
   await runPlugin(
     ["add", "dsh-plugin-pkgseek@0.1.1"],
     "dsh plugin add dsh-plugin-pkgseek@0.1.1",
@@ -214,10 +353,39 @@ async function main(): Promise<void> {
   }
   ok("dsh-plugin-pkgseek@0.1.1 installed and activated by upstream reconcile");
 
-  await runPlugin(
-    ["remove", "dsh-plugin-pkgseek"],
-    "dsh plugin remove dsh-plugin-pkgseek",
+  // Model Desktop's exact pre-disable. Keeping pkgseek installed but absent
+  // from bundles is the same safety boundary as a market package awaiting
+  // explicit Activate.
+  preDisable("dsh-plugin-pkgseek");
+  if (readProfileManifest().dsh?.profile?.bundles?.includes("dsh-plugin-pkgseek")) {
+    fail("pre-disable did not remove dsh-plugin-pkgseek from active bundles");
+  }
+
+  // Production intentionally calls pnpm directly for removal. Upstream
+  // `dsh plugin remove is-odd` would globally reconcile here and reactivate
+  // the still-installed pkgseek bundle as an unrelated side effect.
+  writeFileSync(
+    join(profileDir, ".pnpmfile.cjs"),
+    `require("node:fs").writeFileSync(${JSON.stringify(pnpmfileMarker)}, "unsafe"); module.exports = { hooks: {} };\n`,
   );
+  await runPnpmRemove("is-odd", "direct pnpm remove is-odd");
+  if (existsSync(pnpmfileMarker)) {
+    fail("direct plugin removal executed the profile-local pnpmfile");
+  }
+  rmSync(join(profileDir, ".pnpmfile.cjs"), { force: true });
+  const after = readProfileManifest();
+  if (typeof after.dependencies?.["is-odd"] === "string") {
+    fail(`is-odd still in dependencies after remove: ${JSON.stringify(after.dependencies)}`);
+  }
+  if (existsSync(join(profileDir, "node_modules", "is-odd"))) {
+    fail("node_modules/is-odd still present after remove");
+  }
+  if (after.dsh?.profile?.bundles?.includes("dsh-plugin-pkgseek")) {
+    fail("removing is-odd reactivated the unrelated pre-disabled pkgseek bundle");
+  }
+  ok("direct removal dropped is-odd without activating an unrelated pending bundle");
+
+  await runPnpmRemove("dsh-plugin-pkgseek", "direct pnpm remove dsh-plugin-pkgseek");
   const withoutPkgseek = readProfileManifest();
   if (typeof withoutPkgseek.dependencies?.["dsh-plugin-pkgseek"] === "string") {
     fail("dsh-plugin-pkgseek still present in dependencies after remove");

--- a/scripts/verify-sideload.ts
+++ b/scripts/verify-sideload.ts
@@ -4,15 +4,15 @@
 
 import { spawn, spawnSync } from "node:child_process";
 import {
-  chmodSync,
   existsSync,
   mkdirSync,
   readFileSync,
   rmSync,
   writeFileSync,
 } from "node:fs";
-import { delimiter, join, resolve } from "node:path";
+import { dirname, join, resolve } from "node:path";
 import { runtimeDir as defaultRuntimeDir, tmpDir, fail, ok, info } from "./lib/common.ts";
+import { pluginPath, pluginRemoveArgs, writePluginShims } from "./lib/plugin-shim.ts";
 
 const runtimeDirArg = process.argv.indexOf("--runtime-dir");
 if (runtimeDirArg >= 0 && !process.argv[runtimeDirArg + 1]) {
@@ -39,16 +39,18 @@ const tarball = join(fixture, "fixture.tgz");
 const toolsDir = join(home, ".desktop-tools");
 const profileDir = join(home, "profiles", "web");
 const storeDir = join(home, "pnpm-store");
+const configDir = join(toolsDir, "pnpm-config");
+const uninstallScriptMarker = join(home, "uninstall-script-ran");
 
-function run(args: string[], label: string): Promise<string> {
+function runChild(script: string, args: string[], cwd: string, label: string): Promise<string> {
   return new Promise((resolvePromise, reject) => {
-    const child = spawn(node, [dshBin, "plugin", "--profile", "web", ...args], {
-      cwd: harness,
+    const child = spawn(node, [script, ...args], {
+      cwd,
       env: {
         ...process.env,
         DSH_HOME: home,
         DSH_TELEMETRY_DISABLED: "1",
-        PATH: `${toolsDir}${delimiter}${process.env.PATH ?? ""}`,
+        PATH: pluginPath(toolsDir, process.env.PATH),
         pnpm_config_store_dir: storeDir,
       },
       stdio: ["ignore", "pipe", "pipe"],
@@ -84,12 +86,39 @@ function run(args: string[], label: string): Promise<string> {
   });
 }
 
+function run(args: string[], label: string): Promise<string> {
+  return runChild(dshBin, ["plugin", "--profile", "web", ...args], harness, label);
+}
+
+function runPnpmRemove(name: string, label: string): Promise<string> {
+  const modulesState = JSON.parse(
+    readFileSync(join(profileDir, "node_modules", ".modules.yaml"), "utf8"),
+  ) as { storeDir?: unknown };
+  if (typeof modulesState.storeDir !== "string") {
+    fail("pnpm .modules.yaml did not record a string storeDir");
+  }
+  return runChild(
+    pnpmCjs,
+    pluginRemoveArgs(name, configDir, dirname(modulesState.storeDir)),
+    profileDir,
+    label,
+  );
+}
+
 function makeFixture(): void {
   rmSync(fixture, { recursive: true, force: true });
   mkdirSync(packageDir, { recursive: true });
   writeFileSync(
     join(packageDir, "package.json"),
-    JSON.stringify({ name: "dsh-sideload-fixture", version: "1.0.0" }),
+    JSON.stringify({
+      name: "dsh-sideload-fixture",
+      version: "1.0.0",
+      scripts: { preuninstall: "node uninstall-marker.cjs" },
+    }),
+  );
+  writeFileSync(
+    join(packageDir, "uninstall-marker.cjs"),
+    `require("node:fs").writeFileSync(${JSON.stringify(uninstallScriptMarker)}, "unsafe");\n`,
   );
   const res = spawnSync("tar", ["-czf", tarball, "-C", fixture, "package"], {
     encoding: "utf8",
@@ -101,16 +130,9 @@ function makeFixture(): void {
 
 async function main(): Promise<void> {
   rmSync(home, { recursive: true, force: true });
-  mkdirSync(toolsDir, { recursive: true });
-  writeFileSync(
-    join(toolsDir, "pnpm"),
-    `#!/bin/sh\nexec "${node}" "${pnpmCjs}" "$@"\n`,
-  );
-  writeFileSync(
-    join(toolsDir, "pnpm.cmd"),
-    `@echo off\n"${node}" "${pnpmCjs}" %*\n`,
-  );
-  if (process.platform !== "win32") chmodSync(join(toolsDir, "pnpm"), 0o755);
+  writePluginShims(toolsDir, node, pnpmCjs);
+  mkdirSync(configDir, { recursive: true });
+  writeFileSync(join(configDir, ".npmrc"), "");
   makeFixture();
   info(`isolated DSH_HOME ${home} · tarball ${tarball}`);
 
@@ -138,8 +160,11 @@ async function main(): Promise<void> {
   await run(["add", "is-odd"], "dsh plugin add is-odd while file: dep is retained");
   ok("subsequent add succeeded while file: dependency source was retained");
 
-  await run(["remove", "dsh-sideload-fixture"], "dsh plugin remove dsh-sideload-fixture");
-  ok("dsh plugin remove dsh-sideload-fixture exited 0");
+  await runPnpmRemove("dsh-sideload-fixture", "direct pnpm remove dsh-sideload-fixture");
+  if (existsSync(uninstallScriptMarker)) {
+    fail("direct plugin removal executed the package preuninstall lifecycle script");
+  }
+  ok("direct, scripts-disabled pnpm remove dsh-sideload-fixture exited 0");
 
   rmSync(home, { recursive: true, force: true });
   rmSync(fixture, { recursive: true, force: true });

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -48,7 +48,10 @@ proptest = "1"
 # Needed for no-follow private-file handles and atomic replacement of
 # Desktop-owned state. This is already pinned by dsh-sidecar; declare it
 # directly because Rust crates may not rely on transitive dependencies.
-windows-sys = { version = "0.61", features = ["Win32_Storage_FileSystem"] }
+windows-sys = { version = "0.61", features = [
+  "Win32_Storage_FileSystem",
+  "Win32_System_SystemInformation",
+] }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 # Finder-launched GUI apps cannot rely on shell locale variables. Read the

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -6,8 +6,7 @@
 
 use crate::diagnostics::redact;
 use crate::harness::{
-    child_alive, open_harness_window, publish_snapshot, request_restart, send_raw,
-    snapshot_payload, Runtime, Status, CMD_ID_SHUTDOWN,
+    open_harness_window, request_restart, request_shutdown, snapshot_payload, Runtime, Status,
 };
 use dsh_sidecar::platform::{PlatformChild, SpawnSpec};
 use serde_json::Value;
@@ -83,39 +82,8 @@ pub fn restart(_runtime: State<'_, Runtime>, app: AppHandle) -> Result<(), Strin
 }
 
 #[tauri::command]
-pub fn shutdown(runtime: State<'_, Runtime>, app: AppHandle) -> Result<(), String> {
-    if !child_alive(&runtime) {
-        // Keep the real status (Stopped/Idle stays what it is) — only the
-        // message explains why nothing happened.
-        let error = "sidecar 未运行，无需停止".to_string();
-        runtime
-            .state
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner())
-            .last_error = Some(error.clone());
-        publish_snapshot(&app, &runtime.state);
-        return Err(error);
-    }
-
-    if let Err(error) = send_raw(
-        &runtime,
-        &serde_json::json!({"id": CMD_ID_SHUTDOWN, "command": "shutdown"}),
-    ) {
-        {
-            // Scope the lock: publish_snapshot takes the same mutex and a
-            // held guard here would deadlock the command.
-            let mut s = runtime
-                .state
-                .lock()
-                .unwrap_or_else(|poisoned| poisoned.into_inner());
-            s.last_error = Some(error.clone());
-            s.status = crate::harness::Status::Crashed;
-        }
-        publish_snapshot(&app, &runtime.state);
-        return Err(error);
-    }
-
-    Ok(())
+pub fn shutdown(app: AppHandle) -> Result<(), String> {
+    request_shutdown(&app)
 }
 
 #[tauri::command]

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -7,7 +7,7 @@
 use crate::diagnostics::redact;
 use crate::harness::{
     child_alive, open_harness_window, publish_snapshot, request_restart, send_raw,
-    snapshot_payload, Runtime, CMD_ID_SHUTDOWN,
+    snapshot_payload, Runtime, Status, CMD_ID_SHUTDOWN,
 };
 use dsh_sidecar::platform::{PlatformChild, SpawnSpec};
 use serde_json::Value;
@@ -16,6 +16,9 @@ use std::sync::Arc;
 use tauri::{AppHandle, Emitter, Manager, State};
 
 const MAX_PLUGIN_LOG_LINE_BYTES: usize = 8 * 1024;
+const PLUGIN_LOG_CHANNEL_CAPACITY: usize = 256;
+const PLUGIN_EXIT_DRAIN_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(1);
+const PLUGIN_CANCEL_DRAIN_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
 
 #[tauri::command]
 pub fn get_status(runtime: State<'_, Runtime>) -> Value {
@@ -327,9 +330,7 @@ pub async fn market_install_plugin(
     market: State<'_, std::sync::Arc<crate::market::MarketClient>>,
 ) -> Result<(), String> {
     let plugins = plugins.inner().clone();
-    if plugins.busy.swap(true, Ordering::SeqCst) {
-        return Err("an operation is already running".to_string());
-    }
+    begin_plugin_mutation(&plugins, &runtime)?;
     let dsh_version = runtime
         .state
         .lock()
@@ -340,38 +341,63 @@ pub async fn market_install_plugin(
     let candidate = match market.prepare_install(&slug, &dsh_version).await {
         Ok(candidate) => candidate,
         Err(error) => {
-            plugins.busy.store(false, Ordering::SeqCst);
+            plugins.finish();
             return Err(error);
         }
     };
-    if crate::build_info::STORE_BUILD
-        && !crate::curated_plugins::is_allowed(&candidate.package_name)
-    {
-        plugins.busy.store(false, Ordering::SeqCst);
+    if plugins.cancellation_requested() {
+        plugins.finish();
+        return Err("plugin installation was cancelled before profile mutation".to_string());
+    }
+    if !crate::market::distribution_allows_package(
+        &candidate.package_name,
+        crate::build_info::STORE_BUILD,
+    ) {
+        plugins.finish();
         return Err("仅允许安装 cordis.run 已审核插件".to_string());
     }
     if candidate.entry_revision != entry_revision {
-        plugins.busy.store(false, Ordering::SeqCst);
+        plugins.finish();
         return Err(
             "market entry changed; review the latest entryRevision before installing".to_string(),
         );
     }
     let Some(paths) = runtime.paths() else {
-        plugins.busy.store(false, Ordering::SeqCst);
+        plugins.finish();
         return Err("runtime paths are not resolved yet".to_string());
     };
     if let Err(error) = ensure_no_plugin_recovery(&runtime) {
-        plugins.busy.store(false, Ordering::SeqCst);
+        plugins.finish();
+        return Err(error);
+    }
+    if let Err(error) = crate::plugins::ensure_market_install_config(&paths.dsh_home) {
+        plugins.finish();
         return Err(error);
     }
     if let Err(error) = crate::plugins::pre_disable_market_plugin(&paths.dsh_home, &candidate) {
-        plugins.busy.store(false, Ordering::SeqCst);
+        plugins.finish();
         return Err(error);
     }
-    std::thread::spawn(move || {
-        run_market_pnpm(app, paths, plugins, candidate);
-    });
-    Ok(())
+    if plugins.cancellation_requested() {
+        plugins.finish();
+        return Err(
+            "plugin installation was cancelled after safe pre-disable; the plugin remains disabled"
+                .to_string(),
+        );
+    }
+    let worker_plugins = plugins.clone();
+    std::thread::Builder::new()
+        .name("market-plugin-install".to_string())
+        .spawn(move || {
+            run_market_pnpm(app, paths, worker_plugins, candidate);
+        })
+        .map(|_| ())
+        .map_err(|error| {
+            plugins.finish();
+            format!(
+                "cannot start market plugin worker after safe pre-disable; the plugin remains disabled: {error}"
+            )
+        })
 }
 
 /// Activate a previously verified pending market package. It refetches and
@@ -386,9 +412,7 @@ pub async fn activate_market_plugin(
     market: State<'_, std::sync::Arc<crate::market::MarketClient>>,
 ) -> Result<(), String> {
     let plugins = plugins.inner().clone();
-    if plugins.busy.swap(true, Ordering::SeqCst) {
-        return Err("an operation is already running".to_string());
-    }
+    begin_plugin_mutation(&plugins, &runtime)?;
     let dsh_version = runtime
         .state
         .lock()
@@ -399,32 +423,37 @@ pub async fn activate_market_plugin(
     let candidate = match market.prepare_install(&slug, &dsh_version).await {
         Ok(candidate) => candidate,
         Err(error) => {
-            plugins.busy.store(false, Ordering::SeqCst);
+            plugins.finish();
             return Err(error);
         }
     };
-    if crate::build_info::STORE_BUILD
-        && !crate::curated_plugins::is_allowed(&candidate.package_name)
-    {
-        plugins.busy.store(false, Ordering::SeqCst);
+    if plugins.cancellation_requested() {
+        plugins.finish();
+        return Err("plugin activation was cancelled before profile mutation".to_string());
+    }
+    if !crate::market::distribution_allows_package(
+        &candidate.package_name,
+        crate::build_info::STORE_BUILD,
+    ) {
+        plugins.finish();
         return Err("仅允许激活 cordis.run 已审核插件".to_string());
     }
     if candidate.entry_revision != entry_revision {
-        plugins.busy.store(false, Ordering::SeqCst);
+        plugins.finish();
         return Err(
             "market entry changed; install and review the latest revision before activation"
                 .to_string(),
         );
     }
     if let Err(error) = ensure_no_plugin_recovery(&runtime) {
-        plugins.busy.store(false, Ordering::SeqCst);
+        plugins.finish();
         return Err(error);
     }
     let result = runtime
         .paths()
         .ok_or_else(|| "runtime paths are not resolved yet".to_string())
         .and_then(|paths| crate::plugins::activate_market_plugin(&paths.dsh_home, &candidate));
-    plugins.busy.store(false, Ordering::SeqCst);
+    plugins.finish();
     result
 }
 
@@ -457,9 +486,7 @@ pub fn begin_plugin_recovery(
     plugins: State<'_, Arc<crate::plugins::PluginRunner>>,
 ) -> Result<Value, String> {
     let plugins = plugins.inner().clone();
-    if plugins.busy.swap(true, Ordering::SeqCst) {
-        return Err("an operation is already running".to_string());
-    }
+    begin_plugin_mutation(&plugins, &runtime)?;
     let result = (|| {
         let paths = runtime
             .paths()
@@ -481,7 +508,7 @@ pub fn begin_plugin_recovery(
         serde_json::to_value(transaction)
             .map_err(|error| format!("cannot serialize plugin recovery transaction: {error}"))
     })();
-    plugins.busy.store(false, Ordering::SeqCst);
+    plugins.finish();
     let transaction = result?;
     request_restart(&app).map_err(|error| {
         format!("plugin was safely disabled, but Harness restart failed: {error}")
@@ -498,24 +525,22 @@ pub async fn rollback_plugin_recovery(
     market: State<'_, std::sync::Arc<crate::market::MarketClient>>,
 ) -> Result<(), String> {
     let plugins = plugins.inner().clone();
-    if plugins.busy.swap(true, Ordering::SeqCst) {
-        return Err("an operation is already running".to_string());
-    }
+    begin_plugin_mutation(&plugins, &runtime)?;
     let paths = match runtime.paths() {
         Some(paths) => paths,
         None => {
-            plugins.busy.store(false, Ordering::SeqCst);
+            plugins.finish();
             return Err("runtime paths are not resolved yet".to_string());
         }
     };
     let receipt = match crate::recovery::rollback_receipt(&paths.dsh_home, &transaction_id) {
         Ok(receipt) => receipt,
         Err(error) => {
-            plugins.busy.store(false, Ordering::SeqCst);
+            plugins.finish();
             return Err(error);
         }
     };
-    if let Some(receipt) = receipt {
+    let approved_market_candidate = if let Some(receipt) = receipt {
         let dsh_version = runtime
             .state
             .lock()
@@ -526,44 +551,79 @@ pub async fn rollback_plugin_recovery(
         let candidate = match market.prepare_install(&receipt.slug, &dsh_version).await {
             Ok(candidate) => candidate,
             Err(error) => {
-                plugins.busy.store(false, Ordering::SeqCst);
+                plugins.finish();
                 return Err(format!(
                     "market-managed plugin cannot be re-enabled without live approval: {error}"
                 ));
             }
         };
+        if plugins.cancellation_requested() {
+            plugins.finish();
+            return Err("plugin recovery rollback was cancelled before re-enable".to_string());
+        }
         if !receipt.matches(&candidate) {
-            plugins.busy.store(false, Ordering::SeqCst);
+            plugins.finish();
             return Err(
                 "market entry changed; recovery rollback cannot re-enable the recorded package"
+                    .to_string(),
+            );
+        }
+        if !crate::market::distribution_allows_package(
+            &candidate.package_name,
+            crate::build_info::STORE_BUILD,
+        ) {
+            plugins.finish();
+            return Err(
+                "Microsoft Store recovery cannot re-enable a plugin removed from the reviewed snapshot"
                     .to_string(),
             );
         }
         if let Err(error) =
             crate::plugins::verify_market_installation(&paths.dsh_home, &candidate, true)
         {
-            plugins.busy.store(false, Ordering::SeqCst);
+            plugins.finish();
             return Err(format!(
                 "market-managed plugin failed local integrity revalidation: {error}"
             ));
         }
+        Some(candidate)
     } else if crate::build_info::STORE_BUILD {
-        plugins.busy.store(false, Ordering::SeqCst);
+        plugins.finish();
         return Err(
             "Microsoft Store recovery cannot re-enable a plugin without a live market receipt"
                 .to_string(),
         );
+    } else {
+        None
+    };
+    if plugins.cancellation_requested() {
+        plugins.finish();
+        return Err("plugin recovery rollback was cancelled before profile mutation".to_string());
+    }
+    if let Some(candidate) = &approved_market_candidate {
+        if let Err(error) = crate::plugins::record_active_market_receipt(&paths.dsh_home, candidate)
+        {
+            plugins.finish();
+            return Err(format!(
+                "cannot preserve reviewed market provenance before recovery rollback: {error}"
+            ));
+        }
     }
     if let Err(error) = crate::recovery::rollback(&paths.dsh_home, &transaction_id) {
-        plugins.busy.store(false, Ordering::SeqCst);
+        if let Some(candidate) = &approved_market_candidate {
+            let _ = crate::plugins::remove_active_market_receipt(
+                &paths.dsh_home,
+                &candidate.package_name,
+            );
+        }
+        plugins.finish();
         return Err(error);
     }
     if let Some(observability) = app.try_state::<Arc<crate::observability::Observability>>() {
         observability.record("plugin_recovery_rolled_back", serde_json::json!({}));
     }
-    let restart_result = request_restart(&app);
-    plugins.busy.store(false, Ordering::SeqCst);
-    restart_result
+    plugins.finish();
+    request_restart(&app)
 }
 
 #[tauri::command]
@@ -574,14 +634,12 @@ pub fn finalize_plugin_recovery(
     plugins: State<'_, Arc<crate::plugins::PluginRunner>>,
 ) -> Result<(), String> {
     let plugins = plugins.inner().clone();
-    if plugins.busy.swap(true, Ordering::SeqCst) {
-        return Err("an operation is already running".to_string());
-    }
+    begin_plugin_mutation(&plugins, &runtime)?;
     let result = runtime
         .paths()
         .ok_or_else(|| "runtime paths are not resolved yet".to_string())
         .and_then(|paths| crate::recovery::finalize(&paths.dsh_home, &transaction_id));
-    plugins.busy.store(false, Ordering::SeqCst);
+    plugins.finish();
     result?;
     if let Some(observability) = app.try_state::<Arc<crate::observability::Observability>>() {
         observability.record("plugin_recovery_finalized", serde_json::json!({}));
@@ -602,12 +660,40 @@ fn ensure_no_plugin_recovery(runtime: &Runtime) -> Result<(), String> {
     Ok(())
 }
 
+fn plugin_mutation_status_allowed(status: Status) -> bool {
+    !matches!(status, Status::Idle | Status::Starting | Status::Stopping)
+}
+
+/// Claim the plugin single-flight gate, then verify the Harness is not inside
+/// a start/stop boundary. User and automatic restarts use the same gate, so
+/// once this check succeeds no new restart can race pnpm/profile mutation.
+fn begin_plugin_mutation(
+    plugins: &crate::plugins::PluginRunner,
+    runtime: &Runtime,
+) -> Result<(), String> {
+    if !plugins.try_begin() {
+        return Err("an operation is already running".to_string());
+    }
+    let status = runtime
+        .state
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .status;
+    if !plugin_mutation_status_allowed(status) {
+        plugins.finish();
+        return Err("Harness 尚未就绪或正在启动/停止；状态稳定后才能修改插件".to_string());
+    }
+    Ok(())
+}
+
 #[cfg(test)]
 #[allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
 mod tests {
     use super::{
-        is_zip_content_type, plugin_path_env, read_installed_plugins, redact, sweep_sideload_dir,
-        sweep_sideloads_root,
+        is_zip_content_type, manual_plugin_install_allowed, market_pnpm_args, parse_pnpm_major,
+        plugin_mutation_status_allowed, plugin_path_env, redact, remove_pnpm_args,
+        supervise_plugin_output, sweep_sideload_dir, sweep_sideloads_root,
+        sweep_stale_sideloads_paths,
     };
 
     #[test]
@@ -667,14 +753,6 @@ mod tests {
         assert!(keep.is_file());
         assert!(!stale.exists());
         let _ = std::fs::remove_dir_all(&dir);
-    }
-
-    fn temp_dir(name: &str) -> std::path::PathBuf {
-        let dir =
-            std::env::temp_dir().join(format!("dsd-plugin-test-{name}-{}", std::process::id()));
-        let _ = std::fs::remove_dir_all(&dir);
-        std::fs::create_dir_all(&dir).unwrap();
-        dir
     }
 
     #[test]
@@ -748,48 +826,131 @@ mod tests {
     }
 
     #[test]
-    fn plugin_list_reads_deps_and_versions_sorted() {
-        let dir = temp_dir("list");
-        std::fs::write(
-            dir.join("package.json"),
-            r#"{"dependencies":{"zz-top":"1.0.0","is-odd":"^3.0.1"}}"#,
-        )
-        .unwrap();
-        std::fs::create_dir_all(dir.join("node_modules").join("is-odd")).unwrap();
-        std::fs::write(
-            dir.join("node_modules").join("is-odd").join("package.json"),
-            r#"{"name":"is-odd","version":"3.0.1"}"#,
-        )
-        .unwrap();
-        let entries = read_installed_plugins(&dir);
-        assert_eq!(
-            entries,
-            vec![
-                ("is-odd".to_string(), "3.0.1".to_string()),
-                // zz-top is a dependency but its tree entry is missing:
-                // still listed, with an unresolved version marker.
-                ("zz-top".to_string(), "—".to_string()),
-            ]
-        );
+    fn store_builds_reject_the_generic_install_path() {
+        assert!(manual_plugin_install_allowed(false));
+        assert!(!manual_plugin_install_allowed(true));
     }
 
     #[test]
-    fn plugin_list_tolerates_missing_or_malformed_profile() {
-        let dir = temp_dir("empty");
-        assert_eq!(read_installed_plugins(&dir), Vec::<(String, String)>::new());
-        std::fs::write(dir.join("package.json"), "not json").unwrap();
-        assert_eq!(read_installed_plugins(&dir), Vec::<(String, String)>::new());
-        std::fs::write(
-            dir.join("package.json"),
-            r#"{"dependencies":"not-an-object"}"#,
-        )
-        .unwrap();
-        // Malformed dependency payloads are skipped safely.
-        assert_eq!(read_installed_plugins(&dir), Vec::<(String, String)>::new());
+    fn plugin_mutations_wait_for_harness_transition_boundaries() {
+        assert!(!plugin_mutation_status_allowed(
+            crate::harness::Status::Idle
+        ));
+        assert!(!plugin_mutation_status_allowed(
+            crate::harness::Status::Starting
+        ));
+        assert!(!plugin_mutation_status_allowed(
+            crate::harness::Status::Stopping
+        ));
+        assert!(plugin_mutation_status_allowed(
+            crate::harness::Status::Running
+        ));
+        assert!(plugin_mutation_status_allowed(
+            crate::harness::Status::Crashed
+        ));
+        assert!(plugin_mutation_status_allowed(
+            crate::harness::Status::Stopped
+        ));
     }
 
     #[test]
-    fn plugin_path_splits_a_serialized_multi_segment_parent_path() {
+    fn market_pnpm_isolated_install_contract_is_complete() {
+        let candidate = crate::market::MarketInstallCandidate {
+            slug: "fixture-plugin".to_string(),
+            entry_revision: "revision-1".to_string(),
+            package_name: "fixture-plugin".to_string(),
+            version: "1.0.0".to_string(),
+            integrity: "sha512-fixture".to_string(),
+            registry: "https://registry.npmjs.org".to_string(),
+            tarball: "https://registry.npmjs.org/fixture-plugin/-/fixture-plugin-1.0.0.tgz"
+                .to_string(),
+        };
+        let store = std::path::Path::new("private-market-store");
+        let config = std::path::Path::new("private-market-config");
+        let args = market_pnpm_args(&candidate, Some(store), config);
+
+        assert_eq!(args[0], "add");
+        assert_eq!(args[1], candidate.tarball);
+        for required in [
+            "--ignore-scripts",
+            "--ignore-workspace",
+            "--global=false",
+            "--node-linker=hoisted",
+            "--config.auto-install-peers=false",
+            "--package-import-method=copy",
+            "--virtual-store-dir=node_modules/.pnpm",
+            "--config.enable-global-virtual-store=false",
+            "--verify-store-integrity",
+            "--config.strict-store-pkg-content-check=true",
+            "--config.ignore-pnpmfile=true",
+            "--save-exact",
+            "--reporter=append-only",
+            "--registry=https://registry.npmjs.org",
+        ] {
+            assert!(args.iter().any(|arg| arg == required), "missing {required}");
+        }
+        for required in [
+            format!("--store-dir={}", store.display()),
+            format!("--config.config-dir={}", config.display()),
+            format!("--config.userconfig={}", config.join(".npmrc").display()),
+            format!("--config.globalconfig={}", config.join(".npmrc").display()),
+        ] {
+            assert!(args.contains(&required), "missing {required}");
+        }
+    }
+
+    #[test]
+    fn direct_uninstall_never_uses_upstream_global_reconciliation() {
+        let store = std::path::Path::new("existing-profile-store");
+        let config = std::path::Path::new("private-plugin-config");
+        let args = remove_pnpm_args("fixture-plugin", Some(store), config);
+        assert_eq!(&args[..2], ["remove", "fixture-plugin"]);
+        assert!(args.iter().any(|arg| arg == "--config.ignore-scripts=true"));
+        assert!(args
+            .iter()
+            .any(|arg| arg == "--config.ignore-pnpmfile=true"));
+        assert!(args.iter().any(|arg| arg == "--ignore-workspace"));
+        assert!(args
+            .iter()
+            .any(|arg| arg == "--store-dir=existing-profile-store"));
+        assert!(!args.iter().any(|arg| arg == "plugin"));
+    }
+
+    #[test]
+    fn bundled_pnpm_major_is_strictly_parsed() {
+        assert_eq!(parse_pnpm_major(br#"{"version":"11.21.0"}"#).unwrap(), 11);
+        assert!(parse_pnpm_major(br#"{"version":"latest"}"#).is_err());
+        assert!(parse_pnpm_major(br#"{"version":"11.beta"}"#).is_err());
+        assert!(parse_pnpm_major(br#"{"name":"pnpm"}"#).is_err());
+    }
+
+    #[test]
+    fn sideload_sweep_fails_closed_when_the_profile_is_unreadable() {
+        let root = std::env::temp_dir().join(format!(
+            "dsh-sideload-unreadable-{}",
+            crate::secure_fs::random_suffix().unwrap()
+        ));
+        let profile = root.join("profiles/web");
+        let sideload = root.join(".desktop-tools/sideload");
+        std::fs::create_dir_all(&profile).unwrap();
+        std::fs::create_dir_all(&sideload).unwrap();
+        std::fs::write(profile.join("package.json"), "not json").unwrap();
+        let retained = sideload.join("retained.tgz");
+        std::fs::write(&retained, b"archive").unwrap();
+        let paths = crate::paths::RuntimePaths {
+            sidecar: root.join("sidecar"),
+            node: root.join("node"),
+            harness_dir: root.join("harness"),
+            dsh_home: root.clone(),
+        };
+
+        sweep_stale_sideloads_paths(&paths);
+        assert!(retained.is_file());
+        std::fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn plugin_path_prepends_shim_to_a_multi_segment_parent_path() {
         let parent = std::env::join_paths([
             std::path::Path::new("parent-one"),
             std::path::Path::new("parent-two"),
@@ -806,6 +967,15 @@ mod tests {
         );
     }
 
+    #[cfg(not(windows))]
+    #[test]
+    fn plugin_path_preserves_empty_parent_segments_verbatim() {
+        let inherited = std::ffi::OsStr::new("parent-one::parent-two:");
+        let actual =
+            plugin_path_env(std::path::Path::new("desktop-shim"), Some(inherited)).unwrap();
+        assert_eq!(actual, "desktop-shim:parent-one::parent-two:");
+    }
+
     #[test]
     fn plugin_path_without_parent_keeps_the_owned_shim() {
         let actual = plugin_path_env(std::path::Path::new("desktop-shim"), None).unwrap();
@@ -813,6 +983,47 @@ mod tests {
             std::env::split_paths(&actual).collect::<Vec<_>>(),
             vec![std::path::PathBuf::from("desktop-shim")]
         );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn closed_log_stream_does_not_make_a_running_plugin_uncancellable() {
+        use dsh_sidecar::platform::{PlatformChild, SpawnSpec};
+        use std::sync::Arc;
+
+        let runner = Arc::new(crate::plugins::PluginRunner::new());
+        assert!(runner.try_begin());
+        let child = PlatformChild::spawn(
+            &SpawnSpec {
+                node: "/bin/sh".to_string(),
+                script: "-c".to_string(),
+                args: vec!["exec 1>&- 2>&-; sleep 30".to_string()],
+                cwd: std::env::temp_dir().to_string_lossy().to_string(),
+                env: Vec::new(),
+            },
+            &std::env::vars_os().collect::<Vec<_>>(),
+        )
+        .unwrap();
+        *runner.child.lock().unwrap() = Some(child);
+        let (_tx, rx) = std::sync::mpsc::sync_channel(1);
+        drop(_tx);
+
+        let supervisor_runner = runner.clone();
+        let supervisor =
+            std::thread::spawn(move || supervise_plugin_output(&supervisor_runner, rx, |_| {}));
+        std::thread::sleep(std::time::Duration::from_millis(150));
+        assert!(
+            runner.child.lock().unwrap().is_some(),
+            "pipe closure must not discard the live process handle"
+        );
+        let (accepted, child) = runner.request_cancel();
+        assert!(accepted);
+        let child = child.expect("cancel must recover the registered process tree");
+        child.force();
+        drop(child);
+        runner.child_termination_finished();
+        assert_eq!(supervisor.join().unwrap(), None);
+        runner.finish();
     }
 }
 
@@ -995,45 +1206,11 @@ pub async fn export_preset(
 }
 
 // ---------------------------------------------------------------------------
-// Plugin installation (bundled pnpm + official `dsh plugin` CLI). The whole
-// node → dsh → pnpm → node-gyp tree runs under dsh-sidecar's PlatformChild
-// (process group / Job Object), so cancel and app exit clean it fully.
+// Plugin installation (bundled pnpm + official `dsh plugin` add CLI) and
+// precise direct-pnpm removal. The whole node → dsh/pnpm → node-gyp tree runs
+// under dsh-sidecar's PlatformChild (process group / Job Object), so cancel
+// and app exit clean it fully.
 // ---------------------------------------------------------------------------
-
-/// Pure profile-dir parse (unit-tested): user-installed plugin names from
-/// package.json dependencies, with resolved versions read from
-/// node_modules/<pkg>/package.json ("—" when the tree entry is missing).
-/// In-box bundles are not dependencies here, so they never appear — the UI
-/// can therefore offer uninstall on every listed row (plan §P1.4).
-#[cfg(test)]
-fn read_installed_plugins(profile_dir: &std::path::Path) -> Vec<(String, String)> {
-    let mut out = Vec::new();
-    if let Ok(text) = std::fs::read_to_string(profile_dir.join("package.json")) {
-        if let Ok(json) = serde_json::from_str::<serde_json::Value>(&text) {
-            if let Some(deps) = json.get("dependencies").and_then(|d| d.as_object()) {
-                for (name, _spec) in deps {
-                    let version = std::fs::read_to_string(
-                        profile_dir
-                            .join("node_modules")
-                            .join(name)
-                            .join("package.json"),
-                    )
-                    .ok()
-                    .and_then(|t| serde_json::from_str::<serde_json::Value>(&t).ok())
-                    .and_then(|p| {
-                        p.get("version")
-                            .and_then(|v| v.as_str())
-                            .map(str::to_string)
-                    })
-                    .unwrap_or_else(|| "—".to_string());
-                    out.push((name.clone(), version));
-                }
-            }
-        }
-    }
-    out.sort_by(|a, b| a.0.cmp(&b.0));
-    out
-}
 
 #[tauri::command]
 pub fn list_plugins(
@@ -1049,65 +1226,394 @@ pub fn list_plugins(
         // The backend busy flag survives webview reloads; the UI must be
         // able to resync instead of showing a stale idle state while an op
         // is still running (single-flight is app-wide).
-        "busy": plugins.busy.load(Ordering::SeqCst),
+        "busy": plugins.is_busy(),
     })
 }
 
-/// Prepend the Desktop-owned pnpm shim while retaining every inherited PATH
-/// entry. `join_paths` takes *individual* path segments, not a serialized
-/// PATH value: passing the latter as one segment rejects normal multi-entry
-/// PATH values on every platform (for example `a:b` on Unix).
+/// Prepend the Desktop-owned pnpm shim without parsing and rebuilding the
+/// inherited PATH. `join_paths` validates only the app-owned segment; feeding
+/// the serialized parent value to it as one segment caused the reported
+/// separator error and rebuilding can rewrite Windows quoting/empty segments.
 fn plugin_path_env(
     shim_dir: &std::path::Path,
     inherited_path: Option<&std::ffi::OsStr>,
 ) -> Result<std::ffi::OsString, std::env::JoinPathsError> {
-    let mut segments = vec![shim_dir.as_os_str().to_owned()];
-    if let Some(inherited_path) = inherited_path {
-        segments
-            .extend(std::env::split_paths(inherited_path).map(std::path::PathBuf::into_os_string));
+    let mut path = std::env::join_paths([shim_dir.as_os_str()])?;
+    if let Some(inherited_path) = inherited_path.filter(|path| !path.is_empty()) {
+        #[cfg(windows)]
+        path.push(";");
+        #[cfg(not(windows))]
+        path.push(":");
+        path.push(inherited_path);
     }
-    std::env::join_paths(segments)
+    Ok(path)
 }
 
-fn run_plugin_spec(
-    app: AppHandle,
-    paths: crate::paths::RuntimePaths,
-    plugins: Arc<crate::plugins::PluginRunner>,
-    plugin_spec: String,
+/// Upstream invokes pnpm through `shell: true` on Windows. Do not let an
+/// inherited, attacker-controlled ComSpec redirect that reviewed operation to
+/// an arbitrary executable: resolve cmd.exe from the OS system directory and
+/// pair it with the standard executable-extension search contract.
+#[cfg(windows)]
+fn trusted_windows_comspec() -> Result<String, String> {
+    use std::os::windows::ffi::OsStringExt;
+    use windows_sys::Win32::System::SystemInformation::GetSystemDirectoryW;
+
+    // Windows' documented extended path limit is 32,767 UTF-16 code units;
+    // the system directory is normally far shorter, but a fixed upper bound
+    // avoids trusting an inherited environment variable or allocating from an
+    // untrusted API length.
+    let mut buffer = vec![0_u16; 32_768];
+    // SAFETY: buffer is writable for the advertised length and remains alive
+    // for the duration of the synchronous Win32 call.
+    let length = unsafe { GetSystemDirectoryW(buffer.as_mut_ptr(), buffer.len() as u32) } as usize;
+    if length == 0 {
+        return Err(format!(
+            "cannot resolve the trusted Windows system directory: {}",
+            std::io::Error::last_os_error()
+        ));
+    }
+    if length >= buffer.len() {
+        return Err(
+            "trusted Windows system directory exceeds the supported path limit".to_string(),
+        );
+    }
+    let mut path = std::path::PathBuf::from(std::ffi::OsString::from_wide(&buffer[..length]));
+    path.push("cmd.exe");
+    let metadata = std::fs::symlink_metadata(&path)
+        .map_err(|error| format!("cannot inspect trusted Windows command shell: {error}"))?;
+    if crate::secure_fs::is_symlink_or_reparse(&metadata) || !metadata.is_file() {
+        return Err("trusted Windows command shell must be a regular file".to_string());
+    }
+    path.into_os_string()
+        .into_string()
+        .map_err(|_| "trusted Windows command shell path is not valid Unicode".to_string())
+}
+
+enum PluginChildPoll {
+    Running,
+    Missing,
+    Exited(Option<i32>, PlatformChild),
+    Failed(String, PlatformChild),
+}
+
+fn poll_plugin_child(plugins: &crate::plugins::PluginRunner) -> PluginChildPoll {
+    let mut slot = plugins
+        .child
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let Some(child) = slot.as_mut() else {
+        return PluginChildPoll::Missing;
+    };
+    let status = child.child.try_wait();
+    match status {
+        Ok(None) => PluginChildPoll::Running,
+        Ok(Some(status)) => match slot.take() {
+            Some(child) => PluginChildPoll::Exited(status.code(), child),
+            None => PluginChildPoll::Missing,
+        },
+        Err(error) => match slot.take() {
+            Some(child) => PluginChildPoll::Failed(error.to_string(), child),
+            None => PluginChildPoll::Missing,
+        },
+    }
+}
+
+fn attach_plugin_log_readers(
+    child: &mut PlatformChild,
+    tx: &std::sync::mpsc::SyncSender<(String, String)>,
+) -> Result<(), String> {
+    for (stream, pipe) in [
+        (
+            "stdout",
+            child
+                .child
+                .stdout
+                .take()
+                .map(|pipe| Box::new(pipe) as Box<dyn std::io::Read + Send>),
+        ),
+        (
+            "stderr",
+            child
+                .child
+                .stderr
+                .take()
+                .map(|pipe| Box::new(pipe) as Box<dyn std::io::Read + Send>),
+        ),
+    ] {
+        let Some(pipe) = pipe else {
+            continue;
+        };
+        let tx = tx.clone();
+        std::thread::Builder::new()
+            .name(format!("plugin-{stream}-reader"))
+            .spawn(move || {
+                let _ = dsh_sidecar::for_each_bounded_line(
+                    std::io::BufReader::new(pipe),
+                    MAX_PLUGIN_LOG_LINE_BYTES,
+                    |line| tx.send((stream.to_string(), line)).is_ok(),
+                );
+            })
+            .map_err(|error| format!("cannot start plugin {stream} reader: {error}"))?;
+    }
+    Ok(())
+}
+
+/// Drive one registered plugin process without using pipe closure as a proxy
+/// for process exit. A child can close stdout/stderr and keep running; keeping
+/// its handle registered lets Cancel and app-exit still terminate that tree.
+/// The receiver is bounded, so a noisy pnpm/plugin cannot move an unbounded
+/// amount of output from the OS pipe into Desktop heap memory.
+fn supervise_plugin_output(
+    plugins: &crate::plugins::PluginRunner,
+    rx: std::sync::mpsc::Receiver<(String, String)>,
+    mut on_event: impl FnMut(Option<(String, String)>),
+) -> Option<i32> {
+    let mut readers_disconnected = false;
+    let mut child_missing_since: Option<std::time::Instant> = None;
+
+    loop {
+        if readers_disconnected {
+            std::thread::sleep(std::time::Duration::from_millis(50));
+        } else {
+            match rx.recv_timeout(std::time::Duration::from_millis(100)) {
+                Ok(line) => on_event(Some(line)),
+                Err(std::sync::mpsc::RecvTimeoutError::Timeout) => on_event(None),
+                Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => {
+                    readers_disconnected = true;
+                    on_event(None);
+                }
+            }
+        }
+
+        match poll_plugin_child(plugins) {
+            PluginChildPoll::Running => child_missing_since = None,
+            PluginChildPoll::Missing => {
+                let since = child_missing_since.get_or_insert_with(std::time::Instant::now);
+                if readers_disconnected || since.elapsed() >= PLUGIN_CANCEL_DRAIN_TIMEOUT {
+                    on_event(None);
+                    return None;
+                }
+            }
+            PluginChildPoll::Exited(code, child) => {
+                // PlatformChild::drop tears down any descendants that kept
+                // the inherited pipes open after the direct pnpm/dsh process
+                // exited. Drop outside the runner mutex so Cancel never waits
+                // behind output draining.
+                drop(child);
+                drain_plugin_output(&rx, &mut on_event);
+                return code;
+            }
+            PluginChildPoll::Failed(error, child) => {
+                on_event(Some((
+                    "supervisor".to_string(),
+                    format!("cannot poll plugin process: {error}"),
+                )));
+                drop(child);
+                drain_plugin_output(&rx, &mut on_event);
+                return Some(1);
+            }
+        }
+    }
+}
+
+fn drain_plugin_output(
+    rx: &std::sync::mpsc::Receiver<(String, String)>,
+    on_event: &mut impl FnMut(Option<(String, String)>),
+) {
+    let deadline = std::time::Instant::now() + PLUGIN_EXIT_DRAIN_TIMEOUT;
+    loop {
+        match rx.recv_timeout(std::time::Duration::from_millis(25)) {
+            Ok(line) => on_event(Some(line)),
+            Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => break,
+            Err(std::sync::mpsc::RecvTimeoutError::Timeout)
+                if std::time::Instant::now() >= deadline =>
+            {
+                break;
+            }
+            Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {}
+        }
+    }
+    on_event(None);
+}
+
+fn emit_plugin_done(
+    app: &AppHandle,
+    paths: &crate::paths::RuntimePaths,
+    plugins: &crate::plugins::PluginRunner,
+    exit: Option<i32>,
+    tail: String,
     op: &'static str,
 ) {
-    use std::io::BufReader;
+    sweep_stale_sideloads_paths(paths);
+    plugins.finish_with(|| {
+        let _ = app.emit(
+            "plugin-done",
+            serde_json::json!({ "exit": exit, "tail": tail, "op": op }),
+        );
+    });
+}
 
+fn parse_pnpm_major(package_json: &[u8]) -> Result<u64, String> {
+    let package: serde_json::Value = serde_json::from_slice(package_json)
+        .map_err(|error| format!("bundled pnpm package.json is invalid JSON: {error}"))?;
+    let version = package
+        .get("version")
+        .and_then(serde_json::Value::as_str)
+        .ok_or_else(|| "bundled pnpm package.json has no version".to_string())?;
+    semver::Version::parse(version)
+        .map(|version| version.major)
+        .map_err(|error| format!("bundled pnpm version is invalid: {error}"))
+}
+
+fn bundled_pnpm_major(paths: &crate::paths::RuntimePaths) -> Result<u64, String> {
+    let manifest = paths
+        .harness_dir
+        .join("node_modules")
+        .join("pnpm")
+        .join("package.json");
+    let bytes = crate::secure_fs::read_bounded(&manifest, 256 * 1024)?
+        .ok_or_else(|| "bundled pnpm package.json is missing".to_string())?;
+    parse_pnpm_major(&bytes)
+}
+
+fn prepare_plugin_pnpm_config(dsh_home: &std::path::Path) -> Result<std::path::PathBuf, String> {
+    let tools = crate::plugins::market_tools_dir(dsh_home)?;
+    let config_home = tools.join("pnpm-config");
+    crate::secure_fs::ensure_private_dir(&config_home)
+        .and_then(|()| crate::secure_fs::atomic_write(&config_home.join(".npmrc"), b"", 1024))
+        .map_err(|error| format!("cannot prepare isolated plugin pnpm configuration: {error}"))?;
+    Ok(config_home)
+}
+
+fn isolated_pnpm_args(store_dir: Option<&std::path::Path>) -> Vec<String> {
+    let mut args = vec![
+        "--ignore-workspace".to_string(),
+        "--global=false".to_string(),
+        "--node-linker=hoisted".to_string(),
+        "--config.auto-install-peers=false".to_string(),
+        "--package-import-method=copy".to_string(),
+        "--virtual-store-dir=node_modules/.pnpm".to_string(),
+        "--yes".to_string(),
+        "--reporter=append-only".to_string(),
+    ];
+    if let Some(store_dir) = store_dir {
+        args.push(format!("--store-dir={}", store_dir.display()));
+    }
+    args
+}
+
+fn market_pnpm_args(
+    candidate: &crate::market::MarketInstallCandidate,
+    store_dir: Option<&std::path::Path>,
+    config_home: &std::path::Path,
+) -> Vec<String> {
+    let mut args = vec!["add".to_string(), candidate.tarball.clone()];
+    args.extend(isolated_pnpm_args(store_dir));
+    let npmrc = config_home.join(".npmrc");
+    args.extend([
+        "--ignore-scripts".to_string(),
+        "--config.ignore-pnpmfile=true".to_string(),
+        "--config.enable-global-virtual-store=false".to_string(),
+        "--verify-store-integrity".to_string(),
+        "--config.strict-store-pkg-content-check=true".to_string(),
+        format!("--config.config-dir={}", config_home.display()),
+        format!("--config.userconfig={}", npmrc.display()),
+        format!("--config.globalconfig={}", npmrc.display()),
+    ]);
+    args.push("--save-exact".to_string());
+    args.push(format!("--registry={}", candidate.registry));
+    args
+}
+
+fn remove_pnpm_args(
+    package_name: &str,
+    store_dir: Option<&std::path::Path>,
+    config_home: &std::path::Path,
+) -> Vec<String> {
+    let mut args = vec!["remove".to_string(), package_name.to_string()];
+    args.extend(isolated_pnpm_args(store_dir));
+    let npmrc = config_home.join(".npmrc");
+    // pnpm 11's remove command intentionally does not expose these install
+    // settings as first-class flags. The documented `--config.*` escape hatch
+    // applies them without the CLI rejecting the operation as unknown.
+    args.extend([
+        "--config.ignore-scripts=true".to_string(),
+        "--config.ignore-pnpmfile=true".to_string(),
+        "--config.enable-global-virtual-store=false".to_string(),
+        "--config.verify-store-integrity=true".to_string(),
+        "--config.strict-store-pkg-content-check=true".to_string(),
+        format!("--config.config-dir={}", config_home.display()),
+        format!("--config.userconfig={}", npmrc.display()),
+        format!("--config.globalconfig={}", npmrc.display()),
+    ]);
+    args
+}
+
+fn plugin_spawn_spec(
+    paths: &crate::paths::RuntimePaths,
+    plugin_spec: &str,
+    op: &'static str,
+) -> Result<SpawnSpec, String> {
     let pnpm_cjs = paths
         .harness_dir
         .join("node_modules")
         .join("pnpm")
         .join("bin")
         .join("pnpm.cjs");
-    let shim_dir = match crate::plugins::ensure_pnpm_shim(&paths.dsh_home, &paths.node, &pnpm_cjs) {
-        Ok(d) => d,
-        Err(e) => {
-            let _ = app.emit(
-                "plugin-done",
-                serde_json::json!({ "exit": 1, "tail": e, "op": op }),
-            );
-            plugins.busy.store(false, Ordering::SeqCst);
-            return;
-        }
-    };
+    if op == "remove" {
+        let profile = crate::plugins::market_profile_dir(&paths.dsh_home)?;
+        let config_home = prepare_plugin_pnpm_config(&paths.dsh_home)?;
+        let store_dir = crate::plugins::pnpm_store_base(&profile, bundled_pnpm_major(paths)?)?;
+        return Ok(SpawnSpec {
+            node: paths.node.to_string_lossy().to_string(),
+            script: pnpm_cjs.to_string_lossy().to_string(),
+            args: remove_pnpm_args(plugin_spec, store_dir.as_deref(), &config_home),
+            cwd: profile.to_string_lossy().to_string(),
+            env: vec![
+                (
+                    "DSH_HOME".to_string(),
+                    paths.dsh_home.to_string_lossy().to_string(),
+                ),
+                (
+                    "XDG_CONFIG_HOME".to_string(),
+                    config_home.to_string_lossy().to_string(),
+                ),
+                (
+                    "NPM_CONFIG_USERCONFIG".to_string(),
+                    config_home.join(".npmrc").to_string_lossy().to_string(),
+                ),
+            ],
+        });
+    }
+
+    let shim_dir = crate::plugins::ensure_pnpm_shim(&paths.dsh_home, &paths.node, &pnpm_cjs)?;
     let inherited_path = std::env::var_os("PATH");
-    let path_env = match plugin_path_env(&shim_dir, inherited_path.as_deref()) {
-        Ok(path_env) => path_env.to_string_lossy().to_string(),
-        Err(e) => {
-            let _ = app.emit(
-                "plugin-done",
-                serde_json::json!({ "exit": 1, "tail": format!("cannot build PATH: {e}"), "op": op }),
-            );
-            plugins.busy.store(false, Ordering::SeqCst);
-            return;
-        }
-    };
-    let spawn_spec = SpawnSpec {
+    let path_env = plugin_path_env(&shim_dir, inherited_path.as_deref())
+        .map_err(|error| format!("cannot build PATH: {error}"))?;
+    let store_dir =
+        crate::plugins::generic_profile_store_base(&paths.dsh_home, bundled_pnpm_major(paths)?)?;
+    let mut env = vec![
+        (
+            "DSH_HOME".to_string(),
+            paths.dsh_home.to_string_lossy().to_string(),
+        ),
+        ("PATH".to_string(), path_env.to_string_lossy().to_string()),
+    ];
+    if let Some(store_dir) = store_dir {
+        // PlatformChild removes inherited pnpm_config_* keys, then applies
+        // these Desktop-owned overrides. Reusing only pnpm's recorded store
+        // avoids both config injection and ERR_PNPM_UNEXPECTED_STORE.
+        env.push((
+            "PNPM_CONFIG_STORE_DIR".to_string(),
+            store_dir.to_string_lossy().to_string(),
+        ));
+    }
+    #[cfg(windows)]
+    {
+        env.push(("ComSpec".to_string(), trusted_windows_comspec()?));
+        env.push(("PATHEXT".to_string(), ".COM;.EXE;.BAT;.CMD".to_string()));
+    }
+    Ok(SpawnSpec {
         node: paths.node.to_string_lossy().to_string(),
         script: paths
             .harness_dir
@@ -1123,26 +1629,70 @@ fn run_plugin_spec(
             "--profile".to_string(),
             "web".to_string(),
             op.to_string(),
-            plugin_spec.clone(),
+            plugin_spec.to_string(),
         ],
         cwd: paths.harness_dir.to_string_lossy().to_string(),
-        env: vec![
-            (
-                "DSH_HOME".to_string(),
-                paths.dsh_home.to_string_lossy().to_string(),
-            ),
-            ("PATH".to_string(), path_env),
-        ],
+        env,
+    })
+}
+
+fn run_plugin_spec(
+    app: AppHandle,
+    paths: crate::paths::RuntimePaths,
+    plugins: Arc<crate::plugins::PluginRunner>,
+    plugin_spec: String,
+    op: &'static str,
+) {
+    if plugins.cancellation_requested() {
+        emit_plugin_done(
+            &app,
+            &paths,
+            &plugins,
+            None,
+            "plugin operation cancelled before start".to_string(),
+            op,
+        );
+        return;
+    }
+
+    let spawn_spec = match plugin_spawn_spec(&paths, &plugin_spec, op) {
+        Ok(spawn_spec) => spawn_spec,
+        Err(mut error) => {
+            if op == "remove" {
+                error.push_str("; the requested plugin remains safely disabled");
+            }
+            emit_plugin_done(&app, &paths, &plugins, Some(1), error, op);
+            return;
+        }
     };
+    if plugins.cancellation_requested() {
+        emit_plugin_done(
+            &app,
+            &paths,
+            &plugins,
+            None,
+            "plugin operation cancelled before spawn".to_string(),
+            op,
+        );
+        return;
+    }
     let inherited = std::env::vars_os().collect::<Vec<_>>();
     let child = match PlatformChild::spawn(&spawn_spec, &inherited) {
         Ok(c) => c,
         Err(e) => {
-            let _ = app.emit(
-                "plugin-done",
-                serde_json::json!({ "exit": 1, "tail": format!("spawn failed: {e}"), "op": op }),
+            let suffix = if op == "remove" {
+                "; the requested plugin remains safely disabled"
+            } else {
+                ""
+            };
+            emit_plugin_done(
+                &app,
+                &paths,
+                &plugins,
+                Some(1),
+                format!("spawn failed: {e}{suffix}"),
+                op,
             );
-            plugins.busy.store(false, Ordering::SeqCst);
             return;
         }
     };
@@ -1150,10 +1700,21 @@ fn run_plugin_spec(
     // kill what is already stored, so if the exit latch flipped while the
     // tree was being created, kill the fresh tree HERE (on unix its process
     // group would otherwise outlive the shell).
-    if plugins.exiting.load(Ordering::SeqCst) {
+    if plugins.exiting.load(Ordering::SeqCst) || plugins.cancellation_requested() {
         let _ = child.graceful();
         child.force();
-        plugins.busy.store(false, Ordering::SeqCst);
+        if !plugins.exiting.load(Ordering::SeqCst) {
+            emit_plugin_done(
+                &app,
+                &paths,
+                &plugins,
+                None,
+                "plugin operation cancelled during spawn".to_string(),
+                op,
+            );
+        } else {
+            plugins.finish();
+        }
         return;
     }
 
@@ -1170,40 +1731,15 @@ fn run_plugin_spec(
             .collect();
         let _ = app_c.emit("plugin-log", serde_json::json!(payload));
     };
-    let (tx, rx) = std::sync::mpsc::channel::<(String, String)>();
-    let child = {
-        let mut child = child;
-        for (stream, pipe) in [
-            (
-                "stdout",
-                child
-                    .child
-                    .stdout
-                    .take()
-                    .map(|p| Box::new(p) as Box<dyn std::io::Read + Send>),
-            ),
-            (
-                "stderr",
-                child
-                    .child
-                    .stderr
-                    .take()
-                    .map(|p| Box::new(p) as Box<dyn std::io::Read + Send>),
-            ),
-        ] {
-            if let Some(pipe) = pipe {
-                let tx = tx.clone();
-                std::thread::spawn(move || {
-                    let _ = dsh_sidecar::for_each_bounded_line(
-                        BufReader::new(pipe),
-                        MAX_PLUGIN_LOG_LINE_BYTES,
-                        |line| tx.send((stream.to_string(), line)).is_ok(),
-                    );
-                });
-            }
-        }
-        child
-    };
+    let (tx, rx) = std::sync::mpsc::sync_channel::<(String, String)>(PLUGIN_LOG_CHANNEL_CAPACITY);
+    let mut child = child;
+    if let Err(error) = attach_plugin_log_readers(&mut child, &tx) {
+        drop(tx);
+        child.force();
+        drop(child);
+        emit_plugin_done(&app, &paths, &plugins, Some(1), error, op);
+        return;
+    }
     // The readers hold clones; the ORIGINAL sender must go before the loop
     // or `Disconnected` never fires (cancel takes the child out of the
     // runner, and without Disconnected the loop would spin forever — busy
@@ -1213,7 +1749,7 @@ fn run_plugin_spec(
     // Second half of the exit race: shutdown() may have flipped the latch
     // between the post-spawn check above and this store — it would have
     // taken None, so reclaim and kill the tree ourselves.
-    if plugins.exiting.load(Ordering::SeqCst) {
+    if plugins.exiting.load(Ordering::SeqCst) || plugins.cancellation_requested() {
         if let Some(child) = plugins
             .child
             .lock()
@@ -1223,7 +1759,18 @@ fn run_plugin_spec(
             let _ = child.graceful();
             child.force();
         }
-        plugins.busy.store(false, Ordering::SeqCst);
+        if !plugins.exiting.load(Ordering::SeqCst) {
+            emit_plugin_done(
+                &app,
+                &paths,
+                &plugins,
+                None,
+                "plugin operation cancelled before execution".to_string(),
+                op,
+            );
+        } else {
+            plugins.finish();
+        }
         return;
     }
     fn handle_line(
@@ -1242,51 +1789,11 @@ fn run_plugin_spec(
             flush(pending);
         }
     }
-    let mut exit = loop {
-        match rx.recv_timeout(std::time::Duration::from_millis(100)) {
-            Ok((stream, line)) => handle_line(&mut tail, &mut pending, &mut flush, stream, line),
-            Err(std::sync::mpsc::RecvTimeoutError::Timeout) => flush(&mut pending),
-            Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => {
-                flush(&mut pending);
-                // Pipes closed: normally the tree has exited and wait()
-                // recovers the REAL exit code (reporting null would make
-                // the UI show "terminated" for successful installs). Take
-                // the handle FIRST so the wait() does not hold the runner
-                // mutex — cancel/app-exit must stay able to kill a hung
-                // tree. If cancel took it already, a canceled op keeps its
-                // null code.
-                let handle = plugins
-                    .child
-                    .lock()
-                    .unwrap_or_else(|p| p.into_inner())
-                    .take();
-                break handle
-                    .and_then(|mut c| c.child.wait().ok())
-                    .and_then(|s| s.code());
-            }
-        }
-        if let Some(child) = plugins
-            .child
-            .lock()
-            .unwrap_or_else(|p| p.into_inner())
-            .as_mut()
-        {
-            if let Some(status) = child.child.try_wait().ok().flatten() {
-                // Fast-exit path: drain what the reader threads already
-                // queued (exit closes the pipes, so they wind down within
-                // a tick) so the last log lines reach the UI/tail, then
-                // report the code try_wait() reaped.
-                while let Ok((stream, line)) = rx.recv_timeout(std::time::Duration::from_millis(50))
-                {
-                    handle_line(&mut tail, &mut pending, &mut flush, stream, line);
-                }
-                flush(&mut pending);
-                break status.code();
-            }
-        }
-    };
-    *plugins.child.lock().unwrap_or_else(|p| p.into_inner()) = None;
-    if let Err(error) = crate::plugins::reconcile_active_market_receipts(&paths.dsh_home) {
+    let mut exit = supervise_plugin_output(&plugins, rx, |event| match event {
+        Some((stream, line)) => handle_line(&mut tail, &mut pending, &mut flush, stream, line),
+        None => flush(&mut pending),
+    });
+    if let Err(error) = crate::plugins::reconcile_market_receipts(&paths.dsh_home) {
         handle_line(
             &mut tail,
             &mut pending,
@@ -1295,13 +1802,15 @@ fn run_plugin_spec(
             format!("plugin operation completed, but market provenance cleanup failed: {error}"),
         );
         flush(&mut pending);
-        exit = Some(1);
+        // A successful direct removal is not undone by a corrupt optional
+        // provenance receipt. Keep uninstall available as the fail-safe path;
+        // malformed receipts grant no activation/recovery authority and the
+        // warning remains visible in the operation log.
+        if op != "remove" {
+            exit = Some(1);
+        }
     }
-    plugins.busy.store(false, Ordering::SeqCst);
-    let _ = app.emit(
-        "plugin-done",
-        serde_json::json!({ "exit": exit, "tail": tail.join("\n"), "op": op }),
-    );
+    emit_plugin_done(&app, &paths, &plugins, exit, tail.join("\n"), op);
 }
 
 /// Run the market-only direct pnpm path. The official dsh plugin command
@@ -1315,59 +1824,112 @@ fn run_market_pnpm(
     plugins: Arc<crate::plugins::PluginRunner>,
     candidate: crate::market::MarketInstallCandidate,
 ) {
-    use std::io::BufReader;
+    if plugins.cancellation_requested() {
+        emit_plugin_done(
+            &app,
+            &paths,
+            &plugins,
+            None,
+            "market install cancelled before start".to_string(),
+            "market-install",
+        );
+        return;
+    }
 
     let profile = match crate::plugins::market_profile_dir(&paths.dsh_home) {
         Ok(profile) => profile,
         Err(error) => {
-            let _ = app.emit(
-                "plugin-done",
-                serde_json::json!({ "exit": 1, "tail": error, "op": "market-install" }),
-            );
-            plugins.busy.store(false, Ordering::SeqCst);
+            emit_plugin_done(&app, &paths, &plugins, Some(1), error, "market-install");
             return;
         }
     };
+    if let Err(error) = crate::plugins::ensure_market_install_config(&paths.dsh_home) {
+        emit_plugin_done(&app, &paths, &plugins, Some(1), error, "market-install");
+        return;
+    }
     let pnpm = paths
         .harness_dir
         .join("node_modules")
         .join("pnpm")
         .join("bin")
         .join("pnpm.cjs");
-    let spawn_spec = SpawnSpec {
-        node: paths.node.to_string_lossy().to_string(),
-        script: pnpm.to_string_lossy().to_string(),
-        args: vec![
-            "add".to_string(),
-            candidate.tarball.clone(),
-            "--ignore-scripts".to_string(),
-            "--save-exact".to_string(),
-            "--yes".to_string(),
-            "--reporter=append-only".to_string(),
-            format!("--registry={}", candidate.registry),
-        ],
-        cwd: profile.to_string_lossy().to_string(),
-        env: vec![(
-            "DSH_HOME".to_string(),
-            paths.dsh_home.to_string_lossy().to_string(),
-        )],
-    };
-    let inherited = std::env::vars_os().collect::<Vec<_>>();
-    let child = match PlatformChild::spawn(&spawn_spec, &inherited) {
-        Ok(child) => child,
+    let config_home = match prepare_plugin_pnpm_config(&paths.dsh_home) {
+        Ok(config_home) => config_home,
         Err(error) => {
-            let _ = app.emit(
-                "plugin-done",
-                serde_json::json!({ "exit": 1, "tail": format!("market pnpm spawn failed: {error}"), "op": "market-install" }),
-            );
-            plugins.busy.store(false, Ordering::SeqCst);
+            emit_plugin_done(&app, &paths, &plugins, Some(1), error, "market-install");
             return;
         }
     };
-    if plugins.exiting.load(Ordering::SeqCst) {
+    let store_dir = match bundled_pnpm_major(&paths)
+        .and_then(|major| crate::plugins::pnpm_store_base(&profile, major))
+    {
+        Ok(store_dir) => store_dir,
+        Err(error) => {
+            emit_plugin_done(&app, &paths, &plugins, Some(1), error, "market-install");
+            return;
+        }
+    };
+    let spawn_spec = SpawnSpec {
+        node: paths.node.to_string_lossy().to_string(),
+        script: pnpm.to_string_lossy().to_string(),
+        args: market_pnpm_args(&candidate, store_dir.as_deref(), &config_home),
+        cwd: profile.to_string_lossy().to_string(),
+        env: vec![
+            (
+                "DSH_HOME".to_string(),
+                paths.dsh_home.to_string_lossy().to_string(),
+            ),
+            (
+                "XDG_CONFIG_HOME".to_string(),
+                config_home.to_string_lossy().to_string(),
+            ),
+            (
+                "NPM_CONFIG_USERCONFIG".to_string(),
+                config_home.join(".npmrc").to_string_lossy().to_string(),
+            ),
+        ],
+    };
+    let inherited = std::env::vars_os().collect::<Vec<_>>();
+    if plugins.cancellation_requested() {
+        emit_plugin_done(
+            &app,
+            &paths,
+            &plugins,
+            None,
+            "market install cancelled before spawn".to_string(),
+            "market-install",
+        );
+        return;
+    }
+    let child = match PlatformChild::spawn(&spawn_spec, &inherited) {
+        Ok(child) => child,
+        Err(error) => {
+            emit_plugin_done(
+                &app,
+                &paths,
+                &plugins,
+                Some(1),
+                format!("market pnpm spawn failed: {error}"),
+                "market-install",
+            );
+            return;
+        }
+    };
+    if plugins.exiting.load(Ordering::SeqCst) || plugins.cancellation_requested() {
         let _ = child.graceful();
         child.force();
-        plugins.busy.store(false, Ordering::SeqCst);
+        if !plugins.exiting.load(Ordering::SeqCst) {
+            emit_plugin_done(
+                &app,
+                &paths,
+                &plugins,
+                None,
+                "market install cancelled during spawn".to_string(),
+                "market-install",
+            );
+        } else {
+            plugins.finish();
+        }
         return;
     }
 
@@ -1384,46 +1946,21 @@ fn run_market_pnpm(
             .collect();
         let _ = app_c.emit("plugin-log", serde_json::json!(payload));
     };
-    let (tx, rx) = std::sync::mpsc::channel::<(String, String)>();
-    let child = {
-        let mut child = child;
-        for (stream, pipe) in [
-            (
-                "stdout",
-                child
-                    .child
-                    .stdout
-                    .take()
-                    .map(|pipe| Box::new(pipe) as Box<dyn std::io::Read + Send>),
-            ),
-            (
-                "stderr",
-                child
-                    .child
-                    .stderr
-                    .take()
-                    .map(|pipe| Box::new(pipe) as Box<dyn std::io::Read + Send>),
-            ),
-        ] {
-            if let Some(pipe) = pipe {
-                let tx = tx.clone();
-                std::thread::spawn(move || {
-                    let _ = dsh_sidecar::for_each_bounded_line(
-                        BufReader::new(pipe),
-                        MAX_PLUGIN_LOG_LINE_BYTES,
-                        |line| tx.send((stream.to_string(), line)).is_ok(),
-                    );
-                });
-            }
-        }
-        child
-    };
+    let (tx, rx) = std::sync::mpsc::sync_channel::<(String, String)>(PLUGIN_LOG_CHANNEL_CAPACITY);
+    let mut child = child;
+    if let Err(error) = attach_plugin_log_readers(&mut child, &tx) {
+        drop(tx);
+        child.force();
+        drop(child);
+        emit_plugin_done(&app, &paths, &plugins, Some(1), error, "market-install");
+        return;
+    }
     drop(tx);
     *plugins
         .child
         .lock()
         .unwrap_or_else(|poisoned| poisoned.into_inner()) = Some(child);
-    if plugins.exiting.load(Ordering::SeqCst) {
+    if plugins.exiting.load(Ordering::SeqCst) || plugins.cancellation_requested() {
         if let Some(child) = plugins
             .child
             .lock()
@@ -1433,7 +1970,18 @@ fn run_market_pnpm(
             let _ = child.graceful();
             child.force();
         }
-        plugins.busy.store(false, Ordering::SeqCst);
+        if !plugins.exiting.load(Ordering::SeqCst) {
+            emit_plugin_done(
+                &app,
+                &paths,
+                &plugins,
+                None,
+                "market install cancelled before execution".to_string(),
+                "market-install",
+            );
+        } else {
+            plugins.finish();
+        }
         return;
     }
     fn handle_line(
@@ -1452,43 +2000,11 @@ fn run_market_pnpm(
             flush(pending);
         }
     }
-    let mut exit = loop {
-        match rx.recv_timeout(std::time::Duration::from_millis(100)) {
-            Ok((stream, line)) => handle_line(&mut tail, &mut pending, &mut flush, stream, line),
-            Err(std::sync::mpsc::RecvTimeoutError::Timeout) => flush(&mut pending),
-            Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => {
-                flush(&mut pending);
-                let handle = plugins
-                    .child
-                    .lock()
-                    .unwrap_or_else(|poisoned| poisoned.into_inner())
-                    .take();
-                break handle
-                    .and_then(|mut child| child.child.wait().ok())
-                    .and_then(|status| status.code());
-            }
-        }
-        if let Some(child) = plugins
-            .child
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner())
-            .as_mut()
-        {
-            if let Some(status) = child.child.try_wait().ok().flatten() {
-                while let Ok((stream, line)) = rx.recv_timeout(std::time::Duration::from_millis(50))
-                {
-                    handle_line(&mut tail, &mut pending, &mut flush, stream, line);
-                }
-                flush(&mut pending);
-                break status.code();
-            }
-        }
-    };
-    *plugins
-        .child
-        .lock()
-        .unwrap_or_else(|poisoned| poisoned.into_inner()) = None;
-    if exit == Some(0) {
+    let mut exit = supervise_plugin_output(&plugins, rx, |event| match event {
+        Some((stream, line)) => handle_line(&mut tail, &mut pending, &mut flush, stream, line),
+        None => flush(&mut pending),
+    });
+    if exit == Some(0) && !plugins.cancellation_requested() {
         if let Err(error) =
             crate::plugins::verify_and_mark_market_pending(&paths.dsh_home, &candidate)
         {
@@ -1502,12 +2018,46 @@ fn run_market_pnpm(
             flush(&mut pending);
             exit = Some(1);
         }
+    } else if exit == Some(0) {
+        handle_line(
+            &mut tail,
+            &mut pending,
+            &mut flush,
+            "verify".to_string(),
+            "market install completed, but activation remained disabled because cancellation was requested"
+                .to_string(),
+        );
+        flush(&mut pending);
+        exit = None;
     }
-    plugins.busy.store(false, Ordering::SeqCst);
-    let _ = app.emit(
-        "plugin-done",
-        serde_json::json!({ "exit": exit, "tail": tail.join("\n"), "op": "market-install" }),
+    emit_plugin_done(
+        &app,
+        &paths,
+        &plugins,
+        exit,
+        tail.join("\n"),
+        "market-install",
     );
+}
+
+fn spawn_plugin_worker(
+    app: AppHandle,
+    paths: crate::paths::RuntimePaths,
+    plugins: Arc<crate::plugins::PluginRunner>,
+    spec: String,
+    op: &'static str,
+) -> Result<(), String> {
+    let worker_plugins = plugins.clone();
+    std::thread::Builder::new()
+        .name(format!("plugin-{op}"))
+        .spawn(move || {
+            run_plugin_spec(app, paths, worker_plugins, spec, op);
+        })
+        .map(|_| ())
+        .map_err(|error| {
+            plugins.finish();
+            format!("cannot start plugin operation worker: {error}")
+        })
 }
 
 fn spawn_plugin_spec(
@@ -1517,21 +2067,22 @@ fn spawn_plugin_spec(
     spec: String,
     op: &'static str,
 ) -> Result<(), String> {
-    if plugins.busy.swap(true, Ordering::SeqCst) {
-        return Err("an operation is already running".to_string());
-    }
+    begin_plugin_mutation(&plugins, runtime)?;
     if let Err(error) = ensure_no_plugin_recovery(runtime) {
-        plugins.busy.store(false, Ordering::SeqCst);
+        plugins.finish();
         return Err(error);
     }
     let Some(paths) = runtime.paths() else {
-        plugins.busy.store(false, Ordering::SeqCst);
+        plugins.finish();
         return Err("runtime paths are not resolved yet".to_string());
     };
-    std::thread::spawn(move || {
-        run_plugin_spec(app, paths, plugins, spec, op);
-    });
-    Ok(())
+    if let Err(error) = crate::plugins::ensure_no_pending_market_plugins(&paths.dsh_home) {
+        plugins.finish();
+        return Err(format!(
+            "cannot start a generic plugin addition safely: {error}"
+        ));
+    }
+    spawn_plugin_worker(app, paths, plugins, spec, op)
 }
 
 fn plugin_op(
@@ -1547,6 +2098,10 @@ fn plugin_op(
     spawn_plugin_spec(app, runtime, plugins, spec, op)
 }
 
+fn manual_plugin_install_allowed(store_build: bool) -> bool {
+    !store_build
+}
+
 #[tauri::command]
 pub fn install_plugin(
     app: AppHandle,
@@ -1554,8 +2109,12 @@ pub fn install_plugin(
     plugins: State<'_, Arc<crate::plugins::PluginRunner>>,
     name: String,
 ) -> Result<(), String> {
-    if crate::build_info::STORE_BUILD && !crate::curated_plugins::is_allowed(&name) {
-        return Err("仅允许安装 cordis.run 已审核插件".to_string());
+    // Store installs must always cross the live market candidate gate. A
+    // local allowlist alone cannot prove current blocked/deprecated state,
+    // exact version/integrity, scripts-disabled installation, or pending
+    // activation. Keep this generic npm-name command for website builds only.
+    if !manual_plugin_install_allowed(crate::build_info::STORE_BUILD) {
+        return Err("Microsoft Store 版只能通过 cordis.run 插件市场安装并显式激活插件".to_string());
     }
     plugin_op(app, &runtime, plugins.inner().clone(), name, "add")
 }
@@ -1601,16 +2160,47 @@ pub fn uninstall_plugin(
     plugins: State<'_, Arc<crate::plugins::PluginRunner>>,
     name: String,
 ) -> Result<(), String> {
-    plugin_op(app, &runtime, plugins.inner().clone(), name, "remove")
+    if !crate::plugins::is_valid_package_name(&name) {
+        return Err(format!("invalid package name: {name:?}"));
+    }
+    let plugins = plugins.inner().clone();
+    begin_plugin_mutation(&plugins, &runtime)?;
+    if let Err(error) = ensure_no_plugin_recovery(&runtime) {
+        plugins.finish();
+        return Err(error);
+    }
+    let Some(paths) = runtime.paths() else {
+        plugins.finish();
+        return Err("runtime paths are not resolved yet".to_string());
+    };
+    if plugins.cancellation_requested() {
+        plugins.finish();
+        return Err("plugin uninstall was cancelled before profile mutation".to_string());
+    }
+    // Repair any valid pending receipt left active by an older build before
+    // touching the requested package. Corrupt optional receipt state must not
+    // block the one operation users need to remove an unsafe plugin.
+    let _ = crate::plugins::reconcile_market_receipts(&paths.dsh_home);
+    if let Err(error) = crate::plugins::pre_disable_installed_plugin(&paths.dsh_home, &name) {
+        plugins.finish();
+        return Err(error);
+    }
+    spawn_plugin_worker(app, paths, plugins, name, "remove")
+        .map_err(|error| format!("{error}; the requested plugin remains safely disabled"))
 }
 
 #[tauri::command]
-pub fn cancel_plugin_op(plugins: State<'_, Arc<crate::plugins::PluginRunner>>) {
-    let child = plugins
-        .child
-        .lock()
-        .unwrap_or_else(|poisoned| poisoned.into_inner())
-        .take();
+pub fn cancel_plugin_op(
+    plugins: State<'_, Arc<crate::plugins::PluginRunner>>,
+) -> Result<(), String> {
+    // Latch first: the operation may still be in async market preparation or
+    // between spawn and child registration. The worker checks this before and
+    // after registering its handle, closing the old cancel-before-store race.
+    let plugins = plugins.inner().clone();
+    let (accepted, child) = plugins.request_cancel();
+    if !accepted {
+        return Ok(());
+    }
     if let Some(mut child) = child {
         // Polite signal first. On Windows graceful() only works when the
         // shell initialized a hidden console (see main) — when it reports
@@ -1619,16 +2209,28 @@ pub fn cancel_plugin_op(plugins: State<'_, Arc<crate::plugins::PluginRunner>>) {
         // Give the tree a moment, then finish the job — the same escalation
         // as the sidecar's shutdown path. Taking the handle also prevents
         // the done-path from racing the kill.
-        std::thread::spawn(move || {
-            std::thread::sleep(std::time::Duration::from_secs(if polite { 2 } else { 0 }));
-            // If the tree already exited and the run thread reaped it, skip
-            // the kill: the pgid may already have been recycled.
-            if child.child.try_wait().ok().flatten().is_some() {
-                return;
-            }
-            child.force();
-        });
+        let termination_plugins = plugins.clone();
+        if let Err(error) = std::thread::Builder::new()
+            .name("plugin-cancel".to_string())
+            .spawn(move || {
+                std::thread::sleep(std::time::Duration::from_secs(if polite { 2 } else { 0 }));
+                if child.child.try_wait().ok().flatten().is_none() {
+                    child.force();
+                }
+                // PlatformChild::drop also tears down descendants after the
+                // direct child exits (Job Object / process group guarantee).
+                drop(child);
+                termination_plugins.child_termination_finished();
+            })
+        {
+            // The failed Builder drops the captured PlatformChild, whose Drop
+            // tears down the whole tree. Re-open the gate only after that
+            // synchronous drop has completed.
+            plugins.child_termination_finished();
+            return Err(format!("cannot start plugin cancellation worker: {error}"));
+        }
     }
+    Ok(())
 }
 
 // ---------------------------------------------------------------------------
@@ -1702,14 +2304,30 @@ fn create_remote_preset_dir(
     Ok((dir.clone(), dir.join("archive.dshpreset")))
 }
 
+fn remove_reparse_leaf(path: &std::path::Path, metadata: &std::fs::Metadata) {
+    #[cfg(windows)]
+    {
+        if metadata.is_dir() {
+            let _ = std::fs::remove_dir(path);
+        } else {
+            let _ = std::fs::remove_file(path);
+        }
+    }
+    #[cfg(not(windows))]
+    {
+        let _ = metadata;
+        let _ = std::fs::remove_file(path);
+    }
+}
+
 fn remove_remote_preset_dir(dsh_home: &std::path::Path, request_id: &str) {
     if !valid_request_id(request_id) {
         return;
     }
     let dir = remote_preset_dir(dsh_home, request_id);
     match std::fs::symlink_metadata(&dir) {
-        Ok(meta) if meta.file_type().is_symlink() => {
-            let _ = std::fs::remove_file(&dir);
+        Ok(meta) if crate::secure_fs::is_symlink_or_reparse(&meta) => {
+            remove_reparse_leaf(&dir, &meta);
         }
         Ok(meta) if meta.is_dir() => {
             let _ = std::fs::remove_dir_all(&dir);
@@ -1725,7 +2343,18 @@ pub fn sweep_stale_sideloads(runtime: &Runtime) {
     let Some(paths) = runtime.paths() else {
         return;
     };
-    let referenced: std::collections::HashSet<std::path::PathBuf> = read_web_deps(&paths)
+    sweep_stale_sideloads_paths(&paths);
+}
+
+fn sweep_stale_sideloads_paths(paths: &crate::paths::RuntimePaths) {
+    // A missing/corrupt/unreadable profile is uncertainty, not proof that no
+    // sideload is referenced. Fail closed so a transient profile read during
+    // startup, shutdown, or a killed pnpm write cannot destroy the retained
+    // archive needed by an installed `file:` dependency.
+    let Some(dependencies) = read_web_deps(paths) else {
+        return;
+    };
+    let referenced: std::collections::HashSet<std::path::PathBuf> = dependencies
         .values()
         .filter_map(serde_json::Value::as_str)
         .filter_map(|spec| spec.strip_prefix("file:"))
@@ -1739,7 +2368,7 @@ fn sweep_sideloads_root(
     referenced: &std::collections::HashSet<std::path::PathBuf>,
 ) {
     match std::fs::symlink_metadata(tools) {
-        Ok(meta) if meta.file_type().is_symlink() => return,
+        Ok(meta) if crate::secure_fs::is_symlink_or_reparse(&meta) => return,
         Ok(meta) if !meta.is_dir() => return,
         Ok(_) => {}
         Err(_) => return,
@@ -1752,10 +2381,7 @@ fn sweep_sideload_dir(
     referenced: &std::collections::HashSet<std::path::PathBuf>,
 ) {
     match std::fs::symlink_metadata(dir) {
-        Ok(meta) if meta.file_type().is_symlink() => {
-            let _ = std::fs::remove_file(dir);
-            return;
-        }
+        Ok(meta) if crate::secure_fs::is_symlink_or_reparse(&meta) => return,
         Ok(meta) if !meta.is_dir() => return,
         Ok(_) => {}
         Err(_) => return,
@@ -1774,8 +2400,7 @@ fn sweep_sideload_dir(
         let Ok(meta) = std::fs::symlink_metadata(&path) else {
             continue;
         };
-        if meta.file_type().is_symlink() {
-            let _ = std::fs::remove_file(&path);
+        if crate::secure_fs::is_symlink_or_reparse(&meta) {
             continue;
         }
         if !referenced.contains(&path) {
@@ -1784,22 +2409,13 @@ fn sweep_sideload_dir(
     }
 }
 
-fn read_web_deps(paths: &crate::paths::RuntimePaths) -> serde_json::Map<String, serde_json::Value> {
-    let path = paths
-        .dsh_home
-        .join("profiles")
-        .join("web")
-        .join("package.json");
-    let Ok(text) = std::fs::read_to_string(path) else {
-        return serde_json::Map::new();
-    };
-    let Ok(json) = serde_json::from_str::<serde_json::Value>(&text) else {
-        return serde_json::Map::new();
-    };
+fn read_web_deps(
+    paths: &crate::paths::RuntimePaths,
+) -> Option<serde_json::Map<String, serde_json::Value>> {
+    let (_, json) = crate::plugins::read_profile_manifest(&paths.dsh_home).ok()?;
     json.get("dependencies")
         .and_then(serde_json::Value::as_object)
         .cloned()
-        .unwrap_or_default()
 }
 
 fn remote_preset_dir(dsh_home: &std::path::Path, request_id: &str) -> std::path::PathBuf {
@@ -1818,8 +2434,8 @@ pub fn sweep_remote_preset_temp(runtime: &Runtime) {
     };
     let root = paths.dsh_home.join(".desktop-tools").join("preset-remote");
     match std::fs::symlink_metadata(&root) {
-        Ok(meta) if meta.file_type().is_symlink() => {
-            let _ = std::fs::remove_file(&root);
+        Ok(meta) if crate::secure_fs::is_symlink_or_reparse(&meta) => {
+            remove_reparse_leaf(&root, &meta);
         }
         Ok(meta) if meta.is_dir() => {
             let _ = std::fs::remove_dir_all(&root);

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -692,8 +692,7 @@ mod tests {
     use super::{
         is_zip_content_type, manual_plugin_install_allowed, market_pnpm_args, parse_pnpm_major,
         plugin_mutation_status_allowed, plugin_path_env, redact, remove_pnpm_args,
-        supervise_plugin_output, sweep_sideload_dir, sweep_sideloads_root,
-        sweep_stale_sideloads_paths,
+        sweep_sideload_dir, sweep_sideloads_root, sweep_stale_sideloads_paths,
     };
 
     #[test]
@@ -1009,8 +1008,9 @@ mod tests {
         drop(_tx);
 
         let supervisor_runner = runner.clone();
-        let supervisor =
-            std::thread::spawn(move || supervise_plugin_output(&supervisor_runner, rx, |_| {}));
+        let supervisor = std::thread::spawn(move || {
+            super::supervise_plugin_output(&supervisor_runner, rx, |_| {})
+        });
         std::thread::sleep(std::time::Duration::from_millis(150));
         assert!(
             runner.child.lock().unwrap().is_some(),

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -606,7 +606,7 @@ fn ensure_no_plugin_recovery(runtime: &Runtime) -> Result<(), String> {
 #[allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
 mod tests {
     use super::{
-        is_zip_content_type, read_installed_plugins, redact, sweep_sideload_dir,
+        is_zip_content_type, plugin_path_env, read_installed_plugins, redact, sweep_sideload_dir,
         sweep_sideloads_root,
     };
 
@@ -786,6 +786,33 @@ mod tests {
         .unwrap();
         // Malformed dependency payloads are skipped safely.
         assert_eq!(read_installed_plugins(&dir), Vec::<(String, String)>::new());
+    }
+
+    #[test]
+    fn plugin_path_splits_a_serialized_multi_segment_parent_path() {
+        let parent = std::env::join_paths([
+            std::path::Path::new("parent-one"),
+            std::path::Path::new("parent-two"),
+        ])
+        .unwrap();
+        let actual = plugin_path_env(std::path::Path::new("desktop-shim"), Some(&parent)).unwrap();
+        assert_eq!(
+            std::env::split_paths(&actual).collect::<Vec<_>>(),
+            vec![
+                std::path::PathBuf::from("desktop-shim"),
+                std::path::PathBuf::from("parent-one"),
+                std::path::PathBuf::from("parent-two"),
+            ]
+        );
+    }
+
+    #[test]
+    fn plugin_path_without_parent_keeps_the_owned_shim() {
+        let actual = plugin_path_env(std::path::Path::new("desktop-shim"), None).unwrap();
+        assert_eq!(
+            std::env::split_paths(&actual).collect::<Vec<_>>(),
+            vec![std::path::PathBuf::from("desktop-shim")]
+        );
     }
 }
 
@@ -1026,6 +1053,22 @@ pub fn list_plugins(
     })
 }
 
+/// Prepend the Desktop-owned pnpm shim while retaining every inherited PATH
+/// entry. `join_paths` takes *individual* path segments, not a serialized
+/// PATH value: passing the latter as one segment rejects normal multi-entry
+/// PATH values on every platform (for example `a:b` on Unix).
+fn plugin_path_env(
+    shim_dir: &std::path::Path,
+    inherited_path: Option<&std::ffi::OsStr>,
+) -> Result<std::ffi::OsString, std::env::JoinPathsError> {
+    let mut segments = vec![shim_dir.as_os_str().to_owned()];
+    if let Some(inherited_path) = inherited_path {
+        segments
+            .extend(std::env::split_paths(inherited_path).map(std::path::PathBuf::into_os_string));
+    }
+    std::env::join_paths(segments)
+}
+
 fn run_plugin_spec(
     app: AppHandle,
     paths: crate::paths::RuntimePaths,
@@ -1052,10 +1095,8 @@ fn run_plugin_spec(
             return;
         }
     };
-    let path_env = match std::env::join_paths(
-        std::iter::once(shim_dir.as_os_str().to_owned())
-            .chain(std::env::var_os("PATH").map(|old| old.to_owned())),
-    ) {
+    let inherited_path = std::env::var_os("PATH");
+    let path_env = match plugin_path_env(&shim_dir, inherited_path.as_deref()) {
         Ok(path_env) => path_env.to_string_lossy().to_string(),
         Err(e) => {
             let _ = app.emit(

--- a/src-tauri/src/curated_plugins.rs
+++ b/src-tauri/src/curated_plugins.rs
@@ -1,9 +1,9 @@
 //! Curated plugin allowlist for Store builds.
 //!
-//! The Store product may only install plugins reviewed on cordis.run. The
-//! snapshot is committed so a Store build never depends on a live fetch from
-//! the marketplace; refresh it with the maintainer checklist when the
-//! marketplace list changes.
+//! The Store product may only install plugins that pass BOTH the live
+//! cordis.run candidate gate and this locally reviewed snapshot. The snapshot
+//! is a second distribution boundary, not an offline installation authority;
+//! refresh it with the maintainer checklist when the marketplace list changes.
 
 use serde::Deserialize;
 

--- a/src-tauri/src/harness/mod.rs
+++ b/src-tauri/src/harness/mod.rs
@@ -69,8 +69,10 @@ pub struct Runtime {
     /// Bumped on every sidecar launch; watcher threads hold the value they
     /// started with and must never touch a newer generation's resources.
     gen: Arc<AtomicU64>,
-    /// Bumped on every user-initiated restart; cancels queued auto-restarts.
-    restart_gen: Arc<AtomicU64>,
+    /// Serializes explicit stop/restart requests with deferred auto-restarts.
+    /// The generation makes an already-queued automatic restart stale when a
+    /// user chooses a different lifecycle action.
+    restart: Arc<RestartControl>,
 }
 
 /// The readiness origin currently authorized for the Harness window.
@@ -84,6 +86,11 @@ pub struct WindowOrigin(pub Arc<Mutex<Option<String>>>);
 /// Crash auto-restart policy: up to this many consecutive attempts with
 /// exponential backoff, then give up and surface the error.
 const MAX_RESTART_ATTEMPTS: u32 = 3;
+/// A plugin operation may safely defer a restart briefly while it atomically
+/// updates the profile. It must not keep a crashed Harness in "Starting"
+/// forever when pnpm or its network request stalls.
+const MAX_AUTO_RESTART_PLUGIN_DEFER: std::time::Duration = std::time::Duration::from_secs(120);
+const AUTO_RESTART_DEFER_POLL: std::time::Duration = std::time::Duration::from_millis(250);
 
 /// NDJSON command ids — one place to change protocol bookkeeping.
 pub(crate) const CMD_ID_START: u64 = 1;
@@ -99,46 +106,97 @@ enum AutoRestartOutcome {
     Superseded,
 }
 
+/// Coordinate all sidecar lifecycle commands. The generation is deliberately
+/// separate from the sidecar generation: it answers whether a *queued crash
+/// restart* still reflects the user's latest intention.
+#[derive(Default)]
+struct RestartControl {
+    generation: AtomicU64,
+    transition_gate: Mutex<()>,
+}
+
+impl RestartControl {
+    fn current_generation(&self) -> u64 {
+        self.generation.load(Ordering::SeqCst)
+    }
+
+    fn supersede_queued_auto_restarts(&self) {
+        self.generation.fetch_add(1, Ordering::SeqCst);
+    }
+
+    fn is_superseded(&self, expected_generation: u64) -> bool {
+        self.current_generation() != expected_generation
+    }
+
+    fn with_exclusive_transition<T>(&self, action: impl FnOnce() -> T) -> T {
+        let _gate = self
+            .transition_gate
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        action()
+    }
+}
+
+fn auto_restart_is_superseded(runtime: &Runtime, expected_generation: u64) -> bool {
+    runtime.shutting_down.load(Ordering::SeqCst)
+        || runtime.restart.is_superseded(expected_generation)
+}
+
+fn auto_restart_defer_expired(started_at: std::time::Instant, now: std::time::Instant) -> bool {
+    now.saturating_duration_since(started_at) >= MAX_AUTO_RESTART_PLUGIN_DEFER
+}
+
+/// A policy/receipt error prevented an automatic start; it is not evidence
+/// that an active plugin caused a terminal startup failure. Keep recovery
+/// mutations closed and show the user a normal crashed-state diagnostic.
+fn abandon_auto_restart(state: &Mutex<SharedState>, message: impl Into<String>) {
+    set_error(state, message);
+    state
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .terminal_startup_failure = false;
+}
+
 /// Try one crash auto-restart while holding the same transition gate as every
 /// plugin/profile mutation. A busy plugin operation defers the attempt; it
 /// must never be interrupted by a sidecar restart that reads a half-written
 /// profile or loads a market package still awaiting explicit activation.
 fn try_auto_restart(app: &AppHandle, expected_gen: u64) -> Result<AutoRestartOutcome, String> {
     let runtime = app.state::<Runtime>();
-    if runtime.shutting_down.load(Ordering::SeqCst)
-        || runtime.restart_gen.load(Ordering::SeqCst) != expected_gen
-    {
+    if auto_restart_is_superseded(&runtime, expected_gen) {
         return Ok(AutoRestartOutcome::Superseded);
     }
 
     let action = || {
-        // Recheck after acquiring the plugin transition gate: a user restart
-        // or app exit may have superseded this waiter while it was deferred.
-        if runtime.shutting_down.load(Ordering::SeqCst)
-            || runtime.restart_gen.load(Ordering::SeqCst) != expected_gen
-        {
-            return Ok(AutoRestartOutcome::Superseded);
-        }
-        let paths = runtime
-            .paths
-            .as_ref()
-            .ok_or_else(|| "运行时路径不可用".to_string())?;
-        enforce_plugin_activation_boundary(paths)?;
-        send_raw(
-            &runtime,
-            &serde_json::json!({"id": CMD_ID_RESTART, "command": "restart"}),
-        )?;
-        {
-            let mut state = runtime
-                .state
-                .lock()
-                .unwrap_or_else(|poisoned| poisoned.into_inner());
-            state.status = Status::Starting;
-            state.last_error = None;
-            state.terminal_startup_failure = false;
-        }
-        publish_snapshot(app, &runtime.state);
-        Ok(AutoRestartOutcome::Sent)
+        runtime.restart.with_exclusive_transition(|| {
+            // Recheck after acquiring both transition gates: an explicit stop,
+            // user restart, or app exit may have superseded this waiter while
+            // it was deferred. Holding this gate through send_raw prevents a
+            // stop command from being followed by a stale automatic restart.
+            if auto_restart_is_superseded(&runtime, expected_gen) {
+                return Ok(AutoRestartOutcome::Superseded);
+            }
+            let paths = runtime
+                .paths
+                .as_ref()
+                .ok_or_else(|| "运行时路径不可用".to_string())?;
+            enforce_plugin_activation_boundary(paths)?;
+            send_raw(
+                &runtime,
+                &serde_json::json!({"id": CMD_ID_RESTART, "command": "restart"}),
+            )?;
+            {
+                let mut state = runtime
+                    .state
+                    .lock()
+                    .unwrap_or_else(|poisoned| poisoned.into_inner());
+                state.status = Status::Starting;
+                state.last_error = None;
+                state.terminal_startup_failure = false;
+            }
+            publish_snapshot(app, &runtime.state);
+            Ok(AutoRestartOutcome::Sent)
+        })
     };
 
     let Some(plugin_runner) = app.try_state::<Arc<crate::plugins::PluginRunner>>() else {
@@ -150,10 +208,7 @@ fn try_auto_restart(app: &AppHandle, expected_gen: u64) -> Result<AutoRestartOut
     match plugin_runner.with_idle_profile(action) {
         Ok(outcome) => Ok(outcome),
         Err(_error) if plugin_runner.is_busy() => Ok(AutoRestartOutcome::Deferred),
-        Err(_)
-            if runtime.shutting_down.load(Ordering::SeqCst)
-                || runtime.restart_gen.load(Ordering::SeqCst) != expected_gen =>
-        {
+        Err(_) if auto_restart_is_superseded(&runtime, expected_gen) => {
             Ok(AutoRestartOutcome::Superseded)
         }
         Err(error) => Err(error),
@@ -165,30 +220,39 @@ fn try_auto_restart(app: &AppHandle, expected_gen: u64) -> Result<AutoRestartOut
 /// attempt pending and retry the local gate instead of starting Harness early.
 fn schedule_auto_restart(app: &AppHandle, attempts: u32) {
     let app_c = app.clone();
-    let my_gen = app.state::<Runtime>().restart_gen.load(Ordering::SeqCst);
+    let my_gen = app.state::<Runtime>().restart.current_generation();
     let spawn = std::thread::Builder::new()
         .name("harness-auto-restart".to_string())
         .spawn(move || {
             let backoff =
                 std::time::Duration::from_secs(1u64 << (attempts.saturating_sub(1).min(3)));
             std::thread::sleep(backoff);
+            let mut deferred_since = None;
             loop {
                 match try_auto_restart(&app_c, my_gen) {
                     Ok(AutoRestartOutcome::Sent | AutoRestartOutcome::Superseded) => return,
                     Ok(AutoRestartOutcome::Deferred) => {
-                        std::thread::sleep(std::time::Duration::from_millis(250));
+                        let started_at = deferred_since.get_or_insert_with(std::time::Instant::now);
+                        if auto_restart_defer_expired(*started_at, std::time::Instant::now()) {
+                            let runtime = app_c.state::<Runtime>();
+                            abandon_auto_restart(
+                                &runtime.state,
+                                format!(
+                                    "Harness 自动重启等待插件操作超过 {} 秒，已停止自动重启；请取消或完成插件操作后手动重新启动 Harness。",
+                                    MAX_AUTO_RESTART_PLUGIN_DEFER.as_secs()
+                                ),
+                            );
+                            publish_snapshot(&app_c, &runtime.state);
+                            return;
+                        }
+                        std::thread::sleep(AUTO_RESTART_DEFER_POLL);
                     }
                     Err(error) => {
                         let runtime = app_c.state::<Runtime>();
-                        set_error(
+                        abandon_auto_restart(
                             &runtime.state,
                             format!("Harness 自动重启被插件安全门禁阻止：{error}"),
                         );
-                        runtime
-                            .state
-                            .lock()
-                            .unwrap_or_else(|poisoned| poisoned.into_inner())
-                            .terminal_startup_failure = true;
                         publish_snapshot(&app_c, &runtime.state);
                         return;
                     }
@@ -678,7 +742,7 @@ struct RuntimeArcs {
     shutting_down: Arc<AtomicBool>,
     restart_attempts: Arc<AtomicU32>,
     gen: Arc<AtomicU64>,
-    restart_gen: Arc<AtomicU64>,
+    restart: Arc<RestartControl>,
 }
 
 /// Shared init-failure path: manage an errored Runtime so the UI has a state
@@ -698,7 +762,7 @@ fn fail_init(app: &AppHandle, arcs: RuntimeArcs, paths: Option<RuntimePaths>, me
         restart_attempts: arcs.restart_attempts,
         paths,
         gen: arcs.gen,
-        restart_gen: arcs.restart_gen,
+        restart: arcs.restart,
     });
     // fail_init historically emitted nothing — the tray/UI must see it too.
     if let Some(observability) = app.try_state::<Arc<crate::observability::Observability>>() {
@@ -917,7 +981,7 @@ pub fn init(app: &AppHandle) {
     let shutting_down = Arc::new(AtomicBool::new(false));
     let restart_attempts = Arc::new(AtomicU32::new(0));
     let gen = Arc::new(AtomicU64::new(0));
-    let restart_gen = Arc::new(AtomicU64::new(0));
+    let restart = Arc::new(RestartControl::default());
     app.manage(WindowOrigin::default());
     let arcs = RuntimeArcs {
         stdin: stdin_arc.clone(),
@@ -925,7 +989,7 @@ pub fn init(app: &AppHandle) {
         shutting_down: shutting_down.clone(),
         restart_attempts: restart_attempts.clone(),
         gen: gen.clone(),
-        restart_gen: restart_gen.clone(),
+        restart: restart.clone(),
     };
 
     let paths = match resolve(app) {
@@ -987,7 +1051,7 @@ pub fn init(app: &AppHandle) {
         restart_attempts: restart_attempts.clone(),
         paths: Some(paths.clone()),
         gen: gen.clone(),
-        restart_gen: restart_gen.clone(),
+        restart,
     });
     let runtime = app.state::<Runtime>();
 
@@ -1030,16 +1094,49 @@ pub fn request_restart(app: &AppHandle) -> Result<(), String> {
 
 fn request_restart_inner(app: &AppHandle) -> Result<(), String> {
     let runtime = app.state::<Runtime>();
-    // App teardown has begun (shutdown_blocking sets this before dropping the
-    // stdin pipe): a respawn now would be EOF-killed moments later — refuse
-    // instead of spawning an orphan. Closes the tray-restart vs exit race.
-    if runtime.shutting_down.load(Ordering::SeqCst) {
-        return Err("应用正在退出，无法重启".to_string());
-    }
-    // Supersede any queued crash auto-restart: the user is in control now.
-    runtime.restart_gen.fetch_add(1, Ordering::SeqCst);
-    if !child_alive(&runtime) {
-        let result = respawn_sidecar(app);
+    runtime.restart.with_exclusive_transition(|| {
+        // App teardown has begun (shutdown_blocking sets this before dropping
+        // the stdin pipe): a respawn now would be EOF-killed moments later —
+        // refuse instead of spawning an orphan. Closes the tray-restart vs
+        // exit race.
+        if runtime.shutting_down.load(Ordering::SeqCst) {
+            return Err("应用正在退出，无法重启".to_string());
+        }
+        // Supersede any queued crash auto-restart: the user is in control now.
+        runtime.restart.supersede_queued_auto_restarts();
+        if !child_alive(&runtime) {
+            let result = respawn_sidecar(app);
+            if let Err(e) = &result {
+                let mut s = runtime
+                    .state
+                    .lock()
+                    .unwrap_or_else(|poisoned| poisoned.into_inner());
+                s.last_error = Some(e.clone());
+                s.status = Status::Crashed;
+                s.terminal_startup_failure = false;
+            } else {
+                reset_restart_attempts(&runtime);
+                let mut s = runtime
+                    .state
+                    .lock()
+                    .unwrap_or_else(|poisoned| poisoned.into_inner());
+                s.last_error = None;
+                s.terminal_startup_failure = false;
+            }
+            publish_snapshot(app, &runtime.state);
+            return result;
+        }
+
+        let paths = runtime
+            .paths
+            .as_ref()
+            .ok_or_else(|| "运行时路径不可用".to_string())?;
+        enforce_plugin_activation_boundary(paths)?;
+
+        let result = send_raw(
+            &runtime,
+            &serde_json::json!({"id": CMD_ID_RESTART, "command": "restart"}),
+        );
         if let Err(e) = &result {
             let mut s = runtime
                 .state
@@ -1055,42 +1152,51 @@ fn request_restart_inner(app: &AppHandle) -> Result<(), String> {
                 .lock()
                 .unwrap_or_else(|poisoned| poisoned.into_inner());
             s.last_error = None;
+            s.status = Status::Starting;
             s.terminal_startup_failure = false;
         }
         publish_snapshot(app, &runtime.state);
-        return result;
-    }
+        result
+    })
+}
 
-    let paths = runtime
-        .paths
-        .as_ref()
-        .ok_or_else(|| "运行时路径不可用".to_string())?;
-    enforce_plugin_activation_boundary(paths)?;
+/// Explicitly stop the Harness while keeping the Desktop/sidecar available.
+/// This is a user lifecycle choice, so it must invalidate a queued automatic
+/// crash restart even when the sidecar is already down.
+pub fn request_shutdown(app: &AppHandle) -> Result<(), String> {
+    let runtime = app.state::<Runtime>();
+    runtime.restart.with_exclusive_transition(|| {
+        runtime.restart.supersede_queued_auto_restarts();
+        if !child_alive(&runtime) {
+            // Keep the real status (Stopped/Idle stays what it is) — only the
+            // message explains why nothing happened.
+            let error = "sidecar 未运行，无需停止".to_string();
+            runtime
+                .state
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner())
+                .last_error = Some(error.clone());
+            publish_snapshot(app, &runtime.state);
+            return Err(error);
+        }
 
-    let result = send_raw(
-        &runtime,
-        &serde_json::json!({"id": CMD_ID_RESTART, "command": "restart"}),
-    );
-    if let Err(e) = &result {
-        let mut s = runtime
+        // Block a just-clicked plugin mutation before the sidecar has time to
+        // emit its asynchronous `stopping` event.
+        runtime
             .state
             .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner());
-        s.last_error = Some(e.clone());
-        s.status = Status::Crashed;
-        s.terminal_startup_failure = false;
-    } else {
-        reset_restart_attempts(&runtime);
-        let mut s = runtime
-            .state
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner());
-        s.last_error = None;
-        s.status = Status::Starting;
-        s.terminal_startup_failure = false;
-    }
-    publish_snapshot(app, &runtime.state);
-    result
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .status = Status::Stopping;
+        let result = send_raw(
+            &runtime,
+            &serde_json::json!({"id": CMD_ID_SHUTDOWN, "command": "shutdown"}),
+        );
+        if let Err(error) = &result {
+            set_error(&runtime.state, error.clone());
+        }
+        publish_snapshot(app, &runtime.state);
+        result
+    })
 }
 
 /// Re-launch the sidecar after it died unexpectedly (user presses the restart
@@ -1157,10 +1263,13 @@ pub fn child_alive(runtime: &Runtime) -> bool {
 pub fn shutdown_blocking(app: &AppHandle) {
     let runtime = app.state::<Runtime>();
     runtime.shutting_down.store(true, Ordering::SeqCst);
-    let _ = send_raw(
-        &runtime,
-        &serde_json::json!({"id": CMD_ID_EXIT_SHUTDOWN, "command": "shutdown"}),
-    );
+    runtime.restart.supersede_queued_auto_restarts();
+    runtime.restart.with_exclusive_transition(|| {
+        let _ = send_raw(
+            &runtime,
+            &serde_json::json!({"id": CMD_ID_EXIT_SHUTDOWN, "command": "shutdown"}),
+        );
+    });
 
     let grace = std::env::var("DSH_SHUTDOWN_GRACE_MS")
         .ok()
@@ -1216,6 +1325,41 @@ mod tests {
             AtomicBool::new(false),
             AtomicU32::new(0),
         )
+    }
+
+    #[test]
+    fn explicit_stop_supersedes_a_queued_auto_restart() {
+        let restart = RestartControl::default();
+        let queued_generation = restart.current_generation();
+        restart.supersede_queued_auto_restarts();
+        assert!(restart.is_superseded(queued_generation));
+    }
+
+    #[test]
+    fn auto_restart_plugin_deferral_has_a_hard_deadline() {
+        let started_at = std::time::Instant::now();
+        assert!(!auto_restart_defer_expired(
+            started_at,
+            started_at + MAX_AUTO_RESTART_PLUGIN_DEFER - std::time::Duration::from_millis(1)
+        ));
+        assert!(auto_restart_defer_expired(
+            started_at,
+            started_at + MAX_AUTO_RESTART_PLUGIN_DEFER
+        ));
+    }
+
+    #[test]
+    fn auto_restart_gate_failure_does_not_authorize_plugin_recovery() {
+        let state = Mutex::new(SharedState {
+            status: Status::Starting,
+            terminal_startup_failure: true,
+            ..Default::default()
+        });
+        abandon_auto_restart(&state, "corrupt pending receipt");
+        let state = state.lock().unwrap();
+        assert_eq!(state.status, Status::Crashed);
+        assert_eq!(state.last_error.as_deref(), Some("corrupt pending receipt"));
+        assert!(!state.terminal_startup_failure);
     }
 
     #[test]

--- a/src-tauri/src/harness/mod.rs
+++ b/src-tauri/src/harness/mod.rs
@@ -92,46 +92,117 @@ pub(crate) const CMD_ID_RESTART: u64 = 100;
 pub(crate) const CMD_ID_SHUTDOWN: u64 = 101;
 pub(crate) const CMD_ID_EXIT_SHUTDOWN: u64 = 900;
 
-/// Send a raw command line through the sidecar stdin, if available.
-fn send_restart(stdin: &Arc<Mutex<Option<ChildStdin>>>) {
-    let mut stdin = stdin
-        .lock()
-        .unwrap_or_else(|poisoned| poisoned.into_inner());
-    if let Some(stdin) = stdin.as_mut() {
-        let _ = writeln!(stdin, "{{\"id\":{CMD_ID_RESTART},\"command\":\"restart\"}}");
-        let _ = stdin.flush();
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum AutoRestartOutcome {
+    Sent,
+    Deferred,
+    Superseded,
+}
+
+/// Try one crash auto-restart while holding the same transition gate as every
+/// plugin/profile mutation. A busy plugin operation defers the attempt; it
+/// must never be interrupted by a sidecar restart that reads a half-written
+/// profile or loads a market package still awaiting explicit activation.
+fn try_auto_restart(app: &AppHandle, expected_gen: u64) -> Result<AutoRestartOutcome, String> {
+    let runtime = app.state::<Runtime>();
+    if runtime.shutting_down.load(Ordering::SeqCst)
+        || runtime.restart_gen.load(Ordering::SeqCst) != expected_gen
+    {
+        return Ok(AutoRestartOutcome::Superseded);
+    }
+
+    let action = || {
+        // Recheck after acquiring the plugin transition gate: a user restart
+        // or app exit may have superseded this waiter while it was deferred.
+        if runtime.shutting_down.load(Ordering::SeqCst)
+            || runtime.restart_gen.load(Ordering::SeqCst) != expected_gen
+        {
+            return Ok(AutoRestartOutcome::Superseded);
+        }
+        let paths = runtime
+            .paths
+            .as_ref()
+            .ok_or_else(|| "运行时路径不可用".to_string())?;
+        enforce_plugin_activation_boundary(paths)?;
+        send_raw(
+            &runtime,
+            &serde_json::json!({"id": CMD_ID_RESTART, "command": "restart"}),
+        )?;
+        {
+            let mut state = runtime
+                .state
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+            state.status = Status::Starting;
+            state.last_error = None;
+            state.terminal_startup_failure = false;
+        }
+        publish_snapshot(app, &runtime.state);
+        Ok(AutoRestartOutcome::Sent)
+    };
+
+    let Some(plugin_runner) = app.try_state::<Arc<crate::plugins::PluginRunner>>() else {
+        return action();
+    };
+    if plugin_runner.is_busy() {
+        return Ok(AutoRestartOutcome::Deferred);
+    }
+    match plugin_runner.with_idle_profile(action) {
+        Ok(outcome) => Ok(outcome),
+        Err(_error) if plugin_runner.is_busy() => Ok(AutoRestartOutcome::Deferred),
+        Err(_)
+            if runtime.shutting_down.load(Ordering::SeqCst)
+                || runtime.restart_gen.load(Ordering::SeqCst) != expected_gen =>
+        {
+            Ok(AutoRestartOutcome::Superseded)
+        }
+        Err(error) => Err(error),
     }
 }
 
 /// Schedule a crash auto-restart with exponential backoff (1s, 2s, 4s…).
-fn schedule_auto_restart(
-    state: &Arc<Mutex<SharedState>>,
-    stdin: &Arc<Mutex<Option<ChildStdin>>>,
-    shutting_down: &Arc<AtomicBool>,
-    restart_gen: &Arc<AtomicU64>,
-    attempts: u32,
-) {
-    let state_c = state.clone();
-    let stdin_c = stdin.clone();
-    let shutting_down_c = shutting_down.clone();
-    let restart_gen_c = restart_gen.clone();
-    let my_gen = restart_gen.load(Ordering::SeqCst);
-    std::thread::spawn(move || {
-        let backoff = std::time::Duration::from_secs(1u64 << (attempts.saturating_sub(1).min(3)));
-        std::thread::sleep(backoff);
-        // A user-initiated restart during the backoff supersedes this one.
-        if shutting_down_c.load(Ordering::SeqCst) || restart_gen_c.load(Ordering::SeqCst) != my_gen
-        {
-            return;
-        }
-        {
-            let mut s = state_c
-                .lock()
-                .unwrap_or_else(|poisoned| poisoned.into_inner());
-            s.status = Status::Starting;
-        }
-        send_restart(&stdin_c);
-    });
+/// If a plugin mutation is still active after the backoff, keep the same
+/// attempt pending and retry the local gate instead of starting Harness early.
+fn schedule_auto_restart(app: &AppHandle, attempts: u32) {
+    let app_c = app.clone();
+    let my_gen = app.state::<Runtime>().restart_gen.load(Ordering::SeqCst);
+    let spawn = std::thread::Builder::new()
+        .name("harness-auto-restart".to_string())
+        .spawn(move || {
+            let backoff =
+                std::time::Duration::from_secs(1u64 << (attempts.saturating_sub(1).min(3)));
+            std::thread::sleep(backoff);
+            loop {
+                match try_auto_restart(&app_c, my_gen) {
+                    Ok(AutoRestartOutcome::Sent | AutoRestartOutcome::Superseded) => return,
+                    Ok(AutoRestartOutcome::Deferred) => {
+                        std::thread::sleep(std::time::Duration::from_millis(250));
+                    }
+                    Err(error) => {
+                        let runtime = app_c.state::<Runtime>();
+                        set_error(
+                            &runtime.state,
+                            format!("Harness 自动重启被插件安全门禁阻止：{error}"),
+                        );
+                        runtime
+                            .state
+                            .lock()
+                            .unwrap_or_else(|poisoned| poisoned.into_inner())
+                            .terminal_startup_failure = true;
+                        publish_snapshot(&app_c, &runtime.state);
+                        return;
+                    }
+                }
+            }
+        });
+    if let Err(error) = spawn {
+        let runtime = app.state::<Runtime>();
+        set_error(
+            &runtime.state,
+            format!("无法启动 Harness 自动重启任务：{error}"),
+        );
+        publish_snapshot(app, &runtime.state);
+    }
 }
 
 fn log_line(state: &Mutex<SharedState>, stream: &str, line: &str) {
@@ -469,7 +540,6 @@ fn handle_event(
     stdin: &Arc<Mutex<Option<ChildStdin>>>,
     shutting_down: &Arc<AtomicBool>,
     restart_attempts: &Arc<AtomicU32>,
-    restart_gen: &Arc<AtomicU64>,
     ev: &Value,
 ) {
     // Log lines flow by the thousands during agent runs; the snapshot payload
@@ -488,9 +558,7 @@ fn handle_event(
         match effect {
             SideEffect::OpenWindow(url) => open_harness_window(app, &url),
             SideEffect::RefreshPid => refresh_pid(stdin),
-            SideEffect::ScheduleAutoRestart(attempts) => {
-                schedule_auto_restart(state, stdin, shutting_down, restart_gen, attempts)
-            }
+            SideEffect::ScheduleAutoRestart(attempts) => schedule_auto_restart(app, attempts),
         }
     }
     record_lifecycle_event(app, ev);
@@ -757,7 +825,6 @@ fn launch_sidecar(app: &AppHandle, runtime: &Runtime, paths: &RuntimePaths) -> R
         let app_c = app.clone();
         let shutting_down_c = runtime.shutting_down.clone();
         let attempts_c = runtime.restart_attempts.clone();
-        let restart_gen_c = runtime.restart_gen.clone();
         std::thread::spawn(move || {
             let _ = dsh_sidecar::for_each_bounded_line(
                 BufReader::new(stdout),
@@ -770,7 +837,6 @@ fn launch_sidecar(app: &AppHandle, runtime: &Runtime, paths: &RuntimePaths) -> R
                             &stdin_c,
                             &shutting_down_c,
                             &attempts_c,
-                            &restart_gen_c,
                             &ev,
                         ),
                         Err(_) => log_line(&state_c, "sidecar", &line),
@@ -799,6 +865,7 @@ fn launch_sidecar(app: &AppHandle, runtime: &Runtime, paths: &RuntimePaths) -> R
 
 /// Send the NDJSON `start` command for the bundled runtime.
 fn start_harness(runtime: &Runtime, paths: &RuntimePaths) -> Result<(), String> {
+    enforce_plugin_activation_boundary(paths)?;
     if !paths.node.exists() || !paths.harness_dir.join("node_modules").exists() {
         return Err(
             "runtime 未就绪（缺少 node 或 harness/node_modules）— 请先运行 `pnpm runtime:all`"
@@ -832,6 +899,15 @@ fn start_harness(runtime: &Runtime, paths: &RuntimePaths) -> Result<(), String> 
     state.terminal_startup_failure = false;
     state.status = Status::Starting;
     Ok(())
+}
+
+/// A package recorded as pending must never reach Harness' active bundle
+/// layer, including after an older Desktop build or an interrupted mutation.
+/// Run the durable receipt repair immediately before every start boundary,
+/// not only when the next plugin operation happens.
+fn enforce_plugin_activation_boundary(paths: &RuntimePaths) -> Result<(), String> {
+    crate::plugins::reconcile_market_receipts(&paths.dsh_home)
+        .map_err(|error| format!("cannot enforce pending plugin activation boundary: {error}"))
 }
 
 /// Spawn the sidecar, wire the reader thread, and auto-start the Harness.
@@ -937,6 +1013,22 @@ pub fn init(app: &AppHandle) {
 /// Unified restart entry (tray menu + bootstrap button): sidecar alive → send
 /// restart command; sidecar dead → respawn the whole chain. Publishes state.
 pub fn request_restart(app: &AppHandle) -> Result<(), String> {
+    // Profile reconciliation immediately below reads and may atomically write
+    // the same manifest as plugin pnpm operations. Reuse their single-flight
+    // gate for every user/tray restart so restart cannot observe or expose a
+    // half-mutated profile. Recovery callers release their mutation before
+    // entering this boundary.
+    if let Some(plugin_runner) = app.try_state::<Arc<crate::plugins::PluginRunner>>() {
+        plugin_runner.with_idle_profile(|| request_restart_inner(app))
+    } else {
+        // Setup installs PluginRunner immediately after the initial Harness
+        // launch. Keep this fallback for narrowly scoped harness tests and
+        // initialization failures where managed state was not reached.
+        request_restart_inner(app)
+    }
+}
+
+fn request_restart_inner(app: &AppHandle) -> Result<(), String> {
     let runtime = app.state::<Runtime>();
     // App teardown has begun (shutdown_blocking sets this before dropping the
     // stdin pipe): a respawn now would be EOF-killed moments later — refuse
@@ -968,6 +1060,12 @@ pub fn request_restart(app: &AppHandle) -> Result<(), String> {
         publish_snapshot(app, &runtime.state);
         return result;
     }
+
+    let paths = runtime
+        .paths
+        .as_ref()
+        .ok_or_else(|| "运行时路径不可用".to_string())?;
+    enforce_plugin_activation_boundary(paths)?;
 
     let result = send_raw(
         &runtime,

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -109,6 +109,10 @@ fn main() {
                 std::sync::Arc::new(observability::Observability::new(app.handle()));
             app.manage(observability);
             app.manage(std::sync::Arc::new(diagnostics::DiagnosticExporter::new()));
+            // Install the profile-mutation gate before Harness starts. Crash
+            // auto-restart events can arrive as soon as the sidecar launches,
+            // and every restart path must serialize against plugin changes.
+            app.manage(std::sync::Arc::new(plugins::PluginRunner::new()));
             // Tray first: harness init failure paths publish snapshots that
             // must reach the tray status line.
             tray::init(&app.handle().clone());
@@ -119,7 +123,6 @@ fn main() {
             // preview_preset and import_preset. MUST be managed: extracting
             // an unmanaged State panics at the first command invocation.
             app.manage(commands::PendingPreset(std::sync::Mutex::new(None)));
-            app.manage(std::sync::Arc::new(plugins::PluginRunner::new()));
             // Deep-link parsing/dispatch. Manage the pending-request slot
             // BEFORE init drains get_current(): a cold start URL can arrive
             // before the webview subscribed to plugin-install-request.

--- a/src-tauri/src/market.rs
+++ b/src-tauri/src/market.rs
@@ -920,7 +920,7 @@ fn parse_dsh_requirement(raw: &str) -> Result<VersionReq, String> {
 /// and the mutation command all agree that an unreviewed package is not
 /// installable. The command repeats this check as defense in depth because
 /// IPC callers must never rely on UI-derived state.
-fn distribution_allows_package(package_name: &str, store_build: bool) -> bool {
+pub(crate) fn distribution_allows_package(package_name: &str, store_build: bool) -> bool {
     !store_build || crate::curated_plugins::is_allowed(package_name)
 }
 

--- a/src-tauri/src/plugins.rs
+++ b/src-tauri/src/plugins.rs
@@ -1,4 +1,5 @@
-//! In-app plugin installation via the official `dsh plugin` CLI.
+//! In-app plugin installation through the official `dsh plugin` add path and
+//! precise scripts-disabled removal through the bundled pnpm entry point.
 //!
 //! Process-tree guarantees come from reusing dsh-sidecar's `PlatformChild`
 //! (unix process group / Windows Job Object): cancel and app-exit always
@@ -200,8 +201,16 @@ const MARKET_PENDING_FILE: &str = "market-pending.json";
 const MARKET_ACTIVE_FILE: &str = "market-active.json";
 const MARKET_PENDING_MAX_BYTES: u64 = 256 * 1024;
 const PROFILE_LOCK_MAX_BYTES: u64 = 4 * 1024 * 1024;
+const PROFILE_MANIFEST_MAX_BYTES: u64 = 4 * 1024 * 1024;
+const INSTALLED_MANIFEST_MAX_BYTES: u64 = 256 * 1024;
+const BUNDLE_PATCH_MAX_BYTES: u64 = 4 * 1024 * 1024;
+const BUNDLE_PATCH_PATH_MAX_BYTES: usize = 1024;
+const PROFILE_NPMRC_MAX_BYTES: u64 = 64 * 1024;
+const PNPM_MODULES_STATE_MAX_BYTES: u64 = 1024 * 1024;
+const PNPM_STORE_PATH_MAX_BYTES: usize = 4096;
+const MAX_INSTALLED_PLUGINS: usize = 512;
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct MarketPendingPlugin {
     pub slug: String,
@@ -267,8 +276,10 @@ pub struct InstalledPlugin {
 fn checked_real_dir(path: &Path, label: &str) -> Result<(), String> {
     let metadata =
         std::fs::symlink_metadata(path).map_err(|e| format!("cannot inspect {label}: {e}"))?;
-    if metadata.file_type().is_symlink() {
-        return Err(format!("{label} must not be a symbolic link"));
+    if crate::secure_fs::is_symlink_or_reparse(&metadata) {
+        return Err(format!(
+            "{label} must not be a symbolic link or reparse point"
+        ));
     }
     if !metadata.is_dir() {
         return Err(format!("{label} is not a directory"));
@@ -314,6 +325,22 @@ fn write_active(dsh_home: &Path, active: &MarketActiveFile) -> Result<(), String
         .map_err(|e| format!("cannot serialize active market receipt: {e}"))?;
     crate::secure_fs::atomic_write(&path, &bytes, MARKET_PENDING_MAX_BYTES as usize)
         .map_err(|e| format!("cannot write active market receipt: {e}"))
+}
+
+/// Persist exact live-reviewed provenance before any caller enables a market
+/// bundle. Writing this first makes both normal activation and recovery
+/// rollback crash-safe: an inactive orphan receipt is pruned, while an enabled
+/// bundle never exists without the receipt needed for future gated recovery.
+pub(crate) fn record_active_market_receipt(
+    dsh_home: &Path,
+    candidate: &crate::market::MarketInstallCandidate,
+) -> Result<(), String> {
+    let mut active = load_active(dsh_home)?;
+    active.plugins.insert(
+        candidate.package_name.clone(),
+        MarketPendingPlugin::from(candidate),
+    );
+    write_active(dsh_home, &active)
 }
 
 fn receipt_matches_active_profile(
@@ -366,6 +393,153 @@ pub(crate) fn reconcile_active_market_receipts(dsh_home: &Path) -> Result<(), St
     Ok(())
 }
 
+fn reconcile_pending_market_receipts(dsh_home: &Path) -> Result<(), String> {
+    let mut pending = load_pending(dsh_home)?;
+    if pending.plugins.is_empty() {
+        return Ok(());
+    }
+    // Remember every structurally credible pending name before pruning stale
+    // source/version receipts. If an old global reconciliation activated one
+    // and its dependency was then replaced, dropping only the stale marker
+    // would leave unreviewed content enabled. Stale pending authority must be
+    // removed from both the marker file and the active bundle layer.
+    let pending_names: HashSet<String> = pending
+        .plugins
+        .iter()
+        .filter(|(name, receipt)| is_valid_package_name(name) && receipt.package_name == **name)
+        .map(|(name, _)| name.clone())
+        .collect();
+    let active = load_active(dsh_home)?;
+    let (profile, mut manifest) = read_profile_manifest(dsh_home)?;
+    let dependencies = profile_dependencies(&manifest)?;
+    let before = pending.plugins.len();
+    let mut retained = BTreeMap::new();
+    for (package_name, receipt) in &pending.plugins {
+        let source_matches = is_valid_package_name(package_name)
+            && receipt.package_name == *package_name
+            && dependencies.get(package_name).and_then(Value::as_str)
+                == Some(receipt.tarball.as_str());
+        let installed_version = read_installed_plugin_version(&profile, package_name)
+            .ok()
+            .flatten();
+        if source_matches && installed_version.as_deref() == Some(receipt.version.as_str()) {
+            retained.insert(package_name.clone(), receipt.clone());
+        }
+    }
+    pending.plugins = retained;
+
+    // A generic upstream `dsh plugin` mutation reconciles every installed
+    // bundle, not only its target. If a previous Desktop build or an
+    // interrupted operation let that reconciliation add a still-pending
+    // market package, restore the explicit-Activate boundary before exposing
+    // the profile again. Only receipts whose exact tarball and installed
+    // version still match retain this authority.
+    let bundles = profile_bundles_mut(&mut manifest)?;
+    for bundle in bundles.iter() {
+        if bundle.as_str().is_none() {
+            return Err("web profile bundles contains a non-string value".to_string());
+        }
+    }
+    // Activate persists an exact active receipt BEFORE writing bundles and
+    // removes the pending marker afterwards. A crash between those final two
+    // writes is an explicitly authorized activation, not the old global-
+    // reconcile bug: preserve its bundle and complete marker cleanup. A
+    // pending bundle without the matching active receipt was never approved
+    // and must be removed before Harness starts.
+    let explicitly_committed: HashSet<String> = bundles
+        .iter()
+        .filter_map(Value::as_str)
+        .filter(|name| {
+            pending
+                .plugins
+                .get(*name)
+                .is_some_and(|receipt| active.plugins.get(*name) == Some(receipt))
+        })
+        .map(str::to_string)
+        .collect();
+    let bundle_count = bundles.len();
+    bundles.retain(|bundle| {
+        bundle
+            .as_str()
+            .is_none_or(|name| !pending_names.contains(name) || explicitly_committed.contains(name))
+    });
+    pending
+        .plugins
+        .retain(|name, _| !explicitly_committed.contains(name));
+    if bundles.len() != bundle_count {
+        write_profile_manifest(&profile, &manifest)?;
+    }
+    if pending.plugins.len() != before {
+        write_pending(dsh_home, &pending)?;
+    }
+    Ok(())
+}
+
+pub(crate) fn reconcile_market_receipts(dsh_home: &Path) -> Result<(), String> {
+    reconcile_pending_market_receipts(dsh_home)?;
+    reconcile_active_market_receipts(dsh_home)
+}
+
+/// Generic `dsh plugin add` reconciles every dependency and can therefore
+/// activate an unrelated market package that is still awaiting explicit
+/// confirmation. Keep generic/sideload additions unavailable until all
+/// pending market decisions have been resolved; direct market installs do
+/// not use the upstream reconciliation path and are unaffected.
+pub(crate) fn ensure_no_pending_market_plugins(dsh_home: &Path) -> Result<(), String> {
+    ensure_generic_plugin_layout(dsh_home)?;
+    reconcile_market_receipts(dsh_home)?;
+    if load_pending(dsh_home)?.plugins.is_empty() {
+        Ok(())
+    } else {
+        Err(
+            "a market plugin is awaiting explicit activation; activate or uninstall it before adding another plugin"
+                .to_string(),
+        )
+    }
+}
+
+/// The upstream add path initializes a missing profile itself, so it cannot
+/// use `profile_dir` (which requires an existing manifest). Validate every
+/// hierarchy component that already exists before handing paths to Node;
+/// missing components remain available for the official initializer.
+fn ensure_generic_plugin_layout(dsh_home: &Path) -> Result<(), String> {
+    checked_real_dir(dsh_home, "DSH_HOME")?;
+    let profiles = dsh_home.join("profiles");
+    match std::fs::symlink_metadata(&profiles) {
+        Ok(_) => checked_real_dir(&profiles, "profiles directory")?,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(error) => return Err(format!("cannot inspect profiles directory: {error}")),
+    }
+    let profile = profiles.join("web");
+    match std::fs::symlink_metadata(&profile) {
+        Ok(_) => checked_real_dir(&profile, "web profile directory")?,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(error) => return Err(format!("cannot inspect web profile directory: {error}")),
+    }
+    let manifest = profile.join("package.json");
+    match std::fs::symlink_metadata(&manifest) {
+        Ok(metadata)
+            if crate::secure_fs::is_symlink_or_reparse(&metadata) || !metadata.is_file() =>
+        {
+            return Err("web profile package.json must be a regular file".to_string());
+        }
+        Ok(_) => {}
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+        Err(error) => return Err(format!("cannot inspect web profile package.json: {error}")),
+    }
+    let node_modules = profile.join("node_modules");
+    match std::fs::symlink_metadata(&node_modules) {
+        Ok(_) => checked_real_dir(&node_modules, "plugin profile node_modules")?,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+        Err(error) => {
+            return Err(format!(
+                "cannot inspect plugin profile node_modules: {error}"
+            ));
+        }
+    }
+    Ok(())
+}
+
 pub(crate) fn remove_active_market_receipt(
     dsh_home: &Path,
     package_name: &str,
@@ -373,6 +547,14 @@ pub(crate) fn remove_active_market_receipt(
     let mut active = load_active(dsh_home)?;
     if active.plugins.remove(package_name).is_some() {
         write_active(dsh_home, &active)?;
+    }
+    Ok(())
+}
+
+fn remove_pending_market_receipt(dsh_home: &Path, package_name: &str) -> Result<(), String> {
+    let mut pending = load_pending(dsh_home)?;
+    if pending.plugins.remove(package_name).is_some() {
+        write_pending(dsh_home, &pending)?;
     }
     Ok(())
 }
@@ -438,7 +620,7 @@ pub(crate) fn profile_dir(dsh_home: &Path) -> Result<PathBuf, String> {
     let manifest = web.join("package.json");
     let metadata = std::fs::symlink_metadata(&manifest)
         .map_err(|e| format!("cannot inspect web profile package.json: {e}"))?;
-    if metadata.file_type().is_symlink() || !metadata.is_file() {
+    if crate::secure_fs::is_symlink_or_reparse(&metadata) || !metadata.is_file() {
         return Err("web profile package.json must be a regular file".to_string());
     }
     Ok(web)
@@ -451,12 +633,135 @@ pub fn market_profile_dir(dsh_home: &Path) -> Result<PathBuf, String> {
     profile_dir(dsh_home)
 }
 
+/// Recover the store root already bound to this profile's `node_modules`.
+/// pnpm refuses to operate when a command selects a different store, so a
+/// newly introduced Desktop-private store would break every profile created
+/// by an earlier release. pnpm 11 records the versioned directory (…/v11)
+/// in `.modules.yaml`; the CLI expects its parent as `--store-dir`.
+pub(crate) fn pnpm_store_base(
+    profile: &Path,
+    bundled_pnpm_major: u64,
+) -> Result<Option<PathBuf>, String> {
+    if bundled_pnpm_major == 0 {
+        return Err("bundled pnpm has an invalid major version".to_string());
+    }
+    let node_modules = profile.join("node_modules");
+    match std::fs::symlink_metadata(&node_modules) {
+        Ok(_) => checked_real_dir(&node_modules, "plugin profile node_modules")?,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(error) => {
+            return Err(format!(
+                "cannot inspect plugin profile node_modules: {error}"
+            ))
+        }
+    }
+    let modules_state = node_modules.join(".modules.yaml");
+    let Some(bytes) = crate::secure_fs::read_bounded(&modules_state, PNPM_MODULES_STATE_MAX_BYTES)?
+    else {
+        return Ok(None);
+    };
+
+    // pnpm 11 writes JSON (which is valid YAML). Retain a narrow fallback for
+    // profiles created by older supported runtimes that wrote a scalar YAML
+    // field instead.
+    let recorded = match serde_json::from_slice::<Value>(&bytes) {
+        Ok(value) => value
+            .get("storeDir")
+            .and_then(Value::as_str)
+            .map(str::to_string)
+            .ok_or_else(|| "pnpm modules state has no string storeDir".to_string())?,
+        Err(_) => {
+            let text = std::str::from_utf8(&bytes)
+                .map_err(|error| format!("pnpm modules state is not valid UTF-8: {error}"))?;
+            text.lines()
+                .find_map(|line| line.strip_prefix("storeDir:").map(yaml_scalar))
+                .filter(|value| !value.is_empty())
+                .map(str::to_string)
+                .ok_or_else(|| "pnpm modules state has no storeDir".to_string())?
+        }
+    };
+    if recorded.len() > PNPM_STORE_PATH_MAX_BYTES || recorded.chars().any(char::is_control) {
+        return Err("pnpm modules state has an invalid storeDir".to_string());
+    }
+    let versioned = PathBuf::from(&recorded);
+    if !versioned.is_absolute() {
+        return Err("pnpm modules state storeDir must be absolute".to_string());
+    }
+    let expected_layout = format!("v{bundled_pnpm_major}");
+    if versioned.file_name().and_then(|part| part.to_str()) != Some(expected_layout.as_str()) {
+        return Err(format!(
+            "plugin profile uses an incompatible pnpm store layout ({recorded}); expected {expected_layout}"
+        ));
+    }
+    let base = versioned
+        .parent()
+        .filter(|parent| !parent.as_os_str().is_empty())
+        .ok_or_else(|| "pnpm modules state storeDir has no usable parent".to_string())?;
+    Ok(Some(base.to_path_buf()))
+}
+
+/// Return the store already bound to an initialized generic-plugin profile,
+/// while allowing the official add path to initialize a genuinely missing
+/// profile. Every existing hierarchy component was validated by the caller's
+/// generic-layout gate before this helper is used.
+pub(crate) fn generic_profile_store_base(
+    dsh_home: &Path,
+    bundled_pnpm_major: u64,
+) -> Result<Option<PathBuf>, String> {
+    ensure_generic_plugin_layout(dsh_home)?;
+    let manifest = dsh_home.join("profiles/web/package.json");
+    match std::fs::symlink_metadata(&manifest) {
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(None),
+        Err(error) => Err(format!("cannot inspect web profile package.json: {error}")),
+        Ok(_) => {
+            let profile = profile_dir(dsh_home)?;
+            pnpm_store_base(&profile, bundled_pnpm_major)
+        }
+    }
+}
+
+/// pnpm applies `pnpm.patchedDependencies` after validating the registry
+/// tarball. That would let the extracted package differ from the Cordis
+/// integrity while the lockfile still reports the reviewed SHA-512, so the
+/// strict market path refuses this local content-transform feature.
+pub fn ensure_market_install_config(dsh_home: &Path) -> Result<(), String> {
+    let (profile, manifest) = read_profile_manifest(dsh_home)?;
+    if let Some(npmrc) =
+        crate::secure_fs::read_bounded(&profile.join(".npmrc"), PROFILE_NPMRC_MAX_BYTES)?
+    {
+        if npmrc.iter().any(|byte| !byte.is_ascii_whitespace()) {
+            return Err(
+                "market installation requires the web profile .npmrc to be absent or empty; local pnpm configuration could redirect the reviewed install"
+                    .to_string(),
+            );
+        }
+    }
+    let Some(pnpm) = manifest.get("pnpm") else {
+        return Ok(());
+    };
+    let pnpm = pnpm
+        .as_object()
+        .ok_or_else(|| "web profile package.json has an invalid pnpm configuration".to_string())?;
+    if let Some(patched) = pnpm.get("patchedDependencies") {
+        let patched = patched.as_object().ok_or_else(|| {
+            "web profile package.json has invalid pnpm.patchedDependencies".to_string()
+        })?;
+        if !patched.is_empty() {
+            return Err(
+                "market installation requires pnpm.patchedDependencies to be empty so reviewed integrity cannot be transformed"
+                    .to_string(),
+            );
+        }
+    }
+    Ok(())
+}
+
 pub(crate) fn read_profile_manifest(dsh_home: &Path) -> Result<(PathBuf, Value), String> {
     let profile = profile_dir(dsh_home)?;
     let manifest = profile.join("package.json");
-    let text = std::fs::read_to_string(&manifest)
-        .map_err(|e| format!("cannot read web profile package.json: {e}"))?;
-    let value: Value = serde_json::from_str(&text)
+    let bytes = crate::secure_fs::read_bounded(&manifest, PROFILE_MANIFEST_MAX_BYTES)?
+        .ok_or_else(|| "web profile package.json is missing".to_string())?;
+    let value: Value = serde_json::from_slice(&bytes)
         .map_err(|e| format!("web profile package.json is invalid JSON: {e}"))?;
     if !value.is_object() {
         return Err("web profile package.json must contain an object".to_string());
@@ -472,10 +777,13 @@ pub(crate) fn write_profile_manifest(profile: &Path, value: &Value) -> Result<()
 }
 
 pub(crate) fn write_profile_bytes(profile: &Path, bytes: &[u8]) -> Result<(), String> {
+    if bytes.len() as u64 > PROFILE_MANIFEST_MAX_BYTES {
+        return Err("web profile package.json exceeds 4 MiB".to_string());
+    }
     let path = profile.join("package.json");
     let metadata = std::fs::symlink_metadata(&path)
         .map_err(|e| format!("cannot inspect web profile package.json: {e}"))?;
-    if metadata.file_type().is_symlink() || !metadata.is_file() {
+    if crate::secure_fs::is_symlink_or_reparse(&metadata) || !metadata.is_file() {
         return Err("web profile package.json must be a regular file".to_string());
     }
     let millis = std::time::SystemTime::now()
@@ -487,21 +795,29 @@ pub(crate) fn write_profile_bytes(profile: &Path, bytes: &[u8]) -> Result<(), St
         std::process::id(),
         millis
     ));
-    let mut file = std::fs::OpenOptions::new()
-        .write(true)
-        .create_new(true)
-        .open(&temp)
-        .map_err(|e| format!("cannot create web profile package.json temp file: {e}"))?;
-    file.write_all(bytes)
-        .map_err(|e| format!("cannot write web profile package.json: {e}"))?;
-    file.sync_all()
-        .map_err(|e| format!("cannot sync web profile package.json: {e}"))?;
-    #[cfg(unix)]
-    {
-        std::fs::set_permissions(&temp, metadata.permissions())
+    let result = (|| {
+        let mut file = std::fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(&temp)
+            .map_err(|e| format!("cannot create web profile package.json temp file: {e}"))?;
+        file.write_all(bytes)
+            .map_err(|e| format!("cannot write web profile package.json: {e}"))?;
+        file.sync_all()
+            .map_err(|e| format!("cannot sync web profile package.json: {e}"))?;
+        #[cfg(unix)]
+        file.set_permissions(metadata.permissions())
             .map_err(|e| format!("cannot preserve web profile package.json permissions: {e}"))?;
+        // Windows replacement must not depend on delete-sharing behavior for
+        // an open temp handle. On Unix this also makes the durability boundary
+        // and publication order explicit.
+        drop(file);
+        replace_existing_file(&temp, &path, "web profile package.json")
+    })();
+    if result.is_err() {
+        let _ = std::fs::remove_file(&temp);
     }
-    replace_existing_file(&temp, &path, "web profile package.json")
+    result
 }
 
 pub(crate) fn profile_bundles_mut(value: &mut Value) -> Result<&mut Vec<Value>, String> {
@@ -550,16 +866,61 @@ pub fn pre_disable_market_plugin(
     dsh_home: &Path,
     candidate: &crate::market::MarketInstallCandidate,
 ) -> Result<(), String> {
+    pre_disable_plugin(dsh_home, &candidate.package_name)?;
+    remove_active_market_receipt(dsh_home, &candidate.package_name)?;
+    remove_pending_market_receipt(dsh_home, &candidate.package_name)
+}
+
+/// Remove exactly one dependency from the active bundle layer before pnpm
+/// mutates it. This is intentionally narrower than upstream's global
+/// reconciliation: uninstalling package B must never activate unrelated
+/// pending market package A.
+pub fn pre_disable_plugin(dsh_home: &Path, package_name: &str) -> Result<(), String> {
+    if !is_valid_package_name(package_name) {
+        return Err("cannot pre-disable an invalid plugin package name".to_string());
+    }
     let (profile, mut manifest) = read_profile_manifest(dsh_home)?;
-    let bundles = profile_bundles_mut(&mut manifest)?;
+    pre_disable_profile_bundle(&profile, &mut manifest, package_name)
+}
+
+/// Uninstall is exposed over IPC, so it must not let a caller disable an
+/// in-box bundle merely by naming it. Require a real, non-empty dependency
+/// entry before applying the exact pre-disable mutation; a missing installed
+/// tree is still removable so broken installations remain recoverable.
+pub fn pre_disable_installed_plugin(dsh_home: &Path, package_name: &str) -> Result<(), String> {
+    if !is_valid_package_name(package_name) {
+        return Err("cannot pre-disable an invalid plugin package name".to_string());
+    }
+    let (profile, mut manifest) = read_profile_manifest(dsh_home)?;
+    let installed = profile_dependencies(&manifest)?
+        .get(package_name)
+        .and_then(Value::as_str)
+        .is_some_and(|spec| !spec.is_empty());
+    if !installed {
+        return Err(format!(
+            "plugin {package_name} is not an installed web-profile dependency"
+        ));
+    }
+    pre_disable_profile_bundle(&profile, &mut manifest, package_name)
+}
+
+fn pre_disable_profile_bundle(
+    profile: &Path,
+    manifest: &mut Value,
+    package_name: &str,
+) -> Result<(), String> {
+    let bundles = profile_bundles_mut(manifest)?;
     for bundle in bundles.iter() {
         if bundle.as_str().is_none() {
             return Err("web profile bundles contains a non-string value".to_string());
         }
     }
-    bundles.retain(|bundle| bundle.as_str() != Some(candidate.package_name.as_str()));
-    write_profile_manifest(&profile, &manifest)?;
-    remove_active_market_receipt(dsh_home, &candidate.package_name)
+    let before = bundles.len();
+    bundles.retain(|bundle| bundle.as_str() != Some(package_name));
+    if bundles.len() != before {
+        write_profile_manifest(profile, manifest)?;
+    }
+    Ok(())
 }
 
 fn lockfile_package_key(line: &str) -> Option<&str> {
@@ -646,16 +1007,10 @@ fn inline_lockfile_integrity(line: &str) -> Option<&str> {
 
 fn lockfile_integrity(profile: &Path, package_name: &str, version: &str) -> Result<String, String> {
     let path = profile.join("pnpm-lock.yaml");
-    let metadata = std::fs::symlink_metadata(&path)
-        .map_err(|e| format!("cannot inspect pnpm lockfile: {e}"))?;
-    if metadata.file_type().is_symlink() || !metadata.is_file() {
-        return Err("pnpm lockfile must be a regular file".to_string());
-    }
-    if metadata.len() > PROFILE_LOCK_MAX_BYTES {
-        return Err("pnpm lockfile exceeds 4 MiB".to_string());
-    }
-    let text =
-        std::fs::read_to_string(&path).map_err(|e| format!("cannot read pnpm lockfile: {e}"))?;
+    let bytes = crate::secure_fs::read_bounded(&path, PROFILE_LOCK_MAX_BYTES)?
+        .ok_or_else(|| "pnpm lockfile is missing".to_string())?;
+    let text = std::str::from_utf8(&bytes)
+        .map_err(|e| format!("pnpm lockfile is not valid UTF-8: {e}"))?;
     let expected_key = format!("{package_name}@{version}");
     let mut in_packages = false;
     let mut in_target = false;
@@ -700,6 +1055,39 @@ fn lockfile_integrity(profile: &Path, package_name: &str, version: &str) -> Resu
     ))
 }
 
+/// A bundle patch is resolved by upstream relative to the installed package
+/// directory. Keep the declaration portable and reject every form that could
+/// escape that directory on either Unix or Windows before activation.
+fn is_safe_bundle_patch_path(path: &str) -> bool {
+    if path.is_empty()
+        || path.len() > BUNDLE_PATCH_PATH_MAX_BYTES
+        || path.starts_with('/')
+        || path.contains(['\\', ':'])
+        || path.chars().any(char::is_control)
+    {
+        return false;
+    }
+    let relative = path.strip_prefix("./").unwrap_or(path);
+    !relative.is_empty()
+        && relative
+            .split('/')
+            .all(|component| !component.is_empty() && component != "." && component != "..")
+}
+
+fn checked_installed_package_dir(profile: &Path, package_name: &str) -> Result<PathBuf, String> {
+    let node_modules = profile.join("node_modules");
+    checked_real_dir(&node_modules, "market profile node_modules")?;
+    let package = if let Some((scope, name)) = package_name.split_once('/') {
+        let scope_dir = node_modules.join(scope);
+        checked_real_dir(&scope_dir, "market package scope directory")?;
+        scope_dir.join(name)
+    } else {
+        node_modules.join(package_name)
+    };
+    checked_real_dir(&package, "installed market package directory")?;
+    Ok(package)
+}
+
 /// Verify all installation facts pnpm materialized. No build script can run
 /// in the market pnpm invocation, and normal pending verification requires
 /// the profile to stay pre-disabled throughout this check.
@@ -722,13 +1110,11 @@ pub(crate) fn verify_market_installation(
         return Err("market package became active before explicit activation".to_string());
     }
 
-    let installed_manifest = profile
-        .join("node_modules")
-        .join(&candidate.package_name)
-        .join("package.json");
-    let text = std::fs::read_to_string(&installed_manifest)
-        .map_err(|e| format!("cannot read installed market package: {e}"))?;
-    let installed: Value = serde_json::from_str(&text)
+    let installed_package = checked_installed_package_dir(&profile, &candidate.package_name)?;
+    let installed_manifest = installed_package.join("package.json");
+    let bytes = crate::secure_fs::read_bounded(&installed_manifest, INSTALLED_MANIFEST_MAX_BYTES)?
+        .ok_or_else(|| "installed market package manifest is missing".to_string())?;
+    let installed: Value = serde_json::from_slice(&bytes)
         .map_err(|e| format!("installed market package has invalid JSON: {e}"))?;
     if installed.get("name").and_then(Value::as_str) != Some(candidate.package_name.as_str())
         || installed.get("version").and_then(Value::as_str) != Some(candidate.version.as_str())
@@ -737,17 +1123,30 @@ pub(crate) fn verify_market_installation(
             "installed market package name/version differs from the reviewed source".to_string(),
         );
     }
-    if installed
+    let patch = installed
         .get("dsh")
         .and_then(Value::as_object)
         .and_then(|dsh| dsh.get("bundle"))
         .and_then(Value::as_object)
         .and_then(|bundle| bundle.get("patch"))
         .and_then(Value::as_str)
-        .filter(|patch| !patch.is_empty())
-        .is_none()
-    {
-        return Err("installed market package is not a DSH bundle".to_string());
+        .ok_or_else(|| "installed market package is not a DSH bundle".to_string())?;
+    if !is_safe_bundle_patch_path(patch) {
+        return Err("installed market package has an unsafe dsh.bundle.patch path".to_string());
+    }
+    let patch_path = installed_package.join(patch);
+    let package_root = std::fs::canonicalize(&installed_package)
+        .map_err(|error| format!("cannot resolve installed market package directory: {error}"))?;
+    let resolved_patch = std::fs::canonicalize(&patch_path).map_err(|error| {
+        format!("cannot resolve installed market package bundle patch: {error}")
+    })?;
+    if !resolved_patch.starts_with(&package_root) || resolved_patch == package_root {
+        return Err(
+            "installed market package bundle patch escapes its package directory".to_string(),
+        );
+    }
+    if crate::secure_fs::read_bounded(&patch_path, BUNDLE_PATCH_MAX_BYTES)?.is_none() {
+        return Err("installed market package bundle patch is missing".to_string());
     }
     if lockfile_integrity(&profile, &candidate.package_name, &candidate.version)?
         != candidate.integrity
@@ -805,12 +1204,7 @@ pub fn activate_market_plugin(
     // source-mismatched receipts are ignored and pruned by mutation paths; the
     // reverse ordering could leave an active market plugin that recovery
     // cannot revalidate.
-    let mut active = load_active(dsh_home)?;
-    active.plugins.insert(
-        candidate.package_name.clone(),
-        MarketPendingPlugin::from(candidate),
-    );
-    write_active(dsh_home, &active)?;
+    record_active_market_receipt(dsh_home, candidate)?;
 
     let (profile, mut manifest) = read_profile_manifest(dsh_home)?;
     let bundles = profile_bundles_mut(&mut manifest)?;
@@ -849,24 +1243,29 @@ pub fn installed_plugins(dsh_home: &Path) -> Vec<InstalledPlugin> {
     };
     let bundles = profile_bundles(&manifest).unwrap_or_default();
     let pending = load_pending(dsh_home).unwrap_or_default();
-    let mut entries = Vec::new();
-    for name in dependencies.keys() {
-        let version =
-            std::fs::read_to_string(profile.join("node_modules").join(name).join("package.json"))
-                .ok()
-                .and_then(|text| serde_json::from_str::<Value>(&text).ok())
-                .and_then(|package| {
-                    package
-                        .get("version")
-                        .and_then(Value::as_str)
-                        .map(str::to_owned)
-                })
-                .unwrap_or_else(|| "—".to_string());
-        let marker = pending
-            .plugins
-            .get(name)
-            .filter(|marker| marker.version == version);
-        let (state, slug, entry_revision) = if bundles.contains(name.as_str()) {
+    let mut names: Vec<&str> = dependencies
+        .iter()
+        .filter_map(|(name, spec)| {
+            (is_valid_package_name(name) && spec.as_str().is_some_and(|value| !value.is_empty()))
+                .then_some(name.as_str())
+        })
+        .collect();
+    names.sort_unstable();
+    names.truncate(MAX_INSTALLED_PLUGINS);
+
+    let mut entries = Vec::with_capacity(names.len());
+    for name in names {
+        let version = read_installed_plugin_version(&profile, name)
+            .ok()
+            .flatten()
+            .unwrap_or_else(|| "—".to_string());
+        let dependency_spec = dependencies.get(name).and_then(Value::as_str);
+        let marker = pending.plugins.get(name).filter(|marker| {
+            marker.package_name == name
+                && marker.version == version
+                && dependency_spec == Some(marker.tarball.as_str())
+        });
+        let (state, slug, entry_revision) = if bundles.contains(name) {
             ("active".to_string(), None, None)
         } else if let Some(marker) = marker {
             (
@@ -878,22 +1277,50 @@ pub fn installed_plugins(dsh_home: &Path) -> Vec<InstalledPlugin> {
             ("installed".to_string(), None, None)
         };
         entries.push(InstalledPlugin {
-            name: name.clone(),
+            name: name.to_string(),
             version,
             state,
             slug,
             entry_revision,
         });
     }
-    entries.sort_by(|left, right| left.name.cmp(&right.name));
     entries
 }
 
-/// The runner state managed by the shell: single-flight flag, app-exit
-/// latch, and the live child handle (for cancel and for app-exit cleanup).
+fn read_installed_plugin_version(
+    profile: &Path,
+    package_name: &str,
+) -> Result<Option<String>, String> {
+    let path = checked_installed_package_dir(profile, package_name)?.join("package.json");
+    let Some(bytes) = crate::secure_fs::read_bounded(&path, INSTALLED_MANIFEST_MAX_BYTES)? else {
+        return Ok(None);
+    };
+    let package: Value = serde_json::from_slice(&bytes)
+        .map_err(|error| format!("installed plugin manifest is invalid JSON: {error}"))?;
+    if package.get("name").and_then(Value::as_str) != Some(package_name) {
+        return Err("installed plugin manifest name does not match its dependency".to_string());
+    }
+    let version = package
+        .get("version")
+        .and_then(Value::as_str)
+        .filter(|version| {
+            !version.is_empty() && version.len() <= 128 && !version.chars().any(char::is_control)
+        })
+        .ok_or_else(|| "installed plugin manifest has an invalid version".to_string())?;
+    Ok(Some(version.to_string()))
+}
+
+/// The runner state managed by the shell: single-flight flag, cancellation
+/// latch, app-exit latch, and the live child handle. `operation_gate` makes
+/// begin/cancel/finish one atomic state transition so a cancel arriving
+/// before the child handle is registered cannot be lost or applied to the
+/// next operation.
 pub struct PluginRunner {
     pub busy: AtomicBool,
     pub exiting: AtomicBool,
+    cancel_requested: AtomicBool,
+    terminating_child: AtomicBool,
+    operation_gate: Mutex<()>,
     pub child: Mutex<Option<PlatformChild>>,
 }
 
@@ -902,12 +1329,104 @@ impl PluginRunner {
         PluginRunner {
             busy: AtomicBool::new(false),
             exiting: AtomicBool::new(false),
+            cancel_requested: AtomicBool::new(false),
+            terminating_child: AtomicBool::new(false),
+            operation_gate: Mutex::new(()),
             child: Mutex::new(None),
         }
     }
 
-    /// App-exit cleanup (C1 process-tree guarantee): a running `dsh plugin`
-    /// tree is a separate process group / Job Object from the sidecar's
+    pub fn try_begin(&self) -> bool {
+        let _gate = self
+            .operation_gate
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        if self.exiting.load(Ordering::SeqCst)
+            || self.busy.load(Ordering::SeqCst)
+            || self.terminating_child.load(Ordering::SeqCst)
+        {
+            return false;
+        }
+        self.cancel_requested.store(false, Ordering::SeqCst);
+        self.busy.store(true, Ordering::SeqCst);
+        true
+    }
+
+    pub fn finish(&self) {
+        self.finish_with(|| ());
+    }
+
+    /// Publish a completion side effect before another operation can claim
+    /// the single-flight gate. In particular, queue `plugin-done` while the
+    /// transition is still exclusive so a delayed event cannot belong to a
+    /// newly started operation.
+    pub fn finish_with<T>(&self, action: impl FnOnce() -> T) -> T {
+        let _gate = self
+            .operation_gate
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        self.cancel_requested.store(false, Ordering::SeqCst);
+        self.busy.store(false, Ordering::SeqCst);
+        action()
+    }
+
+    pub fn request_cancel(&self) -> (bool, Option<PlatformChild>) {
+        let _gate = self
+            .operation_gate
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        if !self.busy.load(Ordering::SeqCst)
+            || self.exiting.load(Ordering::SeqCst)
+            || self.cancel_requested.load(Ordering::SeqCst)
+        {
+            return (false, None);
+        }
+        self.cancel_requested.store(true, Ordering::SeqCst);
+        let child = self
+            .child
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .take();
+        self.terminating_child
+            .store(child.is_some(), Ordering::SeqCst);
+        (true, child)
+    }
+
+    pub fn child_termination_finished(&self) {
+        self.terminating_child.store(false, Ordering::SeqCst);
+    }
+
+    pub fn is_busy(&self) -> bool {
+        self.busy.load(Ordering::SeqCst) || self.terminating_child.load(Ordering::SeqCst)
+    }
+
+    pub fn cancellation_requested(&self) -> bool {
+        self.cancel_requested.load(Ordering::SeqCst)
+    }
+
+    /// Run a short profile boundary only when no plugin/recovery mutation is
+    /// active. Holding the transition gate for the action prevents a new
+    /// operation from starting between the idle check and the protected read
+    /// or write, without misreporting the boundary itself as a plugin job.
+    pub fn with_idle_profile<T>(
+        &self,
+        action: impl FnOnce() -> Result<T, String>,
+    ) -> Result<T, String> {
+        let _gate = self
+            .operation_gate
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        if self.exiting.load(Ordering::SeqCst)
+            || self.busy.load(Ordering::SeqCst)
+            || self.terminating_child.load(Ordering::SeqCst)
+        {
+            return Err("插件操作仍在进行，完成或取消后才能重启 Harness".to_string());
+        }
+        action()
+    }
+
+    /// App-exit cleanup (C1 process-tree guarantee): a running plugin
+    /// mutation tree is a separate process group / Job Object from the sidecar's
     /// Harness tree, so it must be killed explicitly — on unix it would
     /// otherwise be orphaned once the shell exits. Taking the handle also
     /// keeps the done-path from racing the kill. Polite signal first, then
@@ -918,7 +1437,12 @@ impl PluginRunner {
     /// that window would find `child == None` — the latch makes the spawn
     /// path kill the fresh tree itself.
     pub fn shutdown(&self) {
+        let _gate = self
+            .operation_gate
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
         self.exiting.store(true, Ordering::SeqCst);
+        self.cancel_requested.store(true, Ordering::SeqCst);
         if let Some(child) = self
             .child
             .lock()
@@ -1000,6 +1524,40 @@ mod tests {
     }
 
     #[test]
+    fn recovery_reactivation_restores_provenance_before_the_bundle() {
+        let home = std::env::temp_dir().join(format!(
+            "dshd-recovery-receipt-{}",
+            crate::secure_fs::random_suffix().unwrap()
+        ));
+        std::fs::create_dir_all(&home).unwrap();
+        let candidate = market_candidate();
+        setup_market_profile(&home, &candidate);
+        record_active_market_receipt(&home, &candidate).unwrap();
+
+        pre_disable_plugin(&home, &candidate.package_name).unwrap();
+        reconcile_market_receipts(&home).unwrap();
+        assert!(load_active(&home).unwrap().plugins.is_empty());
+
+        // The command's market-gated recovery path records provenance first,
+        // then restores the exact backed-up bundle profile.
+        record_active_market_receipt(&home, &candidate).unwrap();
+        let (profile, mut manifest) = read_profile_manifest(&home).unwrap();
+        profile_bundles_mut(&mut manifest)
+            .unwrap()
+            .push(Value::String(candidate.package_name.clone()));
+        write_profile_manifest(&profile, &manifest).unwrap();
+        reconcile_market_receipts(&home).unwrap();
+
+        assert_eq!(
+            active_market_receipt(&home, &candidate.package_name)
+                .unwrap()
+                .as_ref(),
+            Some(&MarketPendingPlugin::from(&candidate))
+        );
+        std::fs::remove_dir_all(home).unwrap();
+    }
+
+    #[test]
     fn package_names_accept_reject() {
         for ok in [
             "is-odd",
@@ -1047,6 +1605,97 @@ mod tests {
         ] {
             assert!(!is_valid_package_name(bad), "should reject {bad:?}");
         }
+    }
+
+    #[test]
+    fn runner_latches_cancel_before_a_child_is_registered() {
+        let runner = PluginRunner::new();
+        assert!(runner.try_begin());
+        assert!(runner.busy.load(Ordering::SeqCst));
+        assert!(runner.request_cancel().0);
+        assert!(runner.cancellation_requested());
+        assert!(
+            !runner.request_cancel().0,
+            "repeated cancellation must be idempotent"
+        );
+        assert!(!runner.try_begin(), "single-flight must remain held");
+
+        runner.finish();
+        assert!(!runner.busy.load(Ordering::SeqCst));
+        assert!(!runner.cancellation_requested());
+        assert!(
+            !runner.request_cancel().0,
+            "idle cancel must not poison the next run"
+        );
+        assert!(runner.try_begin());
+        assert!(!runner.cancellation_requested());
+        runner.finish();
+    }
+
+    #[test]
+    fn terminating_child_keeps_the_single_flight_gate_closed() {
+        let runner = PluginRunner::new();
+        assert!(runner.try_begin());
+        runner.terminating_child.store(true, Ordering::SeqCst);
+        runner.finish();
+        assert!(runner.is_busy());
+        assert!(!runner.try_begin());
+        runner.child_termination_finished();
+        assert!(!runner.is_busy());
+        assert!(runner.try_begin());
+        runner.finish();
+    }
+
+    #[test]
+    fn idle_profile_boundary_does_not_overlap_a_plugin_mutation() {
+        let runner = PluginRunner::new();
+        assert_eq!(runner.with_idle_profile(|| Ok(7)).unwrap(), 7);
+        assert!(!runner.is_busy(), "a restart boundary is not a plugin job");
+
+        assert!(runner.try_begin());
+        let mut called = false;
+        let error = runner
+            .with_idle_profile(|| {
+                called = true;
+                Ok(())
+            })
+            .unwrap_err();
+        assert!(error.contains("插件操作仍在进行"), "{error}");
+        assert!(!called, "busy profile boundary must not run its action");
+        runner.finish();
+    }
+
+    #[test]
+    fn completion_is_published_before_the_next_operation_can_begin() {
+        let runner = std::sync::Arc::new(PluginRunner::new());
+        assert!(runner.try_begin());
+        let (entered_tx, entered_rx) = std::sync::mpsc::channel();
+        let (release_tx, release_rx) = std::sync::mpsc::channel();
+        let finish_runner = runner.clone();
+        let finisher = std::thread::spawn(move || {
+            finish_runner.finish_with(|| {
+                entered_tx.send(()).unwrap();
+                release_rx.recv().unwrap();
+            });
+        });
+        entered_rx.recv().unwrap();
+
+        let (begin_tx, begin_rx) = std::sync::mpsc::channel();
+        let begin_runner = runner.clone();
+        let beginner = std::thread::spawn(move || {
+            begin_tx.send(begin_runner.try_begin()).unwrap();
+        });
+        assert!(
+            begin_rx
+                .recv_timeout(std::time::Duration::from_millis(50))
+                .is_err(),
+            "the next operation must wait until completion publication returns"
+        );
+        release_tx.send(()).unwrap();
+        finisher.join().unwrap();
+        assert!(begin_rx.recv().unwrap());
+        beginner.join().unwrap();
+        runner.finish();
     }
 
     #[test]
@@ -1218,6 +1867,14 @@ mod tests {
         )
         .unwrap();
         std::fs::write(
+            profile
+                .join("node_modules")
+                .join(&candidate.package_name)
+                .join("cordis.patch.yml"),
+            "[]\n",
+        )
+        .unwrap();
+        std::fs::write(
             profile.join("pnpm-lock.yaml"),
             format!(
                 "lockfileVersion: '9.0'\n\npackages:\n\n  {}@{}:\n    resolution: {{integrity: {}}}\n\nsnapshots:\n",
@@ -1225,6 +1882,403 @@ mod tests {
             ),
         )
         .unwrap();
+    }
+
+    #[test]
+    fn existing_pnpm_store_is_reused_without_changing_layout() {
+        let home = std::env::temp_dir().join(format!(
+            "dsh-pnpm-store-{}",
+            crate::secure_fs::random_suffix().unwrap()
+        ));
+        let profile = home.join("profiles/web");
+        let node_modules = profile.join("node_modules");
+        std::fs::create_dir_all(&node_modules).unwrap();
+        std::fs::write(
+            profile.join("package.json"),
+            r#"{"dependencies":{},"dsh":{"profile":{"bundles":[]}}}"#,
+        )
+        .unwrap();
+        let store_base = home.join("shared-pnpm-store");
+        let versioned = store_base.join("v11");
+        std::fs::write(
+            node_modules.join(".modules.yaml"),
+            serde_json::to_vec(&serde_json::json!({"storeDir": versioned})).unwrap(),
+        )
+        .unwrap();
+        assert_eq!(pnpm_store_base(&profile, 11).unwrap(), Some(store_base));
+        assert_eq!(
+            generic_profile_store_base(&home, 11).unwrap(),
+            Some(home.join("shared-pnpm-store"))
+        );
+
+        let wrong = home.join("legacy-store/v10");
+        std::fs::write(
+            node_modules.join(".modules.yaml"),
+            serde_json::to_vec(&serde_json::json!({"storeDir": wrong})).unwrap(),
+        )
+        .unwrap();
+        let error = pnpm_store_base(&profile, 11).unwrap_err();
+        assert!(error.contains("incompatible pnpm store layout"), "{error}");
+        std::fs::remove_dir_all(home).unwrap();
+    }
+
+    #[test]
+    fn pending_receipt_repairs_accidental_activation_and_blocks_generic_add() {
+        let home = std::env::temp_dir().join(format!(
+            "dsh-pending-activation-{}",
+            crate::secure_fs::random_suffix().unwrap()
+        ));
+        let candidate = market_candidate();
+        setup_market_profile(&home, &candidate);
+        pre_disable_market_plugin(&home, &candidate).unwrap();
+        verify_and_mark_market_pending(&home, &candidate).unwrap();
+
+        // Simulate the old upstream global reconciliation adding the pending
+        // dependency while an unrelated plugin was changed.
+        let (profile, mut manifest) = read_profile_manifest(&home).unwrap();
+        profile_bundles_mut(&mut manifest)
+            .unwrap()
+            .push(Value::String(candidate.package_name.clone()));
+        write_profile_manifest(&profile, &manifest).unwrap();
+
+        let error = ensure_no_pending_market_plugins(&home).unwrap_err();
+        assert!(error.contains("awaiting explicit activation"), "{error}");
+        let (_, repaired) = read_profile_manifest(&home).unwrap();
+        assert!(!profile_bundles(&repaired)
+            .unwrap()
+            .contains(candidate.package_name.as_str()));
+        assert!(load_pending(&home)
+            .unwrap()
+            .plugins
+            .contains_key(&candidate.package_name));
+        std::fs::remove_dir_all(home).unwrap();
+    }
+
+    #[test]
+    fn uninstall_pre_disable_requires_a_dependency_and_changes_only_its_target() {
+        let home = std::env::temp_dir().join(format!(
+            "dsh-exact-pre-disable-{}",
+            crate::secure_fs::random_suffix().unwrap()
+        ));
+        let candidate = market_candidate();
+        setup_market_profile(&home, &candidate);
+        let (profile, mut manifest) = read_profile_manifest(&home).unwrap();
+        profile_bundles_mut(&mut manifest)
+            .unwrap()
+            .push(Value::String("other-plugin".to_string()));
+        write_profile_manifest(&profile, &manifest).unwrap();
+
+        let error = pre_disable_installed_plugin(&home, "other-plugin").unwrap_err();
+        assert!(error.contains("not an installed"), "{error}");
+        pre_disable_installed_plugin(&home, &candidate.package_name).unwrap();
+        let (_, manifest) = read_profile_manifest(&home).unwrap();
+        let bundles = profile_bundles(&manifest).unwrap();
+        assert!(!bundles.contains(candidate.package_name.as_str()));
+        assert!(bundles.contains("other-plugin"));
+        std::fs::remove_dir_all(home).unwrap();
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn generic_add_refuses_a_symlinked_node_modules_before_spawn() {
+        use std::os::unix::fs::symlink;
+
+        let home = std::env::temp_dir().join(format!(
+            "dsh-generic-layout-{}",
+            crate::secure_fs::random_suffix().unwrap()
+        ));
+        let profile = home.join("profiles/web");
+        let outside = home.join("outside");
+        std::fs::create_dir_all(&profile).unwrap();
+        std::fs::create_dir_all(outside.join("is-odd")).unwrap();
+        std::fs::write(
+            profile.join("package.json"),
+            r#"{"dependencies":{"is-odd":"3.0.1"},"dsh":{"profile":{"bundles":[]}}}"#,
+        )
+        .unwrap();
+        std::fs::write(
+            outside.join("is-odd/package.json"),
+            r#"{"name":"is-odd","version":"9.9.9"}"#,
+        )
+        .unwrap();
+        symlink(&outside, profile.join("node_modules")).unwrap();
+
+        let error = ensure_no_pending_market_plugins(&home).unwrap_err();
+        assert!(error.contains("symbolic link"), "{error}");
+        let rows = installed_plugins(&home);
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].version, "—");
+        std::fs::remove_dir_all(home).unwrap();
+    }
+
+    #[test]
+    fn installed_list_uses_production_parser_and_rejects_path_like_dependency_keys() {
+        let home = std::env::temp_dir().join(format!(
+            "dsh-installed-list-{}",
+            crate::secure_fs::random_suffix().unwrap()
+        ));
+        let profile = home.join("profiles").join("web");
+        std::fs::create_dir_all(profile.join("node_modules/is-odd")).unwrap();
+        std::fs::create_dir_all(profile.join("outside")).unwrap();
+        std::fs::write(
+            profile.join("package.json"),
+            r#"{
+              "dependencies": {
+                "../outside": "9.9.9",
+                "is-odd": "^3.0.1",
+                "not-a-string": false,
+                "zz-top": "1.0.0"
+              },
+              "dsh": {"profile": {"bundles": []}}
+            }"#,
+        )
+        .unwrap();
+        std::fs::write(
+            profile.join("node_modules/is-odd/package.json"),
+            r#"{"name":"is-odd","version":"3.0.1"}"#,
+        )
+        .unwrap();
+        // This is exactly where the old `node_modules.join("../outside")`
+        // traversal landed. Its version must never become a bootstrap row.
+        std::fs::write(
+            profile.join("outside/package.json"),
+            r#"{"name":"../outside","version":"9.9.9"}"#,
+        )
+        .unwrap();
+
+        let rows = installed_plugins(&home);
+        assert_eq!(rows.len(), 2);
+        assert_eq!(rows[0].name, "is-odd");
+        assert_eq!(rows[0].version, "3.0.1");
+        assert_eq!(rows[1].name, "zz-top");
+        assert_eq!(rows[1].version, "—");
+        std::fs::remove_dir_all(home).unwrap();
+    }
+
+    #[test]
+    fn installed_list_does_not_trust_a_mismatched_or_oversized_package_manifest() {
+        let home = std::env::temp_dir().join(format!(
+            "dsh-installed-manifest-{}",
+            crate::secure_fs::random_suffix().unwrap()
+        ));
+        let profile = home.join("profiles").join("web");
+        std::fs::create_dir_all(profile.join("node_modules/is-odd")).unwrap();
+        std::fs::write(
+            profile.join("package.json"),
+            r#"{"dependencies":{"is-odd":"3.0.1"},"dsh":{"profile":{"bundles":[]}}}"#,
+        )
+        .unwrap();
+        std::fs::write(
+            profile.join("node_modules/is-odd/package.json"),
+            r#"{"name":"different-package","version":"3.0.1"}"#,
+        )
+        .unwrap();
+        assert_eq!(installed_plugins(&home)[0].version, "—");
+
+        std::fs::write(
+            profile.join("node_modules/is-odd/package.json"),
+            vec![b' '; INSTALLED_MANIFEST_MAX_BYTES as usize + 1],
+        )
+        .unwrap();
+        assert_eq!(installed_plugins(&home)[0].version, "—");
+        std::fs::remove_dir_all(home).unwrap();
+    }
+
+    #[test]
+    fn profile_manifest_reads_are_bounded() {
+        let home = std::env::temp_dir().join(format!(
+            "dsh-profile-bound-{}",
+            crate::secure_fs::random_suffix().unwrap()
+        ));
+        let profile = home.join("profiles").join("web");
+        std::fs::create_dir_all(&profile).unwrap();
+        std::fs::write(
+            profile.join("package.json"),
+            vec![b' '; PROFILE_MANIFEST_MAX_BYTES as usize + 1],
+        )
+        .unwrap();
+        let error = read_profile_manifest(&home).unwrap_err();
+        assert!(error.contains("byte limit"), "{error}");
+        std::fs::remove_dir_all(home).unwrap();
+    }
+
+    #[test]
+    fn market_install_rejects_local_patched_dependency_transforms() {
+        let home = std::env::temp_dir().join(format!(
+            "dsh-market-patched-dependency-{}",
+            crate::secure_fs::random_suffix().unwrap()
+        ));
+        let candidate = market_candidate();
+        setup_market_profile(&home, &candidate);
+        let (profile, mut manifest) = read_profile_manifest(&home).unwrap();
+        manifest["pnpm"] = serde_json::json!({
+            "patchedDependencies": {
+                "fixture-plugin@1.0.0": "patches/fixture.patch"
+            }
+        });
+        write_profile_manifest(&profile, &manifest).unwrap();
+
+        let error = ensure_market_install_config(&home).unwrap_err();
+        assert!(error.contains("patchedDependencies"), "{error}");
+        std::fs::remove_dir_all(home).unwrap();
+    }
+
+    #[test]
+    fn market_install_rejects_profile_local_npmrc_redirects() {
+        let home = std::env::temp_dir().join(format!(
+            "dsh-market-npmrc-{}",
+            crate::secure_fs::random_suffix().unwrap()
+        ));
+        let candidate = market_candidate();
+        setup_market_profile(&home, &candidate);
+        std::fs::write(home.join("profiles/web/.npmrc"), "global=true\n").unwrap();
+
+        let error = ensure_market_install_config(&home).unwrap_err();
+        assert!(error.contains(".npmrc"), "{error}");
+        std::fs::remove_dir_all(home).unwrap();
+    }
+
+    #[test]
+    fn pending_state_requires_the_exact_reviewed_dependency_source() {
+        let home = std::env::temp_dir().join(format!(
+            "dsh-pending-source-{}",
+            crate::secure_fs::random_suffix().unwrap()
+        ));
+        std::fs::create_dir_all(&home).unwrap();
+        let candidate = market_candidate();
+        setup_market_profile(&home, &candidate);
+        pre_disable_market_plugin(&home, &candidate).unwrap();
+        verify_and_mark_market_pending(&home, &candidate).unwrap();
+        assert_eq!(installed_plugins(&home)[0].state, "pending");
+
+        let (profile, mut manifest) = read_profile_manifest(&home).unwrap();
+        manifest["dependencies"][&candidate.package_name] =
+            Value::String(candidate.version.clone());
+        profile_bundles_mut(&mut manifest)
+            .unwrap()
+            .push(Value::String(candidate.package_name.clone()));
+        write_profile_manifest(&profile, &manifest).unwrap();
+        assert_eq!(installed_plugins(&home)[0].state, "active");
+        reconcile_market_receipts(&home).unwrap();
+        assert!(load_pending(&home).unwrap().plugins.is_empty());
+        assert!(!profile_bundles(&read_profile_manifest(&home).unwrap().1)
+            .unwrap()
+            .contains(candidate.package_name.as_str()));
+        std::fs::remove_dir_all(home).unwrap();
+    }
+
+    #[test]
+    fn pending_reconciliation_prunes_an_unreadable_installed_manifest() {
+        let home = std::env::temp_dir().join(format!(
+            "dsh-pending-invalid-manifest-{}",
+            crate::secure_fs::random_suffix().unwrap()
+        ));
+        std::fs::create_dir_all(&home).unwrap();
+        let candidate = market_candidate();
+        setup_market_profile(&home, &candidate);
+        pre_disable_market_plugin(&home, &candidate).unwrap();
+        verify_and_mark_market_pending(&home, &candidate).unwrap();
+        std::fs::write(
+            home.join("profiles/web/node_modules")
+                .join(&candidate.package_name)
+                .join("package.json"),
+            "not json",
+        )
+        .unwrap();
+
+        reconcile_market_receipts(&home).unwrap();
+        assert!(load_pending(&home).unwrap().plugins.is_empty());
+        std::fs::remove_dir_all(home).unwrap();
+    }
+
+    #[test]
+    fn market_verifier_rejects_bundle_patch_path_escape() {
+        let home = std::env::temp_dir().join(format!(
+            "dsh-market-patch-escape-{}",
+            crate::secure_fs::random_suffix().unwrap()
+        ));
+        std::fs::create_dir_all(&home).unwrap();
+        let candidate = market_candidate();
+        setup_market_profile(&home, &candidate);
+        pre_disable_market_plugin(&home, &candidate).unwrap();
+        let manifest_path = home
+            .join("profiles/web/node_modules")
+            .join(&candidate.package_name)
+            .join("package.json");
+        std::fs::write(
+            &manifest_path,
+            serde_json::to_vec(&serde_json::json!({
+                "name": candidate.package_name,
+                "version": candidate.version,
+                "dsh": {"bundle": {"patch": "../../../outside.yml"}}
+            }))
+            .unwrap(),
+        )
+        .unwrap();
+        std::fs::write(home.join("outside.yml"), "[]\n").unwrap();
+
+        let error = verify_market_installation(&home, &candidate, true).unwrap_err();
+        assert!(error.contains("unsafe dsh.bundle.patch"), "{error}");
+        std::fs::remove_dir_all(home).unwrap();
+    }
+
+    #[test]
+    fn bundle_patch_path_contract_is_cross_platform() {
+        for valid in ["cordis.patch.yml", "./cordis.patch.yml", "patches/base.yml"] {
+            assert!(is_safe_bundle_patch_path(valid), "should accept {valid:?}");
+        }
+        for invalid in [
+            "",
+            "/etc/passwd",
+            "../outside.yml",
+            "a/../../outside.yml",
+            "./../outside.yml",
+            "C:/Windows/system.ini",
+            "..\\outside.yml",
+            "patches//base.yml",
+            "patches/./base.yml",
+        ] {
+            assert!(
+                !is_safe_bundle_patch_path(invalid),
+                "should reject {invalid:?}"
+            );
+        }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn market_verifier_rejects_bundle_patch_symlink_escape() {
+        use std::os::unix::fs::symlink;
+
+        let home = std::env::temp_dir().join(format!(
+            "dsh-market-patch-link-{}",
+            crate::secure_fs::random_suffix().unwrap()
+        ));
+        std::fs::create_dir_all(&home).unwrap();
+        let candidate = market_candidate();
+        setup_market_profile(&home, &candidate);
+        pre_disable_market_plugin(&home, &candidate).unwrap();
+        let package = home
+            .join("profiles/web/node_modules")
+            .join(&candidate.package_name);
+        let outside = home.join("outside");
+        std::fs::create_dir_all(&outside).unwrap();
+        std::fs::write(outside.join("patch.yml"), "[]\n").unwrap();
+        symlink(&outside, package.join("patches")).unwrap();
+        std::fs::write(
+            package.join("package.json"),
+            serde_json::to_vec(&serde_json::json!({
+                "name": candidate.package_name,
+                "version": candidate.version,
+                "dsh": {"bundle": {"patch": "patches/patch.yml"}}
+            }))
+            .unwrap(),
+        )
+        .unwrap();
+
+        let error = verify_market_installation(&home, &candidate, true).unwrap_err();
+        assert!(error.contains("escapes its package directory"), "{error}");
+        std::fs::remove_dir_all(home).unwrap();
     }
 
     #[test]
@@ -1344,8 +2398,15 @@ mod tests {
         pre_disable_market_plugin(&home, &candidate).expect("pre-disable");
         verify_and_mark_market_pending(&home, &candidate).expect("verified pending");
 
-        // Simulate a crash after the activation profile write but before the
-        // pending marker can be removed.
+        // Activation persists exact provenance before enabling the bundle.
+        // Simulate a crash after both writes but before the pending marker can
+        // be removed.
+        let mut active = MarketActiveFile::default();
+        active.plugins.insert(
+            candidate.package_name.clone(),
+            MarketPendingPlugin::from(&candidate),
+        );
+        write_active(&home, &active).expect("simulate active receipt write");
         let (profile, mut manifest) = read_profile_manifest(&home).expect("profile");
         profile_bundles_mut(&mut manifest)
             .expect("bundle list")
@@ -1353,11 +2414,23 @@ mod tests {
         write_profile_manifest(&profile, &manifest).expect("simulate activation write");
 
         assert_eq!(installed_plugins(&home)[0].state, "active");
-        activate_market_plugin(&home, &candidate).expect("recovery activation");
+        reconcile_market_receipts(&home).expect("startup reconciliation");
         assert!(load_pending(&home)
             .expect("pending state")
             .plugins
             .is_empty());
+        assert!(
+            profile_bundles(&read_profile_manifest(&home).expect("reconciled profile").1)
+                .expect("bundle list")
+                .contains(candidate.package_name.as_str())
+        );
+        assert_eq!(
+            load_active(&home)
+                .expect("active state")
+                .plugins
+                .get(&candidate.package_name),
+            Some(&MarketPendingPlugin::from(&candidate))
+        );
 
         let _ = std::fs::remove_dir_all(&home);
     }

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -73,6 +73,7 @@
   } from "./lib/install-arbitration";
   import { trapDialog } from "./lib/dialog-trap";
   import { marketFailureText } from "./lib/market-error";
+  import { reconcilePluginCompletion } from "./lib/plugin-completion";
 
   let status = $state<Status>("idle");
   let url = $state<string | null>(null);
@@ -111,6 +112,13 @@
   let pluginLogsOpen = $state(false);
   let pluginError = $state<string | null>(null);
   let pluginRestartNotice = $state<string | null>(null);
+  let pluginRefreshInFlight = false;
+  let pluginRefreshQueued = false;
+  let pluginDoneExpected = false;
+  let pluginExpectedOp: "add" | "remove" | "market-install" | null = null;
+  let pluginProfileTransitioning = $derived(
+    status === "idle" || status === "starting" || status === "stopping",
+  );
   let pluginInstallRequest = $state<PluginInstallRequest | null>(null);
   let remotePresetRequest = $state<RemotePresetRequest | null>(null);
   let remotePresetPreview = $state<RemotePresetPreview | null>(null);
@@ -326,7 +334,13 @@
   }
 
   async function prepareMarketInstall(slug: string) {
-    if (pluginBusy || marketPreparing || marketOffline || recoveryOverview?.transaction) return;
+    if (
+      pluginBusy ||
+      pluginProfileTransitioning ||
+      marketPreparing ||
+      marketOffline ||
+      recoveryOverview?.transaction
+    ) return;
     marketPreparing = true;
     marketError = null;
     try {
@@ -346,14 +360,18 @@
 
   function confirmMarketInstall() {
     const preview = marketConfirm;
-    if (!preview || pluginBusy) return;
+    if (!preview || pluginBusy || pluginProfileTransitioning) return;
     marketConfirm = null;
     pluginBusy = true;
+    pluginDoneExpected = true;
+    pluginExpectedOp = "market-install";
     pluginError = null;
     pluginLogs = [];
     pluginLogsOpen = true;
     void marketInstallPlugin(preview.slug, preview.entryRevision).catch((e) => {
       pluginBusy = false;
+      pluginDoneExpected = false;
+      pluginExpectedOp = null;
       pluginError = marketFailureText("市场安装失败", e);
       pluginLogsOpen = true;
       void refreshPlugins();
@@ -364,6 +382,7 @@
   async function doActivateMarketPlugin(plugin: PluginEntry) {
     if (
       pluginBusy ||
+      pluginProfileTransitioning ||
       recoveryOverview?.transaction ||
       plugin.state !== "pending" ||
       !plugin.slug ||
@@ -372,16 +391,30 @@
       return;
     }
     pluginBusy = true;
+    // Activation is a synchronous IPC mutation and deliberately emits no
+    // plugin-done event. Keep it out of the asynchronous completion monitor.
+    pluginDoneExpected = false;
+    pluginExpectedOp = null;
     pluginError = null;
     try {
       await activateMarketPlugin(plugin.slug, plugin.entryRevision);
       pluginRestartNotice = `插件 ${plugin.name} 已激活，需要重启 Harness 后才能生效。`;
       showToast("已激活 " + plugin.name + "；请重启 Harness 后加载");
-      await refreshPlugins();
     } catch (e) {
       pluginError = marketFailureText("激活失败", e);
+    } finally {
+      pluginBusy = false;
+      // Refresh after both success and partial-commit errors. The backend can
+      // truthfully expose an active bundle even when final marker cleanup was
+      // interrupted, and the UI must not keep rendering its stale pending row.
+      await refreshPlugins();
+      if (plugins.some((entry) => entry.name === plugin.name && entry.state === "active")) {
+        pluginRestartNotice = `插件 ${plugin.name} 已激活，需要重启 Harness 后才能生效。`;
+        if (pluginError) {
+          pluginError = `插件已进入激活状态，但收尾操作报告错误：${pluginError}`;
+        }
+      }
     }
-    pluginBusy = false;
   }
 
   async function doPickSideload() {
@@ -394,10 +427,17 @@
   }
 
   async function confirmSideloadInstall() {
-    if (!sideloadPath || pluginBusy || recoveryOverview?.transaction) return;
+    if (
+      !sideloadPath ||
+      pluginBusy ||
+      pluginProfileTransitioning ||
+      recoveryOverview?.transaction
+    ) return;
     const path = sideloadPath;
     sideloadPath = null;
     pluginBusy = true;
+    pluginDoneExpected = true;
+    pluginExpectedOp = "add";
     pluginError = null;
     pluginLogs = [];
     pluginLogsOpen = true;
@@ -406,6 +446,8 @@
       await sideloadPlugin(path);
     } catch (e) {
       pluginBusy = false;
+      pluginDoneExpected = false;
+      pluginExpectedOp = null;
       pluginError = `离线安装失败：${e}`;
       pluginLogsOpen = true;
       void refreshPlugins();
@@ -458,6 +500,7 @@
   }
 
   async function doRestart() {
+    if (busy || pluginBusy || recoveryBusy) return;
     busy = true;
     restartInFlight = true;
     try {
@@ -676,15 +719,61 @@
   }
 
   async function refreshPlugins() {
+    if (pluginRefreshInFlight) {
+      pluginRefreshQueued = true;
+      return;
+    }
+    pluginRefreshInFlight = true;
+    const wasBusy = pluginBusy;
+    const expectedDone = pluginDoneExpected;
+    const expectedOp = pluginExpectedOp;
     try {
       const res = await listPlugins();
+      if (
+        pluginBusy !== wasBusy ||
+        pluginDoneExpected !== expectedDone ||
+        pluginExpectedOp !== expectedOp
+      ) {
+        // A user action or live completion event changed local state while
+        // this request was in flight. Its busy snapshot may predate that
+        // transition, so never let it resurrect or erase the newer state or
+        // plugin list.
+        pluginRefreshQueued = true;
+        return;
+      }
       plugins = res.plugins;
       // Backend busy is the truth across webview reloads: an op may still be
       // running after the UI restarted, and the single-flight flag is
-      // app-wide — resync instead of showing a stale idle state.
+      // app-wide. The helper deliberately does not guess whether an unknown
+      // operation emits plugin-done (activation/recovery do not).
+      const completion = reconcilePluginCompletion({
+        frontendBusy: wasBusy,
+        backendBusy: res.busy,
+        doneExpected: expectedDone,
+      });
       pluginBusy = res.busy;
+      pluginDoneExpected = completion.doneExpected;
+      pluginExpectedOp = res.busy ? expectedOp : null;
+      if (completion.missedDone) {
+        // Tauri events are live notifications, not a durable queue. A very
+        // fast setup failure or a webview reload can miss `plugin-done`;
+        // polling backend truth prevents the UI from remaining busy forever.
+        pluginError ??=
+          "插件操作已经结束，但完成事件未送达；请检查安装日志和当前插件列表。";
+        if (expectedOp === "remove") {
+          pluginRestartNotice =
+            "插件移除操作已经结束；请重启 Harness 停止当前进程中的旧插件，并核对列表后按需重试。";
+        }
+        pluginLogsOpen = true;
+      }
     } catch {
       /* non-fatal */
+    } finally {
+      pluginRefreshInFlight = false;
+      if (pluginRefreshQueued) {
+        pluginRefreshQueued = false;
+        void refreshPlugins();
+      }
     }
   }
 
@@ -725,8 +814,15 @@
   }
 
   function startPluginOp(name: string, op: "install" | "uninstall") {
-    if (pluginBusy || recoveryOverview?.transaction || !name.trim()) return;
+    if (
+      pluginBusy ||
+      pluginProfileTransitioning ||
+      recoveryOverview?.transaction ||
+      !name.trim()
+    ) return;
     pluginBusy = true;
+    pluginDoneExpected = true;
+    pluginExpectedOp = op === "install" ? "add" : "remove";
     pluginError = null;
     pluginLogs = [];
     pluginLogsOpen = true;
@@ -734,6 +830,16 @@
     const call = op === "install" ? installPlugin(name.trim()) : uninstallPlugin(name.trim());
     void call.catch((e) => {
       pluginBusy = false;
+      pluginDoneExpected = false;
+      pluginExpectedOp = null;
+      if (op === "uninstall") {
+        // Synchronous setup can fail after exact pre-disable but before the
+        // worker exists, so no plugin-done event will arrive to set the usual
+        // restart notice. Keep this wording truthful for failures that
+        // happened before mutation as well.
+        pluginRestartNotice =
+          "卸载未开始或未完成；如果插件此前正在运行，请重启 Harness 后检查状态并重试。";
+      }
       pluginError = `${op === "install" ? "安装" : "卸载"}失败：${e}`;
       pluginLogsOpen = true;
       // Resync busy: "an operation is already running" means another
@@ -879,7 +985,16 @@
     let cancelled = false;
     let unlistenFn: (() => void) | null = null;
     void onPluginDone((p) => {
+      if (pluginDoneExpected && pluginExpectedOp && p.op !== pluginExpectedOp) {
+        // Completion is queued before the backend releases its operation
+        // transition gate. Keep this defensive check so an unexpected stale
+        // event can never clear a different operation's busy state.
+        void refreshPlugins();
+        return;
+      }
       pluginBusy = false;
+      pluginDoneExpected = false;
+      pluginExpectedOp = null;
       const tailLines = p.tail
         .split(/\r?\n/)
         .map((line) => line.trim())
@@ -889,7 +1004,17 @@
       if (pluginLogs.length === 0 && tailLines.length > 0) {
         pluginLogs = tailLines.slice(-300);
       }
+      if (p.op === "remove" && p.exit !== 0) {
+        // Every spawned remove has already completed exact pre-disable. Even
+        // when pnpm fails or cancellation wins, the currently running Harness
+        // may still hold the old plugin and must be restarted to unload it.
+        pluginRestartNotice =
+          "插件移除未完成，但目标已安全禁用；请重启 Harness 停止当前进程中的插件后再重试卸载。";
+      }
       if (p.exit === 0) {
+        // A delayed live event can arrive just after polling synthesized a
+        // missed-completion warning. The durable success supersedes it.
+        pluginError = null;
         pluginName = "";
         if (p.op === "market-install") {
           showToast("插件已校验完成，正在等待你的显式激活");
@@ -921,6 +1046,15 @@
       cancelled = true;
       unlistenFn?.();
     };
+  });
+
+  // Event delivery can race an immediate backend failure or a webview
+  // reload. While an operation is active, cheaply poll the local IPC state so
+  // a missed `plugin-done` cannot leave every plugin control disabled.
+  $effect(() => {
+    if (!inTauri || !pluginBusy) return;
+    const timer = setInterval(() => void refreshPlugins(), 1000);
+    return () => clearInterval(timer);
   });
 
   // Deep-link requests: warm links arrive as events; the pending Rust slot
@@ -1098,10 +1232,10 @@
     <div class="actions">
       {#if status === "running"}
         <button class="primary" onclick={doOpen}>打开 Harness 窗口</button>
-        <button class="ghost" onclick={doRestart} disabled={busy}>重新启动</button>
+        <button class="ghost" onclick={doRestart} disabled={busy || pluginBusy || recoveryBusy}>重新启动</button>
         <button class="danger-ghost" onclick={doShutdown} disabled={busy}>停止</button>
       {:else if status === "crashed" || status === "stopped"}
-        <button class="primary" onclick={doRestart} disabled={busy}>
+        <button class="primary" onclick={doRestart} disabled={busy || pluginBusy || recoveryBusy}>
           {status === "stopped" ? "重新启动" : "重新启动 Harness"}
         </button>
         {#if status === "crashed"}
@@ -1291,7 +1425,7 @@
     <div class="update-row">
       <span class="update-title">插件市场</span>
       {#if !storeBuild}
-        <button class="ghost" onclick={doPickSideload} disabled={recoveryOverview?.transaction != null}>离线安装 .tgz</button>
+        <button class="ghost" onclick={doPickSideload} disabled={pluginProfileTransitioning || recoveryOverview?.transaction != null}>离线安装 .tgz</button>
       {/if}
     </div>
     <div class="plugin-row">
@@ -1341,7 +1475,7 @@
             <button
               class="primary"
               onclick={() => doMarketInstall(item)}
-              disabled={pluginBusy || marketPreparing || marketOffline || recoveryOverview?.transaction != null}
+              disabled={pluginBusy || pluginProfileTransitioning || marketPreparing || marketOffline || recoveryOverview?.transaction != null}
             >{marketPreparing ? "校验中…" : "安装"}</button>
           {:else}
             <button class="ghost" disabled title={item.installReason ?? "该条目不可安装"}>
@@ -1376,7 +1510,12 @@
     {#if storeBuild}
       <div class="plugin-row">
         <span class="update-info">仅允许安装 cordis.run 已审核插件</span>
-        <button class="ghost" onclick={() => openSite("https://cordis.run")}>打开插件市场</button>
+        {#if pluginBusy}
+          <span class="plugin-busy"><span class="spinner"></span> 操作中…</span>
+          <button class="danger-ghost" onclick={doCancelPluginOp}>取消</button>
+        {:else}
+          <button class="ghost" onclick={() => openSite("https://cordis.run")}>打开插件市场</button>
+        {/if}
       </div>
       <div class="trust-note">
         插件与 Agent 同权限运行工具和命令；Store 版仅安装已审核插件。
@@ -1388,7 +1527,7 @@
           type="text"
           placeholder="npm 包名，如 @cordisjs/plugin-example"
           bind:value={pluginName}
-          disabled={pluginBusy || recoveryOverview?.transaction != null}
+          disabled={pluginBusy || pluginProfileTransitioning || recoveryOverview?.transaction != null}
           spellcheck="false"
           onkeydown={(e) => {
             if (e.key === "Enter") startPluginOp(pluginName, "install");
@@ -1398,7 +1537,7 @@
           <span class="plugin-busy"><span class="spinner"></span> 操作中…</span>
           <button class="danger-ghost" onclick={doCancelPluginOp}>取消</button>
         {:else}
-          <button class="primary" onclick={() => startPluginOp(pluginName, "install")} disabled={!pluginName.trim() || recoveryOverview?.transaction != null}>
+          <button class="primary" onclick={() => startPluginOp(pluginName, "install")} disabled={pluginProfileTransitioning || !pluginName.trim() || recoveryOverview?.transaction != null}>
             安装
           </button>
         {/if}
@@ -1415,7 +1554,7 @@
     {#if pluginRestartNotice}
       <div class="notice-box">
         {pluginRestartNotice}
-        <button class="primary" onclick={doRestart} disabled={busy || status !== "running"}>
+        <button class="primary" onclick={doRestart} disabled={busy || pluginBusy || recoveryBusy || status !== "running"}>
           立即重启 Harness
         </button>
       </div>
@@ -1428,11 +1567,11 @@
             <span class="badge">{pluginStateText(p.state)}</span>
           </span>
           {#if p.state === "pending" && p.slug && p.entryRevision}
-            <button class="primary" onclick={() => doActivateMarketPlugin(p)} disabled={pluginBusy || recoveryOverview?.transaction != null}>
+            <button class="primary" onclick={() => doActivateMarketPlugin(p)} disabled={pluginBusy || pluginProfileTransitioning || recoveryOverview?.transaction != null}>
               Activate
             </button>
           {/if}
-          <button class="ghost" onclick={() => startPluginOp(p.name, "uninstall")} disabled={pluginBusy || recoveryOverview?.transaction != null}>卸载</button>
+          <button class="ghost" onclick={() => startPluginOp(p.name, "uninstall")} disabled={pluginBusy || pluginProfileTransitioning || recoveryOverview?.transaction != null}>卸载</button>
         </div>
       {/each}
     {:else}
@@ -1630,7 +1769,7 @@
         将校验此修订的 tarball 与 lockfile integrity，禁用构建脚本，并保持为待激活状态。安装完成后不会自动启用，需你再次点击 Activate。
       </div>
       <div class="modal-actions">
-        <button class="primary" onclick={confirmMarketInstall} disabled={pluginBusy}>确认安装</button>
+        <button class="primary" onclick={confirmMarketInstall} disabled={pluginBusy || pluginProfileTransitioning}>确认安装</button>
         <button class="ghost" onclick={() => (marketConfirm = null)}>取消</button>
       </div>
     </div>
@@ -1654,7 +1793,7 @@
       <div class="modal-name">{sideloadPath}</div>
       <div class="modal-warn">插件与 Agent 同权限运行工具和命令，仅安装可信插件。确认后将通过 `dsh plugin add` 安装该 .tgz。</div>
       <div class="modal-actions">
-        <button class="primary" onclick={confirmSideloadInstall} disabled={pluginBusy}>确认安装</button>
+        <button class="primary" onclick={confirmSideloadInstall} disabled={pluginBusy || pluginProfileTransitioning}>确认安装</button>
         <button class="ghost" onclick={() => (sideloadPath = null)}>取消</button>
       </div>
     </div>

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -759,10 +759,15 @@
         // fast setup failure or a webview reload can miss `plugin-done`;
         // polling backend truth prevents the UI from remaining busy forever.
         pluginError ??=
-          "插件操作已经结束，但完成事件未送达；请检查安装日志和当前插件列表。";
+          expectedOp === "market-install"
+            ? "市场插件操作已经结束，但完成事件未送达；请刷新当前插件列表。仅在显式 Activate 后重启 Harness 才会加载该插件。"
+            : "插件操作已经结束，但完成事件未送达；请检查安装日志和当前插件列表。";
         if (expectedOp === "remove") {
           pluginRestartNotice =
             "插件移除操作已经结束；请重启 Harness 停止当前进程中的旧插件，并核对列表后按需重试。";
+        } else if (expectedOp === "add") {
+          pluginRestartNotice =
+            "插件安装操作已经结束；请重启 Harness 后核对当前插件列表并验证是否生效。";
         }
         pluginLogsOpen = true;
       }

--- a/src/lib/plugin-completion.ts
+++ b/src/lib/plugin-completion.ts
@@ -1,0 +1,29 @@
+export interface PluginCompletionSnapshot {
+  frontendBusy: boolean;
+  backendBusy: boolean;
+  doneExpected: boolean;
+}
+
+export interface PluginCompletionDecision {
+  doneExpected: boolean;
+  missedDone: boolean;
+}
+
+/**
+ * Reconcile the live Tauri event stream with the durable backend busy flag.
+ * Synchronous mutations (activation) deliberately expect no plugin-done;
+ * spawned pnpm/dsh operations do. A freshly mounted webview cannot infer the
+ * operation kind from the shared backend busy flag (activation and recovery
+ * use the same single-flight gate), so it adopts busy state without inventing
+ * an expected event. Polling still clears that state when the backend ends.
+ */
+export function reconcilePluginCompletion({
+  frontendBusy,
+  backendBusy,
+  doneExpected,
+}: PluginCompletionSnapshot): PluginCompletionDecision {
+  return {
+    missedDone: frontendBusy && !backendBusy && doneExpected,
+    doneExpected: backendBusy ? doneExpected : false,
+  };
+}

--- a/tests/frontend/plugin-completion.test.ts
+++ b/tests/frontend/plugin-completion.test.ts
@@ -45,3 +45,14 @@ test("an operation that remains busy preserves its completion contract", () => {
     { doneExpected: false, missedDone: false },
   );
 });
+
+test("an in-flight asynchronous operation keeps expecting its completion event", () => {
+  assert.deepEqual(
+    reconcilePluginCompletion({
+      frontendBusy: true,
+      backendBusy: true,
+      doneExpected: true,
+    }),
+    { doneExpected: true, missedDone: false },
+  );
+});

--- a/tests/frontend/plugin-completion.test.ts
+++ b/tests/frontend/plugin-completion.test.ts
@@ -1,0 +1,47 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { reconcilePluginCompletion } from "../../src/lib/plugin-completion.ts";
+
+test("an asynchronous operation reports a missed completion event", () => {
+  assert.deepEqual(
+    reconcilePluginCompletion({
+      frontendBusy: true,
+      backendBusy: false,
+      doneExpected: true,
+    }),
+    { doneExpected: false, missedDone: true },
+  );
+});
+
+test("a synchronous activation does not synthesize a missing event error", () => {
+  assert.deepEqual(
+    reconcilePluginCompletion({
+      frontendBusy: true,
+      backendBusy: false,
+      doneExpected: false,
+    }),
+    { doneExpected: false, missedDone: false },
+  );
+});
+
+test("a reloaded webview adopts busy state without guessing its operation kind", () => {
+  assert.deepEqual(
+    reconcilePluginCompletion({
+      frontendBusy: false,
+      backendBusy: true,
+      doneExpected: false,
+    }),
+    { doneExpected: false, missedDone: false },
+  );
+});
+
+test("an operation that remains busy preserves its completion contract", () => {
+  assert.deepEqual(
+    reconcilePluginCompletion({
+      frontendBusy: true,
+      backendBusy: true,
+      doneExpected: false,
+    }),
+    { doneExpected: false, missedDone: false },
+  );
+});


### PR DESCRIPTION
## Why

The reported `cannot build PATH: path segment contains separator` error exposed a wider set of lifecycle assumptions around plugin install, pending activation, removal, recovery, cancellation, and Harness restart. This PR now fixes the subsystem as one safety boundary instead of treating PATH in isolation.

## Fixes

- prepend the Desktop pnpm shim without parsing or rewriting the inherited serialized PATH
- sanitize inherited npm/pnpm/Node TLS control variables; pin Windows `ComSpec` to the OS system directory for the upstream `shell: true` call
- keep Store installs behind both the live cordis.run candidate gate and the local reviewed snapshot, including recovery re-enable
- install market artifacts through bundled pnpm with scripts and pnpmfile hooks disabled, then verify exact tarball, version, integrity, package layout, and bundle patch before recording `pending`
- reconcile pending and active receipts at every Harness start/restart boundary; generic adds cannot globally reconcile while a market package awaits explicit Activate
- pre-disable only the requested installed dependency and remove it through direct scripts-disabled pnpm, avoiding upstream global reconciliation that could activate another package
- preserve reviewed market provenance across crash-safe activation and recovery rollback
- serialize user, tray, and crash auto-restarts against every profile mutation; automatic restart waits for an active plugin operation instead of reading a changing profile
- harden cancellation races, process-handle ownership, bounded log backpressure, pnpm store compatibility, symlink/reparse checks, bounded manifests, and sideload cleanup
- make frontend completion handling reload-safe, reject stale operation types, expose Store cancellation, and always surface restart guidance after install/activation/removal

## Verification

- `cargo nextest run --locked --workspace` — 219/219
- sidecar coverage 81.03% (50% floor)
- Desktop coverage 64.85% (55% floor); `plugins.rs` 89.76%
- workspace clippy `-D warnings`, formatting, and `STORE_BUILD=1` clippy
- Windows x64 plus macOS x64/arm64 sidecar cross-target clippy
- `cargo deny` for both manifests and `cargo vet --locked`
- frontend production build/type checks; 83 script tests and 9 frontend tests
- command/ACL/capability contract aligned; Harness capability remains empty
- real online plugin e2e: generic add, exact pkgseek market tarball/integrity, pending isolation, unrelated-remove non-activation, exact uninstall
- real sideload e2e: retained `file:` dependency and lifecycle-script-free removal
- runtime readiness/restart/shutdown/orphan smoke, heartbeat smoke, preset discovery, release preflight, dependency audits, and signing/bundle self-tests

No version bump or new dependency is included; the existing `windows-sys` dependency only enables the system-directory API feature.