### PR TITLE
fix: repair NSIS installed runtime smoke

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -907,7 +907,13 @@ jobs:
             throw "registered desktop executable disappeared after NSIS reinstall: $desktopExe"
           }
 
-          $installRoot = Split-Path -LiteralPath $desktopExe -Parent
+          # Split-Path cannot combine -LiteralPath with -Parent in PowerShell's
+          # parameter sets. Use the .NET path API so a registered executable
+          # containing wildcard characters is still treated literally.
+          $installRoot = [System.IO.Path]::GetDirectoryName($desktopExe)
+          if ([string]::IsNullOrWhiteSpace($installRoot)) {
+            throw "registered desktop executable has no parent directory: $desktopExe"
+          }
           $runtime = Join-Path $installRoot 'runtime'
           $sidecar = Join-Path $runtime 'sidecar.exe'
           $node = Join-Path $runtime 'node.exe'

--- a/scripts/lib/release-artifacts.test.ts
+++ b/scripts/lib/release-artifacts.test.ts
@@ -551,3 +551,9 @@ test("macOS release signs runtime, uploads once, then waits in a separate job", 
   assert.equal(workflow.slice(cleanupIndex).includes("always()"), true);
   assert.equal(workflow.slice(cleanupIndex).includes("::warning::"), true);
 });
+
+test("bundle verifier checks node-pty's actual machine type, not only its directory", () => {
+  const bundleVerifier = readFileSync(new URL("../verify-bundle.ts", import.meta.url), "utf8");
+  assert.match(bundleVerifier, /checkBinaryType\(pty, kind, arch, "selected node-pty native addon"\)/);
+  assert.match(bundleVerifier, /\[ptyEntry, "selected node-pty native addon"\]/);
+});

--- a/scripts/lib/release-artifacts.test.ts
+++ b/scripts/lib/release-artifacts.test.ts
@@ -187,6 +187,15 @@ test("Windows installer smoke searches the preserved artifact tree exactly", () 
     new RegExp(accidentalDoubleEscape.slice(1, -1), "i").test(registeredCommand),
     false,
   );
+  // `Split-Path -LiteralPath ... -Parent` is not a valid PowerShell parameter
+  // set. The native path API preserves literal handling while accepting a
+  // fully-qualified executable path from the validated protocol registration.
+  assert.equal(workflow.includes("[System.IO.Path]::GetDirectoryName($desktopExe)"), true);
+  assert.equal(workflow.includes("Split-Path -LiteralPath $desktopExe -Parent"), false);
+  assert.match(
+    workflow,
+    /registered desktop executable has no parent directory: \$desktopExe/,
+  );
   assert.match(workflow, /\$_.Name\.EndsWith\("_\$locale\.msi", \[System\.StringComparison\]::Ordinal\)/);
   assert.match(workflow, /MSI ProductLanguage \$productLanguage does not match \$locale/);
   assert.match(workflow, /\$quotedInstaller = '\"' \+ \$installer\.FullName \+ '\"'/);

--- a/scripts/verify-bundle.ts
+++ b/scripts/verify-bundle.ts
@@ -2,7 +2,7 @@
 //
 // Each package is expanded with its platform-native tool, then checked against
 // one runtime contract: correct host architecture, executable main/Node/
-// sidecar binaries, exact runtime manifest, selected node-pty prebuild,
+// sidecar binaries, selected node-pty native binary, exact runtime manifest,
 // dsharness deep-link registration, and a fully materialized Harness tree.
 
 import {
@@ -256,6 +256,15 @@ function verifyRuntimeTree(
     platform === "win32" ? "PE" : platform === "darwin" ? "Mach-O" : "ELF";
   const node = join(runtimeRoot, `node${extension}`);
   const sidecar = join(runtimeRoot, `sidecar${extension}`);
+  const pty = join(
+    runtimeRoot,
+    "harness",
+    "node_modules",
+    "node-pty",
+    "prebuilds",
+    `${platform}-${arch}`,
+    ptyBinary,
+  );
   for (const [path, label] of [
     [mainBinary, "main binary"],
     [node, "bundled node"],
@@ -264,6 +273,9 @@ function verifyRuntimeTree(
     if (platform !== "win32") assertExecutable(path, label);
     checkBinaryType(path, kind, arch, label);
   }
+  // Directory names are only metadata. The prebuilt native addon must have
+  // the same actual machine type as the package that will load it.
+  checkBinaryType(pty, kind, arch, "selected node-pty native addon");
   checkBundledManifest(join(runtimeRoot, "harness", "runtime-manifest.json"));
 }
 
@@ -319,11 +331,12 @@ function extractNsisFile(artifact: string, innerPath: string, output: string): s
 function verifyNsis(artifact: string, arch: ReleaseArch): void {
   const entries = listNsisEntries(artifact);
   const entrySet = new Set(entries.map((entry) => entry.toLowerCase()));
+  const ptyEntry = `runtime/harness/node_modules/node-pty/prebuilds/win32-${arch}/conpty.node`;
   const required = [
     "runtime/node.exe",
     "runtime/sidecar.exe",
     ...HARNESS_CORE.map((entry) => `runtime/${entry}`),
-    `runtime/harness/node_modules/node-pty/prebuilds/win32-${arch}/conpty.node`,
+    ptyEntry,
   ];
   for (const path of required) {
     if (!entrySet.has(path.toLowerCase())) throw new Error(`NSIS missing required entry: ${path}`);
@@ -346,6 +359,7 @@ function verifyNsis(artifact: string, arch: ReleaseArch): void {
       [mainEntries[0], "main binary"],
       ["runtime/node.exe", "bundled node"],
       ["runtime/sidecar.exe", "sidecar binary"],
+      [ptyEntry, "selected node-pty native addon"],
     ] as const) {
       checkBinaryType(extractNsisFile(artifact, path, extraction), "PE", arch, label);
     }


### PR DESCRIPTION
## Summary
- derive the installed NSIS root through the valid .NET literal-path API
- fail clearly when the registered executable has no parent directory
- add a regression test for the invalid PowerShell parameter combination
- verify the actual PE/Mach-O/ELF machine type of the selected packaged `node-pty` addon in every public bundle, not just its architecture-named directory

## Validation
- pnpm check
- pnpm check:scripts
- pnpm test:scripts (104/104)
- pnpm test:frontend
- pnpm release:preflight
- node scripts/verify-bundle.ts --self-test
- cargo fmt --check (both crates)
- cargo clippy --locked --all-targets -- -D warnings (both crates)
- actionlint -color .github/workflows/release.yml
- git diff --check

This follows the real Windows NSIS artifact smoke: after PR #31 fixed the protocol-command regex, the reused artifact smoke reached an invalid `Split-Path -LiteralPath ... -Parent` parameter set before it could launch the installed sidecar. The release review also found that non-MSIX bundle verification accepted a wrongly-architected `node-pty` native addon if its folder name looked correct; this PR closes that gap.