### PR TITLE
chore: prepare v0.2.12 release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -724,7 +724,7 @@ dependencies = [
 
 [[package]]
 name = "deepseek-harness-desktop"
-version = "0.2.11"
+version = "0.2.12"
 dependencies = [
  "dsh-sidecar",
  "futures-util",
@@ -933,7 +933,7 @@ dependencies = [
 
 [[package]]
 name = "dsh-sidecar"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "libc",
  "proptest",

--- a/README.en.md
+++ b/README.en.md
@@ -9,7 +9,7 @@ intact; the desktop layer only handles lifecycle and the security boundary.
 | Website | [dsharness.app](https://dsharness.app) |
 | Plugin marketplace | [cordis.run](https://cordis.run) |
 | Docs | [SECURITY](SECURITY.md) · [FORKING](FORKING.md) · [RELEASING](RELEASING.md) · [AGENTS](AGENTS.md) |
-| Version | v0.2.11 · Windows x64 EXE/MSI · macOS x64/arm64 DMG · Linux x64/arm64 AppImage/DEB/RPM/Flatpak · signed/notarized macOS · [中文](README.md) |
+| Version | v0.2.12 · Windows x64 EXE/MSI · macOS x64/arm64 DMG · Linux x64/arm64 AppImage/DEB/RPM/Flatpak · signed/notarized macOS · [中文](README.md) |
 
 > **macOS users**: starting with v0.2.9, DMGs are signed with Developer ID
 > Application, notarized by Apple, stapled, and rechecked with Gatekeeper.
@@ -156,7 +156,7 @@ deny.toml + supply-chain/   policy & audits   .github/workflows/   CI
   Partner Center upload, not GitHub Release assets.
 - Harness upgrades follow the startup-contract checklist in
   [AGENTS.md](AGENTS.md); the release flow lives in [RELEASING.md](RELEASING.md).
-- Status: v0.2.11 release candidate, including multi-format installers, macOS
+- Status: v0.2.12 release candidate, including multi-format installers, macOS
   Developer ID signing/notarization, the Cordis v4 marketplace contract,
   diagnostic resilience, and safe plugin recovery.
 - Known limits: Windows GitHub installers do not yet have Authenticode and may

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 | 官网 | [dsharness.app](https://dsharness.app) |
 | 插件市场 | [cordis.run](https://cordis.run) |
 | 文档 | [SECURITY](SECURITY.md) · [FORKING](FORKING.md) · [RELEASING](RELEASING.md) · [AGENTS](AGENTS.md) |
-| 版本 | v0.2.11 · Windows x64 EXE/MSI · macOS x64/arm64 DMG · Linux x64/arm64 AppImage/DEB/RPM/Flatpak · macOS 已签名/公证 · [English](README.en.md) |
+| 版本 | v0.2.12 · Windows x64 EXE/MSI · macOS x64/arm64 DMG · Linux x64/arm64 AppImage/DEB/RPM/Flatpak · macOS 已签名/公证 · [English](README.en.md) |
 
 > **macOS 用户**：v0.2.9 起，DMG 使用 Developer ID Application 签名并经
 > Apple 公证、staple 与 Gatekeeper 复验。请只从本仓库 Releases 下载；若官方
@@ -152,6 +152,6 @@ deny.toml + supply-chain/   供应链策略与审计     .github/workflows/   CI
 - CI：push/PR 跑质量门 + 三平台冒烟；打 `v*` tag 触发五个原生构建目标（Windows x64、macOS x64/arm64、Linux x64/arm64）及 Store MSIX x64/arm64，再经完整资产清单门禁发布 draft release + `latest.json`。
 - Microsoft Store：`v*` tag 同时构建 x64/arm64 MSIX（`build-msix` job，Store 模式关闭应用内更新并限制插件为 cordis.run 审核列表）。MSIX 产物作为 workflow artifact 下载后上传 Partner Center，不发布到 GitHub Release。
 - Harness 升级走 [AGENTS.md](AGENTS.md)「启动契约」清单；发布流程见 [RELEASING.md](RELEASING.md)。
-- 当前状态：v0.2.11 发布候选；包含多格式安装包、macOS Developer ID 签名/公证、Cordis v4 市场契约、诊断韧性与安全插件恢复。
+- 当前状态：v0.2.12 发布候选；包含多格式安装包、macOS Developer ID 签名/公证、Cordis v4 市场契约、诊断韧性与安全插件恢复。
 - 已知边界：Windows GitHub 安装包尚未配置 Authenticode，可能触发 SmartScreen；macOS 更新清单尚未接入；Linux 包当前以 SHA-256 保护，尚无独立软件仓库签名。
 - 许可：MIT；内置 Harness 及全部依赖的 LICENSE 随包附于 `runtime/harness/licenses/`。

--- a/crates/dsh-sidecar/Cargo.toml
+++ b/crates/dsh-sidecar/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dsh-sidecar"
-version = "0.2.4"
+version = "0.2.5"
 description = "Minimal process supervisor for the DSH Desktop runtime"
 edition = "2021"
 license = "MIT"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "deepseek-harness-desktop",
   "private": true,
-  "version": "0.2.11",
+  "version": "0.2.12",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/runtime/runtime-manifest.json
+++ b/runtime/runtime-manifest.json
@@ -1,8 +1,8 @@
 {
-  "desktopVersion": "0.2.11",
+  "desktopVersion": "0.2.12",
   "harnessVersion": "0.1.1-rc.1",
   "nodeVersion": "24.19.0",
-  "sidecarVersion": "0.2.4",
+  "sidecarVersion": "0.2.5",
   "nodeSha256": {
     "win32-x64": "57f71ab3652e797d84acddc79c81cc9ff1c6ddb2a1974cdb83f00fee9bff4c73",
     "darwin-arm64": "8294b7aa9b03997481c06babf1e8b270c859358f27da57a11509afe537ac381d",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deepseek-harness-desktop"
-version = "0.2.11"
+version = "0.2.12"
 description = "DSH Desktop — community desktop packaging of DeepSeek Harness"
 edition = "2021"
 license = "MIT"
@@ -27,7 +27,7 @@ getrandom = "0.2"
 # SAME process-tree guarantees (unix process group / Windows Job Object).
 # The version must stay in lockstep with crates/dsh-sidecar/Cargo.toml —
 # cargo-deny treats a version-less path dep as a wildcard, so it is pinned.
-dsh-sidecar = { path = "../crates/dsh-sidecar", version = "0.2.4" }
+dsh-sidecar = { path = "../crates/dsh-sidecar", version = "0.2.5" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 semver = "1"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "DSH Desktop",
-  "version": "0.2.11",
+  "version": "0.2.12",
   "identifier": "com.yeagoo.dsh-desktop",
   "build": {
     "beforeDevCommand": "pnpm dev",


### PR DESCRIPTION
## Summary
- bump Desktop metadata to 0.2.12
- bump the changed dsh-sidecar crate and pinned manifest dependency to 0.2.5
- synchronize English and Chinese release status

## Validation
- `pnpm release:preflight -- --expect-tag v0.2.12`
- `pnpm check && pnpm check:scripts`
- `pnpm test:scripts && pnpm test:frontend`
- `cargo fmt --check` (both crates)
- `cargo clippy --locked --all-targets -- -D warnings` (both crates)
- `cargo nextest run --locked` (40 sidecar + 182 Desktop tests)