### PR TITLE
fix: correct NSIS deep-link smoke validation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -893,7 +893,7 @@ jobs:
             $command = (Get-ItemProperty $_).'(default)'
             $match = [regex]::Match(
               $command,
-              '^"([^"]+\\.exe)"\s+"%1"$',
+              '^"([^"]+\.exe)"\s+"%1"$',
               [System.Text.RegularExpressions.RegexOptions]::IgnoreCase
             )
             if (-not $match.Success) { throw "invalid NSIS protocol command: $command" }

--- a/scripts/lib/release-artifacts.test.ts
+++ b/scripts/lib/release-artifacts.test.ts
@@ -168,6 +168,25 @@ test("Windows installer smoke searches the preserved artifact tree exactly", () 
   );
   assert.match(workflow, /In-place NSIS reinstall and installed Harness smoke/);
   assert.match(workflow, /installed Harness never became ready/);
+  // PowerShell single-quoted strings do not consume backslashes. The pattern
+  // must escape the dot once, not twice (which looks for a literal backslash
+  // before an arbitrary character). Exercise the
+  // exact registration format emitted by the NSIS installer so every native
+  // deep-link smoke cannot regress into a false failure.
+  const nsisProtocolPattern = String.raw`'^"([^"]+\.exe)"\s+"%1"$'`;
+  const accidentalDoubleEscape = String.raw`'^"([^"]+\\.exe)"\s+"%1"$'`;
+  assert.equal(workflow.includes(nsisProtocolPattern), true);
+  assert.equal(workflow.includes(accidentalDoubleEscape), false);
+  const registeredCommand =
+    '"C:\\Users\\runneradmin\\AppData\\Local\\DSH Desktop\\deepseek-harness-desktop.exe" "%1"';
+  assert.equal(
+    new RegExp(nsisProtocolPattern.slice(1, -1), "i").test(registeredCommand),
+    true,
+  );
+  assert.equal(
+    new RegExp(accidentalDoubleEscape.slice(1, -1), "i").test(registeredCommand),
+    false,
+  );
   assert.match(workflow, /\$_.Name\.EndsWith\("_\$locale\.msi", \[System\.StringComparison\]::Ordinal\)/);
   assert.match(workflow, /MSI ProductLanguage \$productLanguage does not match \$locale/);
   assert.match(workflow, /\$quotedInstaller = '\"' \+ \$installer\.FullName \+ '\"'/);


### PR DESCRIPTION
## Root cause

The full native Release rehearsal proved that the NSIS installers, registry values, MSI installers, MSIX packages, macOS builds, and Linux builds were valid. Three NSIS deep-link smoke jobs failed before the actual URL launch because their PowerShell regex used `\\.exe` inside a single-quoted string. PowerShell preserves backslashes in single quotes, so .NET Regex treated it as a literal backslash plus arbitrary character rather than an escaped dot.

The valid registry value was incorrectly rejected:

```text
"…\deepseek-harness-desktop.exe" "%1"
```

## Changes

- use the correct one-layer regex escape (`\.exe`) for the NSIS registry command;
- add an executable script test that matches the real NSIS registration form and proves the accidental double escape fails.

## Verification

- `pnpm check:scripts`
- `pnpm test:scripts` (103/103)
- `pnpm check`
- `pnpm test:frontend` (17/17)
- `actionlint -color .github/workflows/release.yml`
- `git diff --check`

The preceding main rehearsal is [run #32614408784](https://github.com/web-casa/DeepSeek-Harness-Desktop/actions/runs/32614408784): all six native builds, both MSIX packages, both macOS notarizations, and all four MSI smokes succeeded; only the three affected NSIS test commands failed.