### PR TITLE
chore: release audited dependency upgrades for v0.2.13

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -137,7 +137,12 @@ jobs:
       - name: Rust fallback gate
         if: steps.dependency-changes.outputs.rust == 'true'
         run: |
-          cargo metadata --locked --format-version 1 --no-deps > /dev/null
+          # --no-deps validates only the root manifests; it does not prove
+          # that their requirements are satisfiable by the committed lock.
+          # Resolve the complete, all-feature graph before any audit so an
+          # uncommitted Cargo.lock rewrite cannot be hidden by later commands.
+          cargo metadata --locked --all-features --format-version 1 > /dev/null
+          git diff --exit-code -- Cargo.lock
           cargo deny --manifest-path crates/dsh-sidecar/Cargo.toml check
           cargo deny --manifest-path src-tauri/Cargo.toml check
           cargo vet --locked

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -35,6 +35,14 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c  # stable (version via rust-toolchain.toml)
 
+      - name: Verify committed Cargo.lock
+        run: |
+          # --no-deps only parses manifests. Resolve the full all-feature
+          # graph so an omitted lockfile update fails before test/build tools
+          # can refresh Cargo.lock in the ephemeral CI checkout.
+          cargo metadata --locked --all-features --format-version 1 > /dev/null
+          git diff --exit-code -- Cargo.lock
+
       - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86  # v6.0.10 (SHA-pinned)
       # Version source of truth: packageManager in package.json (action-setup
       # v6 reads it when `version` is omitted; mismatches fail loudly).
@@ -188,6 +196,12 @@ jobs:
           ref: ${{ inputs.checkout_ref || github.ref }}
 
       - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c  # stable (version via rust-toolchain.toml)
+
+      - name: Verify committed Cargo.lock
+        shell: pwsh
+        run: |
+          cargo metadata --locked --all-features --format-version 1 | Out-Null
+          git diff --exit-code -- Cargo.lock
 
       - name: Prepare stub runtime dir (tauri-build asserts the path exists)
         shell: pwsh

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,7 +68,7 @@ DSH CLI 的启动契约随版本演进，社区同类项目已实证踩坑（如
   `scripts/verify-plugins.ts` 断言与 `verify-bundle.ts` 必含文件；
 - 上游若新增 `.dshpreset` 归档导入/导出入口（或变更 `.agent-presets`
   根语义），必须复核壳层预设边界（`src-tauri/src/preset.rs`）——当前
-  rc.8 无归档入口，壳层导入/导出是预设根的唯一写入路径，壳层健康复核
+  0.1.1-rc.1 无归档入口，壳层导入/导出是预设根的唯一写入路径，壳层健康复核
   （validate_user_presets）覆盖该根的全部来源。
   已知语义差异（有意为之，随上游演进复核）：壳层 Broken 只探测
   agent.cordis.yml 缺失/不可读/为空（不重实现 YAML 解析，可读但畸形仍由

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -463,23 +463,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
-name = "cfg_aliases"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
-
-[[package]]
-name = "chacha20"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
-dependencies = [
- "cfg-if",
- "cpufeatures 0.3.0",
- "rand_core 0.10.1",
-]
-
-[[package]]
 name = "chrono"
 version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -585,15 +568,6 @@ name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "cpufeatures"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
@@ -724,15 +698,17 @@ dependencies = [
 
 [[package]]
 name = "deepseek-harness-desktop"
-version = "0.2.12"
+version = "0.2.13"
 dependencies = [
  "dsh-sidecar",
+ "flate2",
  "futures-util",
- "getrandom 0.2.17",
+ "getrandom 0.4.3",
  "libc",
  "objc2-foundation",
  "proptest",
- "reqwest 0.12.28",
+ "reqwest",
+ "rustls",
  "semver",
  "serde",
  "serde_json",
@@ -746,7 +722,7 @@ dependencies = [
  "tauri-plugin-window-state",
  "url",
  "windows-sys 0.61.2",
- "zip 2.4.2",
+ "zip 8.6.0",
 ]
 
 [[package]]
@@ -1376,10 +1352,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
- "js-sys",
  "libc",
  "wasi",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -1401,11 +1375,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
- "js-sys",
  "libc",
  "r-efi 6.0.0",
- "rand_core 0.10.1",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -1680,7 +1651,6 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
- "webpki-roots",
 ]
 
 [[package]]
@@ -2191,12 +2161,6 @@ name = "log"
 version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
-
-[[package]]
-name = "lru-slab"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "markup5ever"
@@ -2922,7 +2886,7 @@ dependencies = [
  "bit-vec",
  "bitflags 2.13.1",
  "num-traits",
- "rand 0.9.5",
+ "rand",
  "rand_chacha",
  "rand_xorshift",
  "regex-syntax",
@@ -2944,62 +2908,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1"
 dependencies = [
  "memchr",
-]
-
-[[package]]
-name = "quinn"
-version = "0.11.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c1a41e437b6bbd489372cd4971de128e85c855f56c57f283d20ff016cf7c0a8"
-dependencies = [
- "bytes",
- "cfg_aliases",
- "pin-project-lite",
- "quinn-proto",
- "quinn-udp",
- "rustc-hash",
- "rustls",
- "socket2",
- "thiserror 2.0.20",
- "tokio",
- "tracing",
- "web-time",
-]
-
-[[package]]
-name = "quinn-proto"
-version = "0.11.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f4bfc015262b9df63c8845072ce59068853ff5872180c2ce2f13038b970e560"
-dependencies = [
- "bytes",
- "getrandom 0.4.3",
- "lru-slab",
- "rand 0.10.2",
- "rand_pcg",
- "ring",
- "rustc-hash",
- "rustls",
- "rustls-pki-types",
- "slab",
- "thiserror 2.0.20",
- "tinyvec",
- "tracing",
- "web-time",
-]
-
-[[package]]
-name = "quinn-udp"
-version = "0.5.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35a133f956daabe89a61a685c2649f13d82d5aa4bd5d12d1277e1072a21c0694"
-dependencies = [
- "cfg_aliases",
- "libc",
- "once_cell",
- "socket2",
- "tracing",
- "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3030,18 +2938,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9ef1d0d795eb7d84685bca4f72f3649f064e6641543d3a8c415898726a57b41"
 dependencies = [
  "rand_chacha",
- "rand_core 0.9.5",
-]
-
-[[package]]
-name = "rand"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
-dependencies = [
- "chacha20",
- "getrandom 0.4.3",
- "rand_core 0.10.1",
+ "rand_core",
 ]
 
 [[package]]
@@ -3051,7 +2948,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.9.5",
+ "rand_core",
 ]
 
 [[package]]
@@ -3064,27 +2961,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "rand_core"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
-
-[[package]]
-name = "rand_pcg"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
-dependencies = [
- "rand_core 0.10.1",
-]
-
-[[package]]
 name = "rand_xorshift"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
 dependencies = [
- "rand_core 0.9.5",
+ "rand_core",
 ]
 
 [[package]]
@@ -3164,47 +3046,6 @@ checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "reqwest"
-version = "0.12.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
-dependencies = [
- "base64 0.22.1",
- "bytes",
- "futures-core",
- "futures-util",
- "http",
- "http-body",
- "http-body-util",
- "hyper",
- "hyper-rustls",
- "hyper-util",
- "js-sys",
- "log",
- "percent-encoding",
- "pin-project-lite",
- "quinn",
- "rustls",
- "rustls-pki-types",
- "serde",
- "serde_json",
- "serde_urlencoded",
- "sync_wrapper",
- "tokio",
- "tokio-rustls",
- "tokio-util",
- "tower",
- "tower-http",
- "tower-service",
- "url",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "wasm-streams 0.4.2",
- "web-sys",
- "webpki-roots",
-]
-
-[[package]]
-name = "reqwest"
 version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
@@ -3238,7 +3079,7 @@ dependencies = [
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
- "wasm-streams 0.5.0",
+ "wasm-streams",
  "web-sys",
 ]
 
@@ -3350,7 +3191,6 @@ version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f4925028c7eb5d1fcdaf196971378ed9d2c1c4efc7dc5d011256f76c99c0a96"
 dependencies = [
- "web-time",
  "zeroize",
 ]
 
@@ -3409,12 +3249,6 @@ dependencies = [
  "tempfile",
  "wait-timeout",
 ]
-
-[[package]]
-name = "ryu"
-version = "1.0.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "same-file"
@@ -3639,18 +3473,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_urlencoded"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
-dependencies = [
- "form_urlencoded",
- "itoa",
- "ryu",
- "serde",
-]
-
-[[package]]
 name = "serde_with"
 version = "3.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3721,7 +3543,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.2.17",
+ "cpufeatures",
  "digest",
 ]
 
@@ -4055,7 +3877,7 @@ dependencies = [
  "percent-encoding",
  "plist",
  "raw-window-handle",
- "reqwest 0.13.4",
+ "reqwest",
  "serde",
  "serde_json",
  "serde_repr",
@@ -4272,7 +4094,7 @@ dependencies = [
  "minisign-verify",
  "osakit",
  "percent-encoding",
- "reqwest 0.13.4",
+ "reqwest",
  "rustls",
  "semver",
  "serde",
@@ -4792,6 +4614,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "typed-path"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e28f89b80c87b8fb0cf04ab448d5dd0dd0ade2f8891bae878de66a75a28600e"
+
+[[package]]
 name = "typeid"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5054,19 +4882,6 @@ dependencies = [
 
 [[package]]
 name = "wasm-streams"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
-dependencies = [
- "futures-util",
- "js-sys",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
-]
-
-[[package]]
-name = "wasm-streams"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d1ec4f6517c9e11ae630e200b2b65d193279042e28edd4a2cda233e46670bbb"
@@ -5083,16 +4898,6 @@ name = "web-sys"
 version = "0.3.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c435338968042f4f59a557f690a253676d47ce13ceb55d70100e7facf6620a30"
-dependencies = [
- "js-sys",
- "wasm-bindgen",
-]
-
-[[package]]
-name = "web-time"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -5159,15 +4964,6 @@ name = "webpki-root-certs"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b96554aa2acc8ccdb7e1c9a58a7a68dd5d13bccc69cd124cb09406db612a1c9b"
-dependencies = [
- "rustls-pki-types",
-]
-
-[[package]]
-name = "webpki-roots"
-version = "1.0.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dcd9d09a39985f5344844e66b0c530a33843579125f23e21e9f0f220850f22a"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -5949,23 +5745,6 @@ dependencies = [
 
 [[package]]
 name = "zip"
-version = "2.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fabe6324e908f85a1c52063ce7aa26b68dcb7eb6dbc83a2d148403c9bc3eba50"
-dependencies = [
- "arbitrary",
- "crc32fast",
- "crossbeam-utils",
- "displaydoc",
- "flate2",
- "indexmap 2.14.0",
- "memchr",
- "thiserror 2.0.20",
- "zopfli",
-]
-
-[[package]]
-name = "zip"
 version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "caa8cd6af31c3b31c6631b8f483848b91589021b28fffe50adada48d4f4d2ed1"
@@ -5977,22 +5756,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "zip"
+version = "8.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d04a6b5381502aa6087c94c669499eb1602eb9c5e8198e534de571f7154809b"
+dependencies = [
+ "crc32fast",
+ "flate2",
+ "indexmap 2.14.0",
+ "memchr",
+ "typed-path",
+]
+
+[[package]]
 name = "zmij"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"
-
-[[package]]
-name = "zopfli"
-version = "0.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f05cd8797d63865425ff89b5c4a48804f35ba0ce8d125800027ad6017d2b5249"
-dependencies = [
- "bumpalo",
- "crc32fast",
- "log",
- "simd-adler32",
-]
 
 [[package]]
 name = "zvariant"

--- a/README.en.md
+++ b/README.en.md
@@ -9,7 +9,7 @@ intact; the desktop layer only handles lifecycle and the security boundary.
 | Website | [dsharness.app](https://dsharness.app) |
 | Plugin marketplace | [cordis.run](https://cordis.run) |
 | Docs | [SECURITY](SECURITY.md) · [FORKING](FORKING.md) · [RELEASING](RELEASING.md) · [AGENTS](AGENTS.md) |
-| Version | v0.2.12 · Windows x64 EXE/MSI · macOS x64/arm64 DMG · Linux x64/arm64 AppImage/DEB/RPM/Flatpak · signed/notarized macOS · [中文](README.md) |
+| Version | v0.2.13 · Windows x64 EXE/MSI · macOS x64/arm64 DMG · Linux x64/arm64 AppImage/DEB/RPM/Flatpak · signed/notarized macOS · [中文](README.md) |
 
 > **macOS users**: starting with v0.2.9, DMGs are signed with Developer ID
 > Application, notarized by Apple, stapled, and rechecked with Gatekeeper.
@@ -156,7 +156,7 @@ deny.toml + supply-chain/   policy & audits   .github/workflows/   CI
   Partner Center upload, not GitHub Release assets.
 - Harness upgrades follow the startup-contract checklist in
   [AGENTS.md](AGENTS.md); the release flow lives in [RELEASING.md](RELEASING.md).
-- Status: v0.2.12 release candidate, including multi-format installers, macOS
+- Current release: v0.2.13, including multi-format installers, macOS
   Developer ID signing/notarization, the Cordis v4 marketplace contract,
   diagnostic resilience, and safe plugin recovery.
 - Known limits: Windows GitHub installers do not yet have Authenticode and may

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 | 官网 | [dsharness.app](https://dsharness.app) |
 | 插件市场 | [cordis.run](https://cordis.run) |
 | 文档 | [SECURITY](SECURITY.md) · [FORKING](FORKING.md) · [RELEASING](RELEASING.md) · [AGENTS](AGENTS.md) |
-| 版本 | v0.2.12 · Windows x64 EXE/MSI · macOS x64/arm64 DMG · Linux x64/arm64 AppImage/DEB/RPM/Flatpak · macOS 已签名/公证 · [English](README.en.md) |
+| 版本 | v0.2.13 · Windows x64 EXE/MSI · macOS x64/arm64 DMG · Linux x64/arm64 AppImage/DEB/RPM/Flatpak · macOS 已签名/公证 · [English](README.en.md) |
 
 > **macOS 用户**：v0.2.9 起，DMG 使用 Developer ID Application 签名并经
 > Apple 公证、staple 与 Gatekeeper 复验。请只从本仓库 Releases 下载；若官方
@@ -152,6 +152,6 @@ deny.toml + supply-chain/   供应链策略与审计     .github/workflows/   CI
 - CI：push/PR 跑质量门 + 三平台冒烟；打 `v*` tag 触发五个原生构建目标（Windows x64、macOS x64/arm64、Linux x64/arm64）及 Store MSIX x64/arm64，再经完整资产清单门禁发布 draft release + `latest.json`。
 - Microsoft Store：`v*` tag 同时构建 x64/arm64 MSIX（`build-msix` job，Store 模式关闭应用内更新并限制插件为 cordis.run 审核列表）。MSIX 产物作为 workflow artifact 下载后上传 Partner Center，不发布到 GitHub Release。
 - Harness 升级走 [AGENTS.md](AGENTS.md)「启动契约」清单；发布流程见 [RELEASING.md](RELEASING.md)。
-- 当前状态：v0.2.12 发布候选；包含多格式安装包、macOS Developer ID 签名/公证、Cordis v4 市场契约、诊断韧性与安全插件恢复。
+- 当前发布版本：v0.2.13；包含多格式安装包、macOS Developer ID 签名/公证、Cordis v4 市场契约、诊断韧性与安全插件恢复。
 - 已知边界：Windows GitHub 安装包尚未配置 Authenticode，可能触发 SmartScreen；macOS 更新清单尚未接入；Linux 包当前以 SHA-256 保护，尚无独立软件仓库签名。
 - 许可：MIT；内置 Harness 及全部依赖的 LICENSE 随包附于 `runtime/harness/licenses/`。

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "deepseek-harness-desktop",
   "private": true,
-  "version": "0.2.12",
+  "version": "0.2.13",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/runtime/package-lock.json
+++ b/runtime/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@deepseek-ai/dsh": "0.1.1-rc.1",
-        "pnpm": "11.21.0"
+        "pnpm": "11.22.0"
       }
     },
     "node_modules/@anthropic-ai/sdk": {
@@ -7213,9 +7213,9 @@
       }
     },
     "node_modules/pnpm": {
-      "version": "11.21.0",
-      "resolved": "https://registry.npmjs.org/pnpm/-/pnpm-11.21.0.tgz",
-      "integrity": "sha512-UhcFvOaJkk6scvWjWHEi82JonvZXHlW6gAdv1jfBETLs/62ib61Op5xIW/3b/T1aKlsFgFp36JPeceyKbMo7sQ==",
+      "version": "11.22.0",
+      "resolved": "https://registry.npmjs.org/pnpm/-/pnpm-11.22.0.tgz",
+      "integrity": "sha512-H/hwxMYTPf2I+yr8Rt0T1H8JyXlLQ4xv20fKmMrzvBY4HuC+k6CRuOOCTPAfiJ9G19niCRD7C+GrD7W6qA3WIQ==",
       "license": "MIT",
       "bin": {
         "pn": "bin/pnpm.mjs",

--- a/runtime/package.json
+++ b/runtime/package.json
@@ -5,6 +5,6 @@
   "description": "Bundled DeepSeek Harness runtime for the desktop packaging. Pin exactly; upgrades happen only through prepare-harness + CI smoke.",
   "dependencies": {
     "@deepseek-ai/dsh": "0.1.1-rc.1",
-    "pnpm": "11.21.0"
+    "pnpm": "11.22.0"
   }
 }

--- a/runtime/runtime-manifest.json
+++ b/runtime/runtime-manifest.json
@@ -1,5 +1,5 @@
 {
-  "desktopVersion": "0.2.12",
+  "desktopVersion": "0.2.13",
   "harnessVersion": "0.1.1-rc.1",
   "nodeVersion": "24.19.0",
   "sidecarVersion": "0.2.5",

--- a/scripts/lib/release-artifacts.test.ts
+++ b/scripts/lib/release-artifacts.test.ts
@@ -292,9 +292,40 @@ test("dependency review is blocking with a graph-unavailable fallback", () => {
   assert.match(dependencyWorkflow, /403\|404\)/);
   assert.match(dependencyWorkflow, /pnpm audit --audit-level low/);
   assert.match(dependencyWorkflow, /npm audit --audit-level=low/);
-  assert.match(dependencyWorkflow, /cargo metadata --locked/);
+  assert.match(
+    dependencyWorkflow,
+    /cargo metadata --locked --all-features --format-version 1 > \/dev\/null/,
+  );
+  assert.doesNotMatch(dependencyWorkflow, /cargo metadata --locked --format-version 1 --no-deps/);
+  assert.match(dependencyWorkflow, /git diff --exit-code -- Cargo\.lock/);
   assert.match(dependencyWorkflow, /cargo vet --locked/);
   assert.match(dependencyWorkflow, /verify-js-licenses\.ts --format pnpm/);
+
+  const qualityWorkflow = readFileSync(
+    new URL("../../.github/workflows/quality.yml", import.meta.url),
+    "utf8",
+  );
+  assert.match(
+    qualityWorkflow,
+    /cargo metadata --locked --all-features --format-version 1/,
+  );
+  assert.match(qualityWorkflow, /git diff --exit-code -- Cargo\.lock/);
+});
+
+test("zip 8 selects an explicit portable flate2 backend on every target", () => {
+  const cargo = readFileSync(new URL("../../src-tauri/Cargo.toml", import.meta.url), "utf8");
+  // zip's deflate-flate2 feature enables its API but deliberately leaves the
+  // flate2 backend unset. Linux happened to receive one through PNG; Windows
+  // did not, so keep the application-level pure-Rust choice contractual.
+  assert.match(
+    cargo,
+    /zip = \{ version = "8", default-features = false, features = \["deflate-flate2"\] \}/,
+  );
+  assert.match(
+    cargo,
+    /flate2 = \{ version = "1\.1\.9", default-features = false, features = \["rust_backend"\] \}/,
+  );
+  assert.doesNotMatch(cargo, /deflate-flate2-zlib|deflate-flate2-zlib-ng|deflate-zopfli/);
 });
 
 test("release verifies external contracts before publishing", () => {

--- a/scripts/verify-plugins.ts
+++ b/scripts/verify-plugins.ts
@@ -23,7 +23,7 @@
 // Store isolation (plan S5): `pnpm_config_store_dir` pins the pnpm content
 // store inside the temp home, so nothing touches the user's real store.
 // (pnpm reads env config under the `pnpm_config_` prefix — verified against
-// the bundled pnpm 11.21.0; `npm_config_*` is NOT honored for this key.)
+// the bundled pnpm 11.22.0; `npm_config_*` is NOT honored for this key.)
 // NOTE: requires network access to registry.npmjs.org (CI runners have it).
 //
 // The Rust side of the shim text/exec is covered by plugins.rs tests. Both

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deepseek-harness-desktop"
-version = "0.2.12"
+version = "0.2.13"
 description = "DSH Desktop — community desktop packaging of DeepSeek Harness"
 edition = "2021"
 license = "MIT"
@@ -16,13 +16,25 @@ tauri-plugin-updater = "2"
 tauri-plugin-dialog = "2"
 tauri-plugin-opener = "2"
 tauri-plugin-deep-link = "2"
-zip = { version = "2", default-features = false, features = ["deflate"] }
-# Remote .dshpreset download and cordis.run market requests. rustls keeps the
-# supply chain to a single TLS backend (already transitive via
-# tauri-plugin-updater); no native-tls/OpenSSL.
-reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "stream"] }
+# Keep the portable flate2/miniz backend used elsewhere in the application.
+# zip's broader `deflate` meta-feature would also pull zopfli and zlib-rs;
+# neither is needed for opening or creating the small preset/diagnostic ZIPs.
+zip = { version = "8", default-features = false, features = ["deflate-flate2"] }
+# zip's deflate-flate2 feature intentionally leaves flate2's backend to the
+# application. Select its portable miniz_oxide backend explicitly: Linux
+# happens to gain it through PNG, but the Windows graph does not.
+flate2 = { version = "1.1.9", default-features = false, features = ["rust_backend"] }
+# Remote .dshpreset download and cordis.run market requests. reqwest 0.13's
+# no-provider variant is paired with the explicit, process-wide ring provider
+# below (installed before Tauri starts), so every client uses one audited TLS
+# backend and never native-tls/OpenSSL.
+reqwest = { version = "0.13.4", default-features = false, features = ["rustls-no-provider", "stream"] }
+# reqwest 0.13 delegates provider choice to the application. Select the
+# current pure-Rust provider explicitly instead of depending on another crate's
+# feature unification or pulling in the AWS-LC/C build chain.
+rustls = { version = "0.23.43", default-features = false, features = ["ring", "std", "tls12"] }
 futures-util = "0.3"
-getrandom = "0.2"
+getrandom = "0.4"
 # The sidecar's library surface: PlatformChild gives the plugin installer the
 # SAME process-tree guarantees (unix process group / Windows Job Object).
 # The version must stay in lockstep with crates/dsh-sidecar/Cargo.toml —

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -2511,7 +2511,11 @@ pub async fn confirm_remote_preset_download(
         }
     };
 
-    let client = reqwest::Client::builder()
+    let client = crate::tls::client_builder()
+        .map_err(|error| {
+            fail(&pending, &arbiter, &request_id, None);
+            format!("client init failed: {error}")
+        })?
         .timeout(std::time::Duration::from_secs(30))
         .redirect(reqwest::redirect::Policy::none())
         .build()

--- a/src-tauri/src/deep_link.rs
+++ b/src-tauri/src/deep_link.rs
@@ -385,7 +385,7 @@ impl PendingRemotePreset {
 
 fn new_request_id() -> Result<String, String> {
     let mut bytes = [0u8; 16];
-    getrandom::getrandom(&mut bytes).map_err(|e| format!("CSPRNG failed: {e}"))?;
+    getrandom::fill(&mut bytes).map_err(|e| format!("CSPRNG failed: {e}"))?;
     Ok(bytes.iter().map(|b| format!("{b:02x}")).collect())
 }
 
@@ -1125,6 +1125,17 @@ mod tests {
         assert!(!arbiter.try_acquire(PendingInstallKind::Plugin));
         assert_eq!(id.len(), 32);
         (pending, arbiter)
+    }
+
+    #[test]
+    fn remote_request_id_is_fixed_length_lower_hex() {
+        let id = new_request_id().expect("OS CSPRNG should provide a request id");
+        assert_eq!(id.len(), 32);
+        assert!(
+            id.bytes()
+                .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte)),
+            "request id must be safe to persist and compare as lower hex: {id}"
+        );
     }
 
     fn fake_preview(id: &str) -> crate::preset::ArchivePreview {

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -18,12 +18,18 @@ mod presentation;
 mod preset;
 mod recovery;
 mod secure_fs;
+mod tls;
 mod tray;
 
 #[cfg(any(target_os = "macos", test))]
 mod app_menu;
 
 fn main() {
+    if let Err(error) = tls::install_process_default() {
+        eprintln!("[dsh-desktop] TLS provider initialization failed: {error}");
+        std::process::exit(1);
+    }
+
     // Windows: give the shell a private hidden console before any plugin
     // child exists. Plugin children are spawned WITHOUT CREATE_NO_WINDOW so
     // they inherit it — that inheritance is what makes PlatformChild's

--- a/src-tauri/src/market.rs
+++ b/src-tauri/src/market.rs
@@ -334,7 +334,7 @@ impl MarketClient {
                     .to_string(),
             );
         }
-        let http = reqwest::Client::builder()
+        let http = crate::tls::client_builder()?
             .timeout(Duration::from_secs(10))
             .redirect(reqwest::redirect::Policy::none())
             .user_agent(format!("dsh-desktop/{}", env!("CARGO_PKG_VERSION")))

--- a/src-tauri/src/secure_fs.rs
+++ b/src-tauri/src/secure_fs.rs
@@ -241,8 +241,7 @@ pub fn read_bounded(path: &Path, max_bytes: u64) -> Result<Option<Vec<u8>>, Stri
 
 pub fn random_suffix() -> Result<String, String> {
     let mut bytes = [0_u8; 12];
-    getrandom::getrandom(&mut bytes)
-        .map_err(|e| format!("cannot generate private file id: {e}"))?;
+    getrandom::fill(&mut bytes).map_err(|e| format!("cannot generate private file id: {e}"))?;
     let mut output = String::with_capacity(bytes.len() * 2);
     for byte in bytes {
         use std::fmt::Write as _;
@@ -344,6 +343,18 @@ pub fn sibling_temp(destination: &Path, purpose: &str) -> Result<PathBuf, String
 #[allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn random_suffix_is_fixed_length_lower_hex() {
+        let suffix = random_suffix().expect("OS CSPRNG should provide a temp-file suffix");
+        assert_eq!(suffix.len(), 24);
+        assert!(
+            suffix
+                .bytes()
+                .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte)),
+            "suffix must be filesystem-safe lower hex: {suffix}"
+        );
+    }
 
     fn test_dir(name: &str) -> PathBuf {
         std::env::temp_dir().join(format!(

--- a/src-tauri/src/tls.rs
+++ b/src-tauri/src/tls.rs
@@ -1,0 +1,50 @@
+//! Process-wide TLS provider selection.
+//!
+//! reqwest 0.13 deliberately allows the application to choose a rustls
+//! provider. Install `ring` before Tauri creates any network client so market,
+//! preset-download, updater, and future TLS users cannot depend on feature
+//! unification or silently select a native-TLS backend.
+
+pub fn install_process_default() -> Result<(), String> {
+    if rustls::crypto::CryptoProvider::get_default().is_some() {
+        return Ok(());
+    }
+
+    match rustls::crypto::ring::default_provider().install_default() {
+        Ok(()) => Ok(()),
+        // Another initializer can only win this race before Tauri starts in a
+        // test or an embedding context. A provider is now present either way.
+        Err(_) if rustls::crypto::CryptoProvider::get_default().is_some() => Ok(()),
+        Err(_) => Err("could not install the rustls ring provider".to_string()),
+    }
+}
+
+/// The only construction path for Desktop-owned reqwest clients.
+///
+/// `main` installs the provider before Tauri starts, but unit tests and small
+/// command helpers can construct a client without entering `main`. Keeping
+/// this guard at the builder boundary makes that safe and prevents a future
+/// call site from accidentally relying on feature unification.
+pub(crate) fn client_builder() -> Result<reqwest::ClientBuilder, String> {
+    install_process_default()?;
+    Ok(reqwest::Client::builder())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn provider_initialization_is_idempotent() {
+        assert!(install_process_default().is_ok());
+        assert!(install_process_default().is_ok());
+        assert!(rustls::crypto::CryptoProvider::get_default().is_some());
+    }
+
+    #[test]
+    fn client_builder_initializes_before_constructing_reqwest() {
+        let client =
+            client_builder().and_then(|builder| builder.build().map_err(|error| error.to_string()));
+        assert!(client.is_ok());
+    }
+}

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "DSH Desktop",
-  "version": "0.2.12",
+  "version": "0.2.13",
   "identifier": "com.yeagoo.dsh-desktop",
   "build": {
     "beforeDevCommand": "pnpm dev",

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -1583,6 +1583,11 @@ criteria = "safe-to-deploy"
 version = "0.2.5"
 criteria = "safe-to-deploy"
 
+[[exemptions.typed-path]]
+version = "0.12.3"
+criteria = "safe-to-deploy"
+notes = "Reviewed as zip 8's only new transitive dependency: no build script or native code; its unsafe code is confined to documented UTF-8 representation conversions and transparent path casts. The application does not expose typed-path directly."
+
 [[exemptions.typeid]]
 version = "1.0.3"
 criteria = "safe-to-deploy"
@@ -2028,6 +2033,11 @@ notes = "Shell-UX chain pulled in by tauri-plugin-dialog / tauri-plugin-opener (
 version = "4.6.1"
 criteria = "safe-to-deploy"
 notes = "Zip archive handling pulled in by tauri-plugin-updater (update package extraction); upstream of the updater plugin, verified via plugin pin."
+
+[[exemptions.zip]]
+version = "8.6.0"
+criteria = "safe-to-deploy"
+notes = "Direct preset/diagnostics archive dependency, source-reviewed: no build script; default, encryption, native and zlib-rs backends remain disabled. Application uses only safe ZipArchive/ZipWriter APIs and retains bounded, traversal-safe preset extraction tests."
 
 [[exemptions.zmij]]
 version = "1.0.23"


### PR DESCRIPTION
## Scope

- upgrade bundled pnpm to 11.22.0
- upgrade getrandom to 0.4, zip to 8.6.0, and reqwest to 0.13.4
- install the explicit rustls ring provider before any Desktop-owned TLS client, including direct unit-test paths
- make CI verify the complete locked Cargo graph and reject an implicitly rewritten Cargo.lock
- synchronize v0.2.13 release metadata and correct the stale Harness baseline documentation

## Security and review

- reqwest uses rustls-no-provider plus an explicit ring provider; no native-tls, AWS-LC, zlib-rs, or zopfli backend was introduced.
- zip 8 is restricted to deflate-flate2; typed-path and zip 8.6.0 received precise cargo-vet review exemptions.
- Rust direct-client construction is centralized in `tls::client_builder`, which initializes the provider even outside `main`.
- Cargo metadata uses `--locked --all-features` and the workflow asserts that Cargo.lock remains untouched.

## Verification

- 42 sidecar nextest tests; 194 Desktop nextest tests
- Desktop coverage 63.74% (floor 55%); sidecar coverage 81.77% (floor 50%)
- clippy -D warnings and rustfmt clean
- cargo vet --locked; cargo deny for both crates
- 83 script tests; 17 frontend tests; frontend build/type checks; ACL contract check
- runtime Node/Harness/sidecar smoke plus plugin install/remove and sideload E2E
- production Cordis preset direct 200 application/zip and market ETag/304 + JSON 404 probes
- release preflight bound to v0.2.13