### PR TITLE
fix: harden install arbitration and CodeQL coverage

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -9,6 +9,7 @@ on:
     - cron: "17 2 * * 3"
 
 permissions:
+  contents: read
   security-events: write
 
 concurrency:
@@ -42,7 +43,7 @@ jobs:
   analyze-rust:
     name: Analyze (Rust)
     runs-on: ubuntu-latest
-    timeout-minutes: 45
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1 (SHA-pinned)
 
@@ -53,8 +54,41 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c  # stable (version via rust-toolchain.toml)
 
-      - name: Build (sidecar)
-        run: cargo build --manifest-path crates/dsh-sidecar/Cargo.toml
+      # CodeQL records only code that is compiled after initialization. The
+      # shell owns the security-sensitive IPC/deep-link/preset/market surface,
+      # so analyzing the sidecar alone leaves most Rust code out of the DB.
+      # Mirror the established Linux quality host dependencies before building
+      # both workspace executables.
+      - name: Install Tauri system dependencies
+        timeout-minutes: 15
+        run: |
+          test -f /etc/apt/apt-mirrors.txt
+          grep -q '^http://azure\.archive\.ubuntu\.com/ubuntu/' /etc/apt/apt-mirrors.txt
+          grep -q '^https://archive\.ubuntu\.com/ubuntu/' /etc/apt/apt-mirrors.txt
+          sudo sed -i '\|^http://azure\.archive\.ubuntu\.com/ubuntu/|d' /etc/apt/apt-mirrors.txt
+          if grep -q '^http://azure\.archive\.ubuntu\.com/ubuntu/' /etc/apt/apt-mirrors.txt; then
+            echo 'Azure apt mirror remained enabled after sanitization' >&2
+            exit 1
+          fi
+
+          apt_options=(
+            -o Acquire::Retries=3
+            -o Acquire::http::Timeout=20
+            -o Acquire::https::Timeout=20
+            -o Acquire::Languages=none
+            -o Dpkg::Use-Pty=0
+          )
+          sudo apt-get "${apt_options[@]}" update
+          sudo DEBIAN_FRONTEND=noninteractive apt-get "${apt_options[@]}" install -y \
+            libwebkit2gtk-4.1-dev libayatana-appindicator3-dev librsvg2-dev
+
+      - name: Build sidecar and Tauri shell
+        run: |
+          cargo build --locked --manifest-path crates/dsh-sidecar/Cargo.toml
+          # tauri-build asserts this bundle resource path exists. Runtime
+          # staging is intentionally not needed for static analysis.
+          mkdir -p src-tauri/resources/runtime
+          cargo build --locked --manifest-path src-tauri/Cargo.toml
 
       - name: Perform CodeQL analysis
         uses: github/codeql-action/analyze@f3712979fa5f215279b101dd0a2e3bdfb4353324  # v3 (SHA-pinned, peeled commit)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -35,7 +35,7 @@ DSH Desktop 是社区桌面打包层：Tauri 2 壳 + Rust `dsh-sidecar`
 - **进程树保证**：unix 进程组 + sigaction；Windows Job Object
   （KILL_ON_JOB_CLOSE）+ 私有隐藏控制台。sidecar 消失（任何原因）即整树
   消失；存活性心跳在进程挂死（活着但无响应）时杀树并交由壳按退避上限重启。
-- **DSH_HOME 0700** 且拒绝符号链接；安装包内 harness 子树零符号链接
+- **DSH_HOME 0700**，拒绝符号链接与文件系统根目录；安装包内 harness 子树零符号链接
   （构建期断言 + 安装包验证）。
 - **供应链**：Node 下载 SHA-256 钉死（官方 SHASUMS256 核对）；npm 安装脚本
   白名单（strict-allow-scripts）；cargo-vet（社区审计集 + 本仓库审计）与
@@ -47,15 +47,17 @@ DSH Desktop 是社区桌面打包层：Tauri 2 壳 + Rust `dsh-sidecar`
   `entryRevision` 后才能进入受控安装；预设链接只接受直出
   `https://cordis.run/api/presets/<slug>/download` 的 200 zip 响应且不跟随重定向。
   未确认前不会 spawn 任何进程或下载预设，非法链接直接丢弃且不会弹窗。
-- **CSP 与桌面 IPC**：`withGlobalTauri: false`；35 个桌面命令经 AppManifest
+- **CSP 与桌面 IPC**：`withGlobalTauri: false`；47 个桌面命令经 AppManifest
   ACL 仅授权 bootstrap 窗口。
 
 ## 已知边界（请如实预期）
 
-- **未签名分发**：当前发布未做代码签名/公证。Windows SmartScreen 与 macOS
-  Gatekeeper 会提示并需要用户手动放行；macOS 首次启动可能需
-  `xattr -cr` 或系统设置放行（见 README）。签名/公证接入后，
-  `verify-signing.ts` 会在 CI 强制验签（fail-closed）。
+- **签名与分发边界**：自 v0.2.9 起，公开 macOS DMG 使用 Developer ID
+  签名并经 Apple 公证；CI 对已配置的证书路径执行 `codesign`、Gatekeeper 与
+  staple 验证，任一失败均阻断发布。Windows Authenticode 仍取决于发布时是否
+  配置 Windows 证书：未配置时安装包会有意保持未签名，可能触发 SmartScreen；
+  配置后 CI 强制验证其为 `Valid`。请只从本仓库 Releases 下载，不要把 SHA-256
+  或 Tauri updater 签名误认为 Authenticode。
 - **存活心跳的语义边界**：默认连续 4 次探针无响应（约 40 秒）判定挂死并
   自动重启；极端长同步任务阻塞事件循环可能触发。旋钮：
   `DSH_HEARTBEAT_INTERVAL_MS`（0=禁用）/`DSH_HEARTBEAT_FAIL_LIMIT`/
@@ -106,5 +108,5 @@ DSH Desktop 是社区桌面打包层：Tauri 2 壳 + Rust `dsh-sidecar`
 
 ## 支持版本
 
-仅支持最新发布版（当前 v0.2.11）。旧版本不提供安全修复；发现漏洞请先
-升级到最新版再验证是否仍可复现。
+仅支持 GitHub Releases 中标记为 **Latest** 的发布版。旧版本不提供安全修复；
+发现漏洞请先升级到最新版再验证是否仍可复现。

--- a/scripts/lib/workflow-safety.test.ts
+++ b/scripts/lib/workflow-safety.test.ts
@@ -6,6 +6,24 @@ const workflow = readFileSync(
   new URL("../../.github/workflows/test.yml", import.meta.url),
   "utf8",
 );
+const codeqlWorkflow = readFileSync(
+  new URL("../../.github/workflows/codeql.yml", import.meta.url),
+  "utf8",
+);
+
+test("Rust CodeQL compiles both the sidecar and the Tauri security boundary", () => {
+  assert.match(codeqlWorkflow, /^  contents: read$/m);
+  assert.match(codeqlWorkflow, /libwebkit2gtk-4\.1-dev/);
+  assert.match(
+    codeqlWorkflow,
+    /cargo build --locked --manifest-path crates\/dsh-sidecar\/Cargo\.toml/,
+  );
+  assert.match(
+    codeqlWorkflow,
+    /cargo build --locked --manifest-path src-tauri\/Cargo\.toml/,
+  );
+  assert.match(codeqlWorkflow, /mkdir -p src-tauri\/resources\/runtime/);
+});
 
 test("macOS shell path gate validates event SHAs and fails closed", () => {
   const start = workflow.indexOf("      - name: Detect macOS shell changes");

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1290,18 +1290,18 @@ pub async fn preview_preset(
     let path = match rx.recv().map_err(|e| e.to_string()) {
         Ok(Some(path)) => path,
         Ok(None) => {
-            arbiter.release();
+            let _ = arbiter.release(crate::deep_link::PendingInstallKind::LocalPresetPicker);
             return Err("cancelled".to_string());
         }
         Err(error) => {
-            arbiter.release();
+            let _ = arbiter.release(crate::deep_link::PendingInstallKind::LocalPresetPicker);
             return Err(error);
         }
     };
     let preview = match crate::preset::inspect_archive(&path) {
         Ok(preview) => preview,
         Err(error) => {
-            arbiter.release();
+            let _ = arbiter.release(crate::deep_link::PendingInstallKind::LocalPresetPicker);
             return Err(error);
         }
     };
@@ -1328,7 +1328,7 @@ pub fn cancel_preset_preview(
         .0
         .lock()
         .unwrap_or_else(|poisoned| poisoned.into_inner()) = None;
-    arbiter.release();
+    let _ = arbiter.release(crate::deep_link::PendingInstallKind::LocalPresetPicker);
 }
 
 /// Install the previously previewed archive (two-phase: the confirmation
@@ -1363,7 +1363,7 @@ pub fn import_preset(
                 .0
                 .lock()
                 .unwrap_or_else(|poisoned| poisoned.into_inner()) = None;
-            arbiter.release();
+            let _ = arbiter.release(crate::deep_link::PendingInstallKind::LocalPresetPicker);
             Ok(id)
         }
         Err(e) => Err(e),
@@ -2520,7 +2520,7 @@ pub fn dismiss_pending_plugin_install(
     arbiter: State<'_, crate::deep_link::InstallArbiter>,
 ) {
     pending.clear();
-    arbiter.release();
+    let _ = arbiter.release(crate::deep_link::PendingInstallKind::Plugin);
 }
 
 // ---------------------------------------------------------------------------
@@ -2746,21 +2746,28 @@ pub fn dismiss_remote_preset(
     arbiter: State<'_, crate::deep_link::InstallArbiter>,
     runtime: State<'_, Runtime>,
 ) -> Result<(), String> {
-    let removed = pending.dismiss(&request_id)?;
+    // A failed or partially initialized Runtime must not make a user-visible
+    // cancel permanently occupy the global modal slot. The archive path, when
+    // present, is enough to remove its private request directory; the
+    // DSH_HOME-based cleanup below is therefore best effort.
     let dsh_home = runtime
         .state
         .lock()
         .unwrap_or_else(|poisoned| poisoned.into_inner())
         .dsh_home
-        .clone()
-        .ok_or_else(|| "DSH_HOME is unknown".to_string())?;
+        .clone();
+    let removed = pending.dismiss(&request_id)?;
     if let Some(archive) = removed {
         if let Some(dir) = archive.parent() {
             let _ = std::fs::remove_dir_all(dir);
         }
     }
-    remove_remote_preset_dir(std::path::Path::new(&dsh_home), &request_id);
-    arbiter.release();
+    if let Some(dsh_home) = dsh_home {
+        remove_remote_preset_dir(std::path::Path::new(&dsh_home), &request_id);
+    } else {
+        eprintln!("[preset] DSH_HOME unavailable while dismissing remote preset; request data cleanup deferred");
+    }
+    let _ = arbiter.release(crate::deep_link::PendingInstallKind::RemotePreset);
     Ok(())
 }
 
@@ -2789,7 +2796,7 @@ pub async fn confirm_remote_preset_download(
                 request_id: &str,
                 dir: Option<&std::path::Path>| {
         if pending.fail_download(request_id) {
-            arbiter.release();
+            let _ = arbiter.release(crate::deep_link::PendingInstallKind::RemotePreset);
         }
         if let Some(dir) = dir {
             let _ = std::fs::remove_dir_all(dir);
@@ -2803,7 +2810,7 @@ pub async fn confirm_remote_preset_download(
             // matching request is pending, release the arbiter so a stale
             // frontend retry cannot leave the modal permanently occupied.
             if pending.snapshot().is_none() {
-                arbiter.release();
+                let _ = arbiter.release(crate::deep_link::PendingInstallKind::RemotePreset);
             }
             return Err(error);
         }
@@ -2923,7 +2930,7 @@ pub fn import_remote_preset(
         Ok(id) => {
             pending.finish_install_success(&request_id);
             remove_remote_preset_dir(std::path::Path::new(&dsh_home), &request_id);
-            arbiter.release();
+            let _ = arbiter.release(crate::deep_link::PendingInstallKind::RemotePreset);
             Ok(id)
         }
         Err(error) => {

--- a/src-tauri/src/deep_link.rs
+++ b/src-tauri/src/deep_link.rs
@@ -158,11 +158,22 @@ impl InstallArbiter {
         true
     }
 
-    pub fn release(&self) {
-        *self
+    /// Release the modal slot only when `expected` is still its owner.
+    ///
+    /// Commands are independently callable from the bootstrap capability, so
+    /// a stale cancel request must not clear another install flow's lock.
+    /// Returning false lets callers deliberately treat that situation as a
+    /// no-op rather than turning a UI race into cross-flow authorization.
+    pub fn release(&self, expected: PendingInstallKind) -> bool {
+        let mut slot = self
             .inner
             .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner()) = None;
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        if *slot != Some(expected) {
+            return false;
+        }
+        *slot = None;
+        true
     }
 }
 
@@ -183,7 +194,7 @@ impl PendingRemotePreset {
             Ok(id) => id,
             Err(error) => {
                 eprintln!("[deep-link] cannot generate request_id: {error}");
-                arbiter.release();
+                let _ = arbiter.release(PendingInstallKind::RemotePreset);
                 return None;
             }
         };
@@ -192,7 +203,7 @@ impl PendingRemotePreset {
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner());
         if slot.is_some() {
-            arbiter.release();
+            let _ = arbiter.release(PendingInstallKind::RemotePreset);
             return None;
         }
         *slot = Some(RemotePresetSession {
@@ -1159,6 +1170,15 @@ mod tests {
     }
 
     #[test]
+    fn remote_dismiss_releases_its_own_modal_slot() {
+        let (pending, arbiter) = remote_pending();
+        let id = pending.snapshot().unwrap().request_id;
+        assert!(pending.dismiss(&id).is_ok());
+        assert!(arbiter.release(PendingInstallKind::RemotePreset));
+        assert!(arbiter.try_acquire(PendingInstallKind::Plugin));
+    }
+
+    #[test]
     fn remote_fail_download_clears_only_matching_request() {
         let (pending, arbiter) = remote_pending();
         let id = pending.snapshot().unwrap().request_id;
@@ -1167,7 +1187,7 @@ mod tests {
         assert!(pending.snapshot().is_some());
         assert!(pending.fail_download(&id));
         assert!(pending.snapshot().is_none());
-        arbiter.release();
+        assert!(arbiter.release(PendingInstallKind::RemotePreset));
     }
 
     #[test]
@@ -1216,11 +1236,13 @@ mod tests {
     }
 
     #[test]
-    fn install_arbiter_release_allows_next_flow() {
+    fn install_arbiter_release_allows_only_the_current_owner_to_continue() {
         let arbiter = InstallArbiter::default();
         assert!(arbiter.try_acquire(PendingInstallKind::Plugin));
         assert!(!arbiter.try_acquire(PendingInstallKind::RemotePreset));
-        arbiter.release();
+        assert!(!arbiter.release(PendingInstallKind::RemotePreset));
+        assert!(!arbiter.try_acquire(PendingInstallKind::LocalPresetPicker));
+        assert!(arbiter.release(PendingInstallKind::Plugin));
         assert!(arbiter.try_acquire(PendingInstallKind::RemotePreset));
     }
 

--- a/src-tauri/src/paths.rs
+++ b/src-tauri/src/paths.rs
@@ -9,7 +9,7 @@
 //! `harness/` subfolder — deliberately isolated from the CLI's `~/.dsh` so a
 //! pinned Desktop runtime can never corrupt a user's CLI profiles.
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use tauri::{path::BaseDirectory, Manager};
 
 #[derive(Clone)]
@@ -18,6 +18,20 @@ pub struct RuntimePaths {
     pub node: PathBuf,
     pub harness_dir: PathBuf,
     pub dsh_home: PathBuf,
+}
+
+/// Keep a developer override from targeting a filesystem root. The harness
+/// initializer protects its data root with mode 0700 on Unix, so accepting
+/// `/`, a drive root, or a UNC share root would make an accidental privileged
+/// launch capable of changing a system directory's permissions.
+fn validate_dsh_home_override(home: &Path) -> Result<(), String> {
+    if home.as_os_str().is_empty() || !home.is_absolute() {
+        return Err("DSH_HOME must be a non-empty absolute path".to_string());
+    }
+    if home.parent().is_none() {
+        return Err("DSH_HOME must not be a filesystem root".to_string());
+    }
+    Ok(())
 }
 
 pub fn resolve(app: &tauri::AppHandle) -> Result<RuntimePaths, String> {
@@ -60,9 +74,7 @@ pub fn resolve(app: &tauri::AppHandle) -> Result<RuntimePaths, String> {
 
     let dsh_home = if let Ok(h) = std::env::var("DSH_HOME") {
         let home = PathBuf::from(&h);
-        if h.is_empty() || !home.is_absolute() {
-            return Err("DSH_HOME must be a non-empty absolute path".to_string());
-        }
+        validate_dsh_home_override(&home)?;
         home
     } else {
         app.path()
@@ -77,4 +89,44 @@ pub fn resolve(app: &tauri::AppHandle) -> Result<RuntimePaths, String> {
         harness_dir,
         dsh_home,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::validate_dsh_home_override;
+    use std::path::Path;
+
+    #[test]
+    fn dsh_home_override_rejects_filesystem_root() {
+        // POSIX permits repeated leading separators. They still name the same
+        // root and must not bypass the permission-changing guard.
+        for root in [Path::new("/"), Path::new("//"), Path::new("///")] {
+            assert!(
+                validate_dsh_home_override(root).is_err(),
+                "must reject {root:?}"
+            );
+        }
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn dsh_home_override_rejects_a_windows_drive_root() {
+        assert!(validate_dsh_home_override(Path::new(r"C:\")).is_err());
+    }
+
+    #[test]
+    fn dsh_home_override_keeps_the_non_empty_absolute_path_requirement() {
+        for invalid in [Path::new(""), Path::new("relative/dsh-home")] {
+            assert!(
+                validate_dsh_home_override(invalid).is_err(),
+                "must reject {invalid:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn dsh_home_override_accepts_a_real_absolute_child_directory() {
+        let child = std::env::temp_dir().join("dsh-desktop-test-home");
+        assert!(validate_dsh_home_override(&child).is_ok());
+    }
 }

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -478,6 +478,17 @@
     marketDetailBusy = false;
   }
 
+  async function fetchMarketInstallPreview(slug: string) {
+    marketError = null;
+    try {
+      // This refetches the detail with ETag revalidation. The modal then
+      // presents its current entryRevision for an explicit user confirmation.
+      marketConfirm = await marketPrepareInstall(slug);
+    } catch (e) {
+      marketError = marketFailureMessage("market.prepareFailed", e);
+    }
+  }
+
   async function prepareMarketInstall(slug: string) {
     if (
       pluginBusy ||
@@ -487,15 +498,11 @@
       recoveryOverview?.transaction
     ) return;
     marketPreparing = true;
-    marketError = null;
     try {
-      // This refetches the detail with ETag revalidation. The modal then
-      // presents its current entryRevision for an explicit user confirmation.
-      marketConfirm = await marketPrepareInstall(slug);
-    } catch (e) {
-      marketError = marketFailureMessage("market.prepareFailed", e);
+      await fetchMarketInstallPreview(slug);
+    } finally {
+      marketPreparing = false;
     }
-    marketPreparing = false;
   }
 
   async function doMarketInstall(item: MarketPluginSummary) {
@@ -1127,15 +1134,24 @@
   async function confirmPluginInstallRequest() {
     const request = pluginInstallRequest;
     if (!request || pluginBusy || marketPreparing) return;
+    // Take the UI-side market guard before releasing the Rust-owned plugin
+    // slot. A second deep link arriving during the IPC round trip is then
+    // rejected by the already-tested frontend arbiter instead of opening a
+    // second confirmation surface.
+    marketPreparing = true;
     pluginInstallRequest = null;
     try {
-      await dismissPendingPluginInstall();
-    } catch {
-      // The request was already removed from the UI. The market command still
-      // validates the Rust-derived slug and freshly revalidates the entry
-      // before any profile mutation.
+      try {
+        await dismissPendingPluginInstall();
+      } catch {
+        // The request was already removed from the UI. The market command
+        // still validates the Rust-derived slug and freshly revalidates the
+        // entry before any profile mutation.
+      }
+      await fetchMarketInstallPreview(request.slug);
+    } finally {
+      marketPreparing = false;
     }
-    await prepareMarketInstall(request.slug);
   }
 
   // Browsers notify language-preference changes, but do not expose a portable


### PR DESCRIPTION
## Summary
- Require install-arbiter releases to match the owning flow, and keep remote-preset cancellation recoverable when Runtime is only partially initialized.
- Hold the frontend market guard before releasing a deep-link slot, preventing a second confirmation surface during the IPC handoff.
- Reject filesystem-root `DSH_HOME` overrides before Unix permission hardening can touch a system root.
- Compile both Rust security boundaries in CodeQL and grant the workflow explicit read access.
- Correct the security policy’s command count, signing/notarization boundary, and supported-version rule.

## Validation
- `pnpm check`
- `pnpm check:scripts`
- `pnpm test:scripts` (105 passing)
- `pnpm test:frontend` (17 passing)
- `cargo fmt --check` (both crates)
- `cargo clippy --all-targets -- -D warnings` (both crates)
- `cargo nextest run` (Tauri 228 + sidecar 42)
- `cargo deny check` and `cargo vet --locked`
- `pnpm verify:command-contract`
- `pnpm release:preflight`
- `actionlint` and `git diff --check`