### PR TITLE
fix: normalize Windows verbatim Node launch paths

### DIFF
--- a/crates/dsh-sidecar/src/lib.rs
+++ b/crates/dsh-sidecar/src/lib.rs
@@ -126,6 +126,47 @@ pub fn quote_arg(arg: &str) -> String {
     out
 }
 
+/// Convert the two Win32 verbatim path forms that Node cannot use as a main
+/// entrypoint back to their ordinary DOS/UNC spelling.
+///
+/// Rust and Win32 APIs correctly accept `\\?\C:\…`, and Tauri can return it
+/// for a packaged resource directory. Node's `resolveMainPath`, however,
+/// currently reduces that form to `C:` and fails with `EISDIR`. Only canonical
+/// drive-absolute and UNC forms are converted; device/volume namespaces and
+/// malformed inputs keep their original spelling rather than broadening the
+/// path semantics of an untrusted start command.
+#[cfg_attr(not(windows), allow(dead_code))]
+pub(crate) fn node_compatible_windows_path(path: &str) -> String {
+    const VERBATIM_PREFIX: &str = "\\\\?\\";
+    const VERBATIM_UNC_PREFIX: &str = "\\\\?\\UNC\\";
+
+    let strip_ascii_prefix = |prefix: &str| {
+        path.get(..prefix.len())
+            .filter(|candidate| candidate.eq_ignore_ascii_case(prefix))
+            .map(|_| &path[prefix.len()..])
+    };
+
+    if let Some(rest) = strip_ascii_prefix(VERBATIM_UNC_PREFIX) {
+        let mut parts = rest.split(['\\', '/']).filter(|part| !part.is_empty());
+        if parts.next().is_some() && parts.next().is_some() {
+            return format!("\\\\{rest}");
+        }
+    }
+
+    if let Some(rest) = strip_ascii_prefix(VERBATIM_PREFIX) {
+        let bytes = rest.as_bytes();
+        if bytes.len() >= 3
+            && bytes[0].is_ascii_alphabetic()
+            && bytes[1] == b':'
+            && matches!(bytes[2], b'\\' | b'/')
+        {
+            return rest.to_string();
+        }
+    }
+
+    path.to_string()
+}
+
 // ---------------------------------------------------------------------------
 // Child environment hygiene: the sidecar inherits the parent's (Tauri shell's)
 // environment and forwards it to the bundled Node. A user launching the app
@@ -264,5 +305,35 @@ mod bounded_line_tests {
         })
         .unwrap();
         assert_eq!(lines, ["one"]);
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+mod windows_node_path_tests {
+    use super::node_compatible_windows_path;
+
+    #[test]
+    fn converts_only_supported_verbatim_dos_and_unc_paths() {
+        assert_eq!(
+            node_compatible_windows_path(r"\\?\C:\Program Files\DSH Desktop\runtime\node.exe"),
+            r"C:\Program Files\DSH Desktop\runtime\node.exe"
+        );
+        assert_eq!(
+            node_compatible_windows_path(r"\\?\unc\server\share\DSH Desktop\bin.js"),
+            r"\\server\share\DSH Desktop\bin.js"
+        );
+    }
+
+    #[test]
+    fn leaves_noncanonical_verbatim_namespaces_unchanged() {
+        for path in [
+            r"C:\normal\runtime\node.exe",
+            r"\\?\Volume{01234567-89ab-cdef-0123-456789abcdef}\runtime\node.exe",
+            r"\\?\UNC\server",
+            r"\\?\C:",
+        ] {
+            assert_eq!(node_compatible_windows_path(path), path);
+        }
     }
 }

--- a/crates/dsh-sidecar/src/platform.rs
+++ b/crates/dsh-sidecar/src/platform.rs
@@ -516,10 +516,32 @@ mod imp {
             spec: &SpawnSpec,
             _inherited: &[(std::ffi::OsString, std::ffi::OsString)],
         ) -> io::Result<Self> {
+            // Tauri may return its packaged resource directory as a Win32
+            // verbatim (`\\?\`) path. Win32 itself accepts that spelling, but
+            // Node 24's main-entry resolver does not: it attempts to lstat the
+            // bare drive name (`C:`) and exits before Harness can start. Keep
+            // the conversion at the Node launch boundary so Rust filesystem
+            // operations retain their original long-path-safe representation.
+            let node = crate::node_compatible_windows_path(&spec.node);
+            let script = crate::node_compatible_windows_path(&spec.script);
+            let cwd = crate::node_compatible_windows_path(&spec.cwd);
+            let env = spec
+                .env
+                .iter()
+                .map(|(key, value)| {
+                    let value = if key.eq_ignore_ascii_case("DSH_HOME") {
+                        crate::node_compatible_windows_path(value)
+                    } else {
+                        value.clone()
+                    };
+                    (key.clone(), value)
+                })
+                .collect::<Vec<_>>();
+
             // Command line: node <script> <args…>, quoted per Windows rules.
-            let mut cmdline = quote_arg(&spec.node);
+            let mut cmdline = quote_arg(&node);
             cmdline.push(' ');
-            cmdline.push_str(&quote_arg(&spec.script));
+            cmdline.push_str(&quote_arg(&script));
             for arg in &spec.args {
                 cmdline.push(' ');
                 cmdline.push_str(&quote_arg(arg));
@@ -527,8 +549,8 @@ mod imp {
             let mut cmdline_w: Vec<u16> = cmdline.encode_utf16().collect();
             cmdline_w.push(0);
 
-            let cwd_w: Vec<u16> = spec.cwd.encode_utf16().chain(std::iter::once(0)).collect();
-            let env_block = build_env_block(&spec.env)?;
+            let cwd_w: Vec<u16> = cwd.encode_utf16().chain(std::iter::once(0)).collect();
+            let env_block = build_env_block(&env)?;
             let mut env_block = env_block;
 
             // stdin: pipe whose write end we close immediately (child sees EOF),

--- a/scripts/verify-runtime.ts
+++ b/scripts/verify-runtime.ts
@@ -59,6 +59,19 @@ requireFile(nodePath, "bundled node");
 const dshBin = join(harnessDir, "node_modules", "@deepseek-ai", "dsh", "lib", "bin.js");
 requireFile(dshBin, "dsh entry (lib/bin.js)");
 
+// Tauri can return resource paths in Win32's `\\?\` (verbatim) form. Node
+// currently cannot resolve a main entrypoint in that form: it reduces it to
+// the bare drive (`C:`) and exits with EISDIR. Deliberately pass this form to
+// the real sidecar on Windows so the smoke test proves its launch boundary
+// converts only the Node-facing paths back to ordinary DOS/UNC notation.
+function nodeLaunchPath(path: string): string {
+  if (process.platform !== "win32") return path;
+  if (path.startsWith("\\\\?\\")) return path;
+  if (path.startsWith("\\\\")) return `\\\\?\\UNC\\${path.slice(2)}`;
+  if (/^[A-Za-z]:[\\/]/.test(path)) return `\\\\?\\${path}`;
+  runtimeFail(`Windows runtime path is not absolute: ${path}`);
+}
+
 // Fresh, isolated DSH_HOME for the smoke run.
 const dshHome = join(tmpDir, `smoke-dsh-home-${Date.now()}`);
 mkdirSync(dshHome, { recursive: true });
@@ -168,13 +181,13 @@ async function main(): Promise<void> {
   // --- boot -------------------------------------------------------------
   send({
     command: "start",
-    node: nodePath,
-    script: dshBin,
+    node: nodeLaunchPath(nodePath),
+    script: nodeLaunchPath(dshBin),
     args: ["web", "--no-open", "--host", "127.0.0.1", "--port", "0"],
-    cwd: harnessDir,
+    cwd: nodeLaunchPath(harnessDir),
     // Keep this env in lockstep with src-tauri/src/harness/mod.rs
     // (start_harness): the smoke must exercise the production contract.
-    env: { DSH_HOME: dshHome, DSH_TELEMETRY_DISABLED: "1" },
+    env: { DSH_HOME: nodeLaunchPath(dshHome), DSH_TELEMETRY_DISABLED: "1" },
   });
   info("waiting for readiness line…");
   const ready = await waitFor((e) => e.type === "ready", "ready", 180_000);


### PR DESCRIPTION
## Root cause
Node 24 fails in `resolveMainPath` when a Windows resource path is supplied in the `\\?\` verbatim form, reducing it to `C:` and exiting with `EISDIR`. Windows on Arm x64 emulation is supported; the path representation is the failure mechanism.

## Change
- normalize only canonical verbatim DOS and UNC paths at the Windows Node launch boundary
- preserve unsupported device/volume namespaces unchanged
- normalize the Node entrypoint, script, cwd, and `DSH_HOME` without changing Rust filesystem paths
- make the real Windows runtime smoke deliberately send verbatim paths to the sidecar

## Validation
- `cargo nextest run --locked --manifest-path crates/dsh-sidecar/Cargo.toml` (42 tests)
- `cargo clippy --locked --all-targets -- -D warnings` (Linux, Windows x64, Windows arm64 sidecar targets)
- `pnpm check && pnpm check:scripts`
- `pnpm test:scripts && pnpm test:frontend`
- `pnpm runtime:all && pnpm runtime:verify`
- `cargo deny` and `cargo vet --locked`