### PR TITLE
fix: restore Windows native Release checks

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -233,9 +233,10 @@ jobs:
       - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c  # stable branch (toolchain version pinned via rust-toolchain.toml)
 
       - name: Assert native build host
-        env:
-          RELEASE_TARGET: ${{ matrix.target }}
-        run: node scripts/verify-native-host.ts --target "$RELEASE_TARGET"
+        # Matrix values are emitted from the reviewed static release plan.
+        # Expand them before the runner shell so Windows pwsh and Unix bash
+        # receive the same literal argument; `$RELEASE_TARGET` is Bash-only.
+        run: node scripts/verify-native-host.ts --target "${{ matrix.target }}"
 
       - uses: Swatinem/rust-cache@49a0bdc70d2e1b713ca9e2869b211fcce03d3c1c  # v2 (SHA-pinned)
         with:
@@ -618,9 +619,8 @@ jobs:
           targets: ${{ matrix.target }}
 
       - name: Assert native Store build host
-        env:
-          RELEASE_TARGET: ${{ matrix.nativeTarget }}
-        run: node scripts/verify-native-host.ts --target "$RELEASE_TARGET"
+        # See the native build job: avoid shell-specific environment syntax.
+        run: node scripts/verify-native-host.ts --target "${{ matrix.nativeTarget }}"
 
       - uses: Swatinem/rust-cache@49a0bdc70d2e1b713ca9e2869b211fcce03d3c1c  # v2 (SHA-pinned)
         with:

--- a/scripts/lib/msix.test.ts
+++ b/scripts/lib/msix.test.ts
@@ -1,6 +1,16 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { normalizeMsixEntryName } from "./msix.ts";
+import { normalizeMsixEntryName, windowsPeArchitecture } from "./msix.ts";
+
+function peHeader(machine: number): Buffer {
+  const header = Buffer.alloc(0x90);
+  header[0] = 0x4d;
+  header[1] = 0x5a;
+  header.writeUInt32LE(0x80, 0x3c);
+  header.write("PE\0\0", 0x80, "ascii");
+  header.writeUInt16LE(machine, 0x84);
+  return header;
+}
 
 test("normalizes AppX URI escaping and Windows separators", () => {
   assert.equal(
@@ -15,4 +25,15 @@ test("rejects encoded separators, traversal, and malformed escapes", () => {
   for (const entry of ["safe/%2fhidden", "safe/%5chidden", "safe/%2e%2e/file", "bad/%xy"]) {
     assert.throws(() => normalizeMsixEntryName(entry));
   }
+});
+
+test("reads only reviewed x64 and arm64 PE machine headers", () => {
+  assert.equal(windowsPeArchitecture(peHeader(0x8664)), "x64");
+  assert.equal(windowsPeArchitecture(peHeader(0xaa64)), "arm64");
+  assert.throws(() => windowsPeArchitecture(peHeader(0x014c)), /unreviewed PE machine/);
+  assert.throws(() => windowsPeArchitecture(Buffer.alloc(0x40)), /DOS\/PE header/);
+
+  const malformedOffset = peHeader(0x8664);
+  malformedOffset.writeUInt32LE(0x200, 0x3c);
+  assert.throws(() => windowsPeArchitecture(malformedOffset), /outside the captured/);
 });

--- a/scripts/lib/msix.ts
+++ b/scripts/lib/msix.ts
@@ -23,3 +23,43 @@ export function normalizeMsixEntryName(name: string): string {
     })
     .join("/");
 }
+
+export type WindowsPeArchitecture = "x64" | "arm64";
+
+const PE_MACHINE_ARCHITECTURES: Readonly<Record<number, WindowsPeArchitecture>> = {
+  0x8664: "x64",
+  0xaa64: "arm64",
+};
+
+/**
+ * Read the architecture from the PE/COFF header of a Windows executable or
+ * native Node module. The caller may pass only a prefix: this validates that
+ * the DOS and PE offsets are present before reading the machine field.
+ */
+export function windowsPeArchitecture(header: Uint8Array): WindowsPeArchitecture {
+  if (header.length < 0x40 || header[0] !== 0x4d || header[1] !== 0x5a) {
+    throw new Error("file is not a complete DOS/PE header");
+  }
+  const peOffset =
+    header[0x3c] |
+    (header[0x3d] << 8) |
+    (header[0x3e] << 16) |
+    (header[0x3f] << 24);
+  if (peOffset < 0 || peOffset + 6 > header.length) {
+    throw new Error("PE header offset is outside the captured file prefix");
+  }
+  if (
+    header[peOffset] !== 0x50 ||
+    header[peOffset + 1] !== 0x45 ||
+    header[peOffset + 2] !== 0 ||
+    header[peOffset + 3] !== 0
+  ) {
+    throw new Error("file has no PE signature at its declared header offset");
+  }
+  const machine = header[peOffset + 4] | (header[peOffset + 5] << 8);
+  const architecture = PE_MACHINE_ARCHITECTURES[machine];
+  if (!architecture) {
+    throw new Error(`unreviewed PE machine 0x${machine.toString(16).padStart(4, "0")}`);
+  }
+  return architecture;
+}

--- a/scripts/lib/release-artifacts.test.ts
+++ b/scripts/lib/release-artifacts.test.ts
@@ -228,11 +228,21 @@ test("release host and installer smokes cover each declared native architecture"
     new URL("../../.github/workflows/release.yml", import.meta.url),
     "utf8",
   );
-  assert.equal(
-    workflow.split('node scripts/verify-native-host.ts --target "$RELEASE_TARGET"').length - 1,
-    2,
+  // GitHub expands these reviewed matrix values before selecting the runner
+  // shell. Do not route them through `$RELEASE_TARGET`: Windows defaults to
+  // PowerShell, where environment variables use `$env:RELEASE_TARGET`.
+  assert.match(
+    workflow,
+    /node scripts\/verify-native-host\.ts --target "\$\{\{ matrix\.target \}\}"/,
   );
-  assert.match(workflow, /RELEASE_TARGET: \$\{\{ matrix\.nativeTarget \}\}/);
+  assert.match(
+    workflow,
+    /node scripts\/verify-native-host\.ts --target "\$\{\{ matrix\.nativeTarget \}\}"/,
+  );
+  assert.doesNotMatch(
+    workflow,
+    /verify-native-host\.ts --target "\$RELEASE_TARGET"/,
+  );
   assert.match(workflow, /os: windows-11-arm/);
   assert.match(workflow, /artifact: deepseek-harness-desktop-windows-arm64/);
   assert.match(workflow, /x64 compatibility on ARM64/);

--- a/scripts/lib/windows-installer-locales.test.ts
+++ b/scripts/lib/windows-installer-locales.test.ts
@@ -37,6 +37,7 @@ test("Tauri config emits the reviewed WiX locales and one multilingual NSIS inst
   ) as {
     bundle?: {
       windows?: {
+        webviewInstallMode?: { type?: string };
         wix?: { language?: string[] };
         nsis?: { languages?: string[]; displayLanguageSelector?: boolean };
       };
@@ -45,4 +46,9 @@ test("Tauri config emits the reviewed WiX locales and one multilingual NSIS inst
   assert.deepEqual(config.bundle?.windows?.wix?.language, WINDOWS_WIX_INSTALLER_LOCALES);
   assert.deepEqual(config.bundle?.windows?.nsis?.languages, WINDOWS_NSIS_INSTALLER_LANGUAGES);
   assert.equal(config.bundle?.windows?.nsis?.displayLanguageSelector, true);
+  // Keep the Tauri default explicit: a clean supported Windows installation
+  // may need the Evergreen WebView2 bootstrapper before the first launch.
+  assert.deepEqual(config.bundle?.windows?.webviewInstallMode, {
+    type: "downloadBootstrapper",
+  });
 });

--- a/scripts/verify-msix.ts
+++ b/scripts/verify-msix.ts
@@ -14,7 +14,7 @@ import { existsSync, readdirSync } from "node:fs";
 import { join } from "node:path";
 import { spawnSync } from "node:child_process";
 import { repoRoot, fail, ok } from "./lib/common.ts";
-import { normalizeMsixEntryName } from "./lib/msix.ts";
+import { normalizeMsixEntryName, windowsPeArchitecture } from "./lib/msix.ts";
 
 const PACKAGE_NAME = "53660AlanM.DSHDesktopCommunity";
 const PUBLISHER = "CN=84AC3716-04E0-4D67-8951-0D3E51674CA0";
@@ -49,7 +49,7 @@ for (const target of targets) {
   }
 }
 
-function readZipEntries(msix: string): { name: string; content?: string }[] {
+function readZipEntries(msix: string): { name: string; content?: string; peHeader?: string }[] {
   const ps = `
 $ErrorActionPreference = "Stop"
 Add-Type -AssemblyName System.IO.Compression.FileSystem
@@ -62,7 +62,24 @@ foreach ($entry in $zip.Entries) {
       $content = $reader.ReadToEnd()
       $reader.Close()
     }
-    [pscustomobject]@{ name = $name; content = $content } | ConvertTo-Json -Compress
+    $peHeader = $null
+    if ($name.EndsWith(".exe", [System.StringComparison]::OrdinalIgnoreCase) -or
+        $name.EndsWith(".node", [System.StringComparison]::OrdinalIgnoreCase)) {
+      $stream = $entry.Open()
+      try {
+        # The PE header pointer lives at byte 0x3c. A 1 KiB prefix safely
+        # covers normal Windows executable and native-addon headers without
+        # extracting arbitrary package contents to disk.
+        $bytes = New-Object byte[] 1024
+        $count = $stream.Read($bytes, 0, $bytes.Length)
+        if ($count -gt 0) {
+          $peHeader = [Convert]::ToBase64String($bytes, 0, $count)
+        }
+      } finally {
+        $stream.Dispose()
+      }
+    }
+    [pscustomobject]@{ name = $name; content = $content; peHeader = $peHeader } | ConvertTo-Json -Compress
   }
   $zip.Dispose()
 `;
@@ -74,12 +91,22 @@ foreach ($entry in $zip.Entries) {
   if (res.status !== 0) {
     fail(`failed to list ${msix}: ${(res.stderr ?? res.stdout ?? "").trim()}`);
   }
-  const parsed: { name: string; content?: string }[] = [];
+  const parsed: { name: string; content?: string; peHeader?: string }[] = [];
   for (const line of (res.stdout ?? "").split(/\r?\n/)) {
     if (!line.trim()) continue;
     try {
-      const obj = JSON.parse(line) as { name?: string; content?: string | null };
-      if (obj.name) parsed.push({ name: obj.name, content: obj.content ?? undefined });
+      const obj = JSON.parse(line) as {
+        name?: string;
+        content?: string | null;
+        peHeader?: string | null;
+      };
+      if (obj.name) {
+        parsed.push({
+          name: obj.name,
+          content: obj.content ?? undefined,
+          peHeader: obj.peHeader ?? undefined,
+        });
+      }
     } catch {
       // Ignore non-JSON progress/format lines emitted by PowerShell hosts.
     }
@@ -127,6 +154,29 @@ for (const target of targets) {
   }
   if (lowerNames.has("appxsignature.p7x")) {
     fail(`${msix} unexpectedly contains a signature; pfx:null Store inputs must remain unsigned`);
+  }
+
+  const requiredPeEntries = [
+    "deepseek-harness-desktop.exe",
+    "runtime/node.exe",
+    "runtime/sidecar.exe",
+    `runtime/harness/node_modules/node-pty/prebuilds/win32-${target.arch}/conpty.node`,
+  ];
+  for (const path of requiredPeEntries) {
+    const entry = entries.find((candidate) => candidate.name.toLowerCase() === path.toLowerCase());
+    if (!entry?.peHeader) fail(`${msix} is missing a readable PE header for ${path}`);
+    let actualArchitecture: "x64" | "arm64";
+    try {
+      actualArchitecture = windowsPeArchitecture(Buffer.from(entry.peHeader, "base64"));
+    } catch (error) {
+      fail(
+        `${msix} has an invalid PE header for ${path}: ` +
+          `${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
+    if (actualArchitecture !== target.arch) {
+      fail(`${msix} ${path} is ${actualArchitecture}, expected ${target.arch}`);
+    }
   }
   ok(`${msix} verified (${names.size} entries, identity/arch/protocol OK, unsigned Store input)`);
 }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -44,6 +44,9 @@
     },
     "createUpdaterArtifacts": true,
     "windows": {
+      "webviewInstallMode": {
+        "type": "downloadBootstrapper"
+      },
       "wix": {
         "language": [
           "en-US",


### PR DESCRIPTION
## Root cause

The v0.2.14 Release workflow passed an empty `--target` on every Windows job. GitHub Actions uses PowerShell on Windows, where `$RELEASE_TARGET` is not the Bash environment-variable syntax. The jobs therefore stopped before compilation, bundle verification, or installer smoke.

## Changes

- expand the reviewed static matrix target before runner-shell selection for both public Windows builds and Store MSIX builds;
- lock the workflow contract in script tests so the Bash-only syntax cannot return;
- make the public Windows WebView2 bootstrapper policy explicit;
- verify the actual PE architecture of the MSIX app, Node runtime, sidecar, and `node-pty` native module, in addition to manifest architecture.

## Local verification

- `pnpm check:scripts`
- `pnpm test:scripts` (103/103)
- `pnpm check`
- `pnpm test:frontend` (17/17)
- `cargo check --locked --manifest-path src-tauri/Cargo.toml --all-targets`
- `cargo fmt --check --manifest-path src-tauri/Cargo.toml`
- `actionlint -color .github/workflows/release.yml`
- `git diff --check`