### PR TITLE
fix: verify published release checksum sidecars

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1300,6 +1300,15 @@ jobs:
           tag_name: ${{ github.ref_name }}
           files: artifacts/**/*
 
+      # The upload action normalizes public asset filenames. Inspect the draft
+      # through GitHub's API before publishing so each sidecar names the asset
+      # users can actually download and matches GitHub's server-side digest.
+      - name: Audit draft Release SHA-256 sidecars
+        run: node scripts/verify-release-checksums.ts --tag "$RELEASE_TAG"
+        env:
+          RELEASE_TAG: ${{ github.ref_name }}
+          GH_TOKEN: ${{ github.token }}
+
       # The updater manifest needs the ABSOLUTE asset URLs that only exist
       # after the release is created; fail-closed if an exact NSIS
       # architecture has no artifact+sig pair. Generic Windows targets are

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -698,7 +698,7 @@ dependencies = [
 
 [[package]]
 name = "deepseek-harness-desktop"
-version = "0.2.14"
+version = "0.2.15"
 dependencies = [
  "dsh-sidecar",
  "flate2",

--- a/README.en.md
+++ b/README.en.md
@@ -9,7 +9,7 @@ intact; the desktop layer only handles lifecycle and the security boundary.
 | Website | [dsharness.app](https://dsharness.app) |
 | Plugin marketplace | [cordis.run](https://cordis.run) |
 | Docs | [SECURITY](SECURITY.md) · [FORKING](FORKING.md) · [RELEASING](RELEASING.md) · [AGENTS](AGENTS.md) |
-| Current version | v0.2.14 · Windows x64/ARM64 EXE/MSI · macOS x64/arm64 DMG · Linux x64/arm64 AppImage/DEB/RPM/Flatpak · signed/notarized macOS · [中文](README.md) |
+| Current version | v0.2.15 · Windows x64/ARM64 EXE/MSI · macOS x64/arm64 DMG · Linux x64/arm64 AppImage/DEB/RPM/Flatpak · signed/notarized macOS · [中文](README.md) |
 
 > **macOS users**: starting with v0.2.9, DMGs are signed with Developer ID
 > Application, notarized by Apple, stapled, and rechecked with Gatekeeper.
@@ -18,7 +18,7 @@ intact; the desktop layer only handles lifecycle and the security boundary.
 
 | Platform | GitHub Release packages |
 |---|---|
-| Windows (from the next release) | Native x64 and ARM64: multilingual NSIS `*-setup.exe`, WiX `.msi` |
+| Windows | Native x64 and ARM64: multilingual NSIS `*-setup.exe`, WiX `.msi` |
 | macOS | arm64 and x64 `.dmg` |
 | Linux | x64 and arm64 `.AppImage`, `.deb`, `.rpm`, `.flatpak` |
 
@@ -38,7 +38,7 @@ actual `ProductLanguage`, so the suffix is never merely cosmetic.
 | | |
 |---|---|
 | 🔌 **Plugin ecosystem** | Cordis plugins ship with the bundle; in-app marketplace search/install; safe preset import/export |
-| 🔄 **Auto-updater** (next release: Windows NSIS) | x64 and ARM64 payloads are separately verified by an embedded minisign pubkey; MSI, Store, macOS and Linux retain their own safe update paths |
+| 🔄 **Auto-updater** (Windows NSIS) | x64 and ARM64 payloads are separately verified by an embedded minisign pubkey; MSI, Store, macOS and Linux retain their own safe update paths |
 | 💓 **Hung-process self-healing** | Heartbeat detects an unresponsive Harness and restarts it (backoff + cap) |
 | 🛡️ **Security boundary** | Harness window has zero IPC; app commands granted to the local window only; env sanitization |
 | 🔒 **Privacy defaults** | Session telemetry OFF; child env sanitized (NODE_OPTIONS, loader injection keys, …) |
@@ -187,7 +187,7 @@ deny.toml + supply-chain/   policy & audits   .github/workflows/   CI
   Partner Center upload, not GitHub Release assets.
 - Harness upgrades follow the startup-contract checklist in
   [AGENTS.md](AGENTS.md); the release flow lives in [RELEASING.md](RELEASING.md).
-- Current release: v0.2.14, including six native build targets, Windows
+- Current release: v0.2.15, including six native build targets, Windows
   x64/ARM64 installers and English/Simplified-Chinese MSI packages, macOS
   Developer ID signing/notarization, the Cordis v4 marketplace contract,
   diagnostic resilience, and safe plugin recovery. The historical v0.2.13

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 | 官网 | [dsharness.app](https://dsharness.app) |
 | 插件市场 | [cordis.run](https://cordis.run) |
 | 文档 | [SECURITY](SECURITY.md) · [FORKING](FORKING.md) · [RELEASING](RELEASING.md) · [AGENTS](AGENTS.md) |
-| 当前版本 | v0.2.14 · Windows x64/ARM64 EXE/MSI · macOS x64/arm64 DMG · Linux x64/arm64 AppImage/DEB/RPM/Flatpak · macOS 已签名/公证 · [English](README.en.md) |
+| 当前版本 | v0.2.15 · Windows x64/ARM64 EXE/MSI · macOS x64/arm64 DMG · Linux x64/arm64 AppImage/DEB/RPM/Flatpak · macOS 已签名/公证 · [English](README.en.md) |
 
 > **macOS 用户**：v0.2.9 起，DMG 使用 Developer ID Application 签名并经
 > Apple 公证、staple 与 Gatekeeper 复验。请只从本仓库 Releases 下载；若官方
@@ -16,7 +16,7 @@
 
 | 平台 | GitHub Release 安装包 |
 |---|---|
-| Windows（下一版起） | 原生 x64 与 ARM64：双语 NSIS `*-setup.exe`、WiX `.msi` |
+| Windows | 原生 x64 与 ARM64：双语 NSIS `*-setup.exe`、WiX `.msi` |
 | macOS | arm64 与 x64 `.dmg` |
 | Linux | x64 与 arm64 `.AppImage`、`.deb`、`.rpm`、`.flatpak` |
 
@@ -35,7 +35,7 @@ Desktop 控制器的可用语言：两种包内的控制器都支持简体中文
 | | |
 |---|---|
 | 🔌 **插件生态** | Cordis 插件体系随包携带；插件市场浏览/搜索/一键安装；预设安全导入导出；离线 `.tgz` 侧载 |
-| 🔄 **自动更新**（下一版起：Windows NSIS） | x64/ARM64 更新包各自由内嵌 minisign 公钥校验；MSI、Store、macOS 与 Linux 走其各自安全更新路径 |
+| 🔄 **自动更新**（Windows NSIS） | x64/ARM64 更新包各自由内嵌 minisign 公钥校验；MSI、Store、macOS 与 Linux 走其各自安全更新路径 |
 | 💓 **挂死自愈** | 心跳检测 Harness「活着但无响应」并自动重启（退避+上限） |
 | 🛡️ **安全边界** | Harness 窗口零 IPC 权限；桌面命令仅授权本地窗口；环境消毒 |
 | 🔒 **隐私默认值** | 会话遥测默认关闭；子进程环境消毒（NODE_OPTIONS/loader 注入键等） |
@@ -168,6 +168,6 @@ deny.toml + supply-chain/   供应链策略与审计     .github/workflows/   CI
 - CI：push/PR 跑质量门 + 三平台冒烟；打 `v*` tag 触发六个**原生**构建目标（Windows x64/ARM64、macOS x64/arm64、Linux x64/arm64）及 Store MSIX x64/arm64，再经完整资产清单门禁创建 draft release、生成并校验 `latest.json`，最后才自动公开 Release。每一 lane 都会同时核对 Node、Rust host triple 与目标架构；Windows on ARM 另加 x64 兼容性安装 smoke，不把它误称为原生构建。
 - Microsoft Store：`v*` tag 同时构建 x64/arm64 MSIX（`build-msix` job，Store 模式关闭应用内更新并限制插件为 cordis.run 审核列表）。MSIX 产物作为 workflow artifact 下载后上传 Partner Center，不发布到 GitHub Release。
 - Harness 升级走 [AGENTS.md](AGENTS.md)「启动契约」清单；发布流程见 [RELEASING.md](RELEASING.md)。
-- 当前发布版本：v0.2.14；包含六个原生构建目标、Windows x64/ARM64 安装包与中英文 MSI、macOS Developer ID 签名/公证、Cordis v4 市场契约、诊断韧性与安全插件恢复。历史 v0.2.13 文件名中的 `_en-US` 只表示其安装向导为英文。
+- 当前发布版本：v0.2.15；包含六个原生构建目标、Windows x64/ARM64 安装包与中英文 MSI、macOS Developer ID 签名/公证、Cordis v4 市场契约、诊断韧性与安全插件恢复。历史 v0.2.13 文件名中的 `_en-US` 只表示其安装向导为英文。
 - 已知边界：Windows GitHub 安装包尚未配置 Authenticode，可能触发 SmartScreen；应用内更新只接受与当前 CPU 架构及 NSIS 安装方式完全匹配的 payload，MSI 不会自动切换到 NSIS；macOS 仍待“公证后 updater archive + 原生升级 smoke”闭环；Linux 包当前以 SHA-256 保护，尚无独立软件仓库签名。
 - 许可：MIT；内置 Harness 及全部依赖的 LICENSE 随包附于 `runtime/harness/licenses/`。

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,8 +1,9 @@
 # RELEASING.md — 发布手册
 
 发布流程全自动：在 `main` 上打 `v*` tag 即触发完整流水线（质量门 → 六个原生目标
-构建 → 内容/签名验证 → draft release → `latest.json` 验证 → Publish）。草稿在
-全部公开资产与更新清单通过精确校验后才会自动公开；中途失败会保留为未公开草稿。
+构建 → 内容/签名验证 → draft release → 远端 SHA-256 sidecar 审计 → `latest.json`
+验证 → Publish）。草稿在全部公开资产、GitHub 实际资产名/摘要与更新清单通过精确
+校验后才会自动公开；中途失败会保留为未公开草稿。
 人工职责是版本对齐、打 tag，并在发布后抽查公开资产。
 
 ## 1. 版本对齐（发布前本地完成）
@@ -62,8 +63,9 @@ git push origin v0.2.1
 6. `release`：tag 绑定 preflight（`--expect-tag`）→ 只下载
    `deepseek-harness-desktop-*` 公开制品 → 校验 16 个安装包、16 个 checksum、
    2 个 Windows NSIS updater signature 且没有 MSIX/未知文件 → 创建 **draft** GitHub
-   Release → 上传并校验 `latest.json` → 自动 Publish。若最后两步失败，草稿保持
-   不公开，绝不会让客户端读取半成品更新清单。
+Release → 通过 GitHub API 逐一核对上传后资产名、服务端 SHA-256 与 sidecar 内容
+→ 上传并校验 `latest.json` → 自动 Publish。若最后三步失败，草稿保持不公开，绝不会
+让客户端读取半成品更新清单。
 
 发布矩阵只使用 GitHub 标准 hosted runner：`windows-latest` / `windows-11-arm`、
 `macos-15-intel` / `macos-15`、`ubuntu-22.04` / `ubuntu-22.04-arm`。公开仓库的
@@ -143,7 +145,9 @@ Desktop 工作区直接改为公开发布。
    只表示安装向导语言，不是控制器语言限制；NSIS 是一个内含中英文资源的安装器。
    macOS 两个 job 会在本地强制检查各自 `.app.tar.gz.sig` 已生成，但在 updater
    尚未启用期间不上传这些同名、无对应公开更新包的 build-only tripwire。
-2. 抽查 checksum：`shasum -a 256 <下载文件>` 对照 `.sha256` 内容。
+2. 抽查 checksum：从同一 Release 下载安装包和其 `.sha256` 后执行
+   `sha256sum -c <文件>.sha256`（macOS 可用 `shasum -a 256 <下载文件>` 对照
+   sidecar 内容）。
 3. 手动下载安装验证（未签名构建：确认 SmartScreen/Gatekeeper 放行路径可走通）。
 4. 点 **Publish release**。
 5. 记录下载基线：`node scripts/release-stats.ts`（公开下载计数是本项目

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "deepseek-harness-desktop",
   "private": true,
-  "version": "0.2.14",
+  "version": "0.2.15",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/runtime/runtime-manifest.json
+++ b/runtime/runtime-manifest.json
@@ -1,5 +1,5 @@
 {
-  "desktopVersion": "0.2.14",
+  "desktopVersion": "0.2.15",
   "harnessVersion": "0.1.1-rc.2",
   "nodeVersion": "24.19.0",
   "sidecarVersion": "0.2.5",

--- a/scripts/checksums.ts
+++ b/scripts/checksums.ts
@@ -14,6 +14,7 @@ import {
   isWindowsWixInstallerLocale,
   type WindowsWixInstallerLocale,
 } from "./lib/windows-installer-locales.ts";
+import { sha256SidecarContent } from "./lib/release-checksums.ts";
 
 const bundleArg = process.argv.indexOf("--bundle");
 const bundleType = bundleArg >= 0 ? process.argv[bundleArg + 1] : undefined;
@@ -50,6 +51,6 @@ for await (const chunk of stream) {
 }
 const digest = hash.digest("hex");
 const out = `${artifact}.sha256`;
-writeFileSync(out, `${digest}  ${basename(artifact)}\n`);
+writeFileSync(out, sha256SidecarContent(digest, basename(artifact)));
 ok(`${basename(artifact)} sha256 → ${digest}`);
 ok(`written ${out}`);

--- a/scripts/lib/release-artifacts.test.ts
+++ b/scripts/lib/release-artifacts.test.ts
@@ -137,6 +137,19 @@ test("in-app updates publish only exact NSIS architecture targets", () => {
   assert.doesNotMatch(workflow, /--platforms windows-x86_64(?:\s|$)/);
 });
 
+test("the draft release is checksum-audited against GitHub's uploaded asset identities", () => {
+  const workflow = readFileSync(
+    new URL("../../.github/workflows/release.yml", import.meta.url),
+    "utf8",
+  );
+  const publish = workflow.indexOf("      - name: Publish release");
+  const audit = workflow.indexOf("      - name: Audit draft Release SHA-256 sidecars");
+  const updater = workflow.indexOf("      - name: Publish updater manifest (latest.json)");
+  assert.ok(publish >= 0 && audit > publish && updater > audit);
+  assert.match(workflow, /node scripts\/verify-release-checksums\.ts --tag "\$RELEASE_TAG"/);
+  assert.match(workflow, /GH_TOKEN: \$\{\{ github\.token \}\}/);
+});
+
 test("both reusable quality jobs checkout the requested release revision", () => {
   const workflow = readFileSync(
     new URL("../../.github/workflows/quality.yml", import.meta.url),

--- a/scripts/lib/release-checksums.test.ts
+++ b/scripts/lib/release-checksums.test.ts
@@ -1,0 +1,61 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  githubReleaseAssetName,
+  parseSha256Sidecar,
+  releaseChecksumProblems,
+  sha256SidecarContent,
+} from "./release-checksums.ts";
+
+const digest = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+const installer = {
+  id: 10,
+  name: "DSH.Desktop_0.2.15_x64-setup.exe",
+  digest: `sha256:${digest}`,
+};
+const sidecar = { id: 11, name: `${installer.name}.sha256` };
+
+test("checksum sidecars use the GitHub Release asset name, not the local name", () => {
+  assert.equal(
+    githubReleaseAssetName("DSH Desktop_0.2.15_x64-setup.exe"),
+    installer.name,
+  );
+  assert.equal(
+    sha256SidecarContent(digest, "DSH Desktop_0.2.15_x64-setup.exe"),
+    `${digest}  ${installer.name}\n`,
+  );
+  assert.throws(() => githubReleaseAssetName("../DSH Desktop.exe"), /unsafe local release asset filename/);
+  assert.throws(() => githubReleaseAssetName("DSH\tDesktop.exe"), /unsafe local release asset filename/);
+});
+
+test("draft release checksum audit accepts the exact uploaded asset identity and digest", () => {
+  const contents = new Map([[sidecar.id, `${digest}  ${installer.name}\n`]]);
+  assert.deepEqual(releaseChecksumProblems([installer], [sidecar], contents), []);
+  assert.deepEqual(parseSha256Sidecar(contents.get(sidecar.id) ?? ""), {
+    digest,
+    filename: installer.name,
+  });
+});
+
+test("draft release checksum audit rejects upload-time filename and digest drift", () => {
+  const oldLocalName = "DSH Desktop_0.2.15_x64-setup.exe";
+  const wrongName = new Map([[sidecar.id, `${digest}  ${oldLocalName}\n`]]);
+  assert.deepEqual(releaseChecksumProblems([installer], [sidecar], wrongName), [
+    `SHA-256 sidecar filename mismatch: ${sidecar.name} names ${oldLocalName}, published asset is ${installer.name}`,
+  ]);
+
+  const wrongDigest = new Map([[sidecar.id, `${"f".repeat(64)}  ${installer.name}\n`]]);
+  assert.deepEqual(releaseChecksumProblems([installer], [sidecar], wrongDigest), [
+    `SHA-256 sidecar digest mismatch: ${sidecar.name} has sha256:${"f".repeat(64)}, GitHub reports sha256:${digest} for ${installer.name}`,
+  ]);
+});
+
+test("draft release checksum audit rejects missing and orphan sidecars", () => {
+  assert.deepEqual(releaseChecksumProblems([installer], [], new Map()), [
+    `missing SHA-256 sidecar for published asset: ${installer.name}`,
+  ]);
+  assert.deepEqual(
+    releaseChecksumProblems([], [{ id: 12, name: "unrelated.txt.sha256" }], new Map()),
+    ["orphan SHA-256 sidecar on public release: unrelated.txt.sha256"],
+  );
+});

--- a/scripts/lib/release-checksums.ts
+++ b/scripts/lib/release-checksums.ts
@@ -1,0 +1,117 @@
+// GitHub Release uploads normalize spaces in an asset filename to dots. Keep
+// the name recorded in a SHA-256 sidecar aligned with the *published* asset,
+// not its local staging filename. The draft-release audit below independently
+// verifies this contract against the API before a release becomes public.
+
+import { basename } from "node:path";
+
+export interface GithubReleaseAsset {
+  id: number;
+  name: string;
+  digest?: string | null;
+}
+
+export interface ParsedSha256Sidecar {
+  digest: string;
+  filename: string;
+}
+
+function isSafeAssetBasename(name: string): boolean {
+  return (
+    name.length > 0 &&
+    name === basename(name) &&
+    !name.startsWith(".") &&
+    !/[\\/:\u0000-\u001f\u007f]/.test(name) &&
+    name.trim() === name
+  );
+}
+
+/**
+ * Return the reviewed name exposed by the GitHub Release upload action.
+ *
+ * The build emits local Tauri filenames such as `DSH Desktop_…`; GitHub's
+ * upload path exposes them as `DSH.Desktop_…`. Other whitespace is rejected
+ * rather than guessed, and the draft audit remains the authoritative final
+ * check in case the host changes its normalization behavior.
+ */
+export function githubReleaseAssetName(localName: string): string {
+  if (!isSafeAssetBasename(localName) || /\s/.test(localName.replaceAll(" ", ""))) {
+    throw new Error(`unsafe local release asset filename: ${JSON.stringify(localName)}`);
+  }
+  return localName.replaceAll(" ", ".");
+}
+
+export function sha256SidecarContent(digest: string, localAssetName: string): string {
+  if (!/^[a-f0-9]{64}$/.test(digest)) {
+    throw new Error("SHA-256 digest must be 64 lowercase hexadecimal characters");
+  }
+  return `${digest}  ${githubReleaseAssetName(localAssetName)}\n`;
+}
+
+export function parseSha256Sidecar(content: string): ParsedSha256Sidecar | null {
+  const match = /^([a-f0-9]{64})  ([^\r\n]+)\r?\n$/.exec(content);
+  if (!match || !isSafeAssetBasename(match[2])) return null;
+  return { digest: match[1], filename: match[2] };
+}
+
+/**
+ * Validate all public installer / SHA-256 pairs visible on a draft release.
+ * `sidecarContents` maps an asset id to its downloaded text content.
+ */
+export function releaseChecksumProblems(
+  installers: readonly GithubReleaseAsset[],
+  sidecars: readonly GithubReleaseAsset[],
+  sidecarContents: ReadonlyMap<number, string>,
+): string[] {
+  const problems: string[] = [];
+  const installerByName = new Map<string, GithubReleaseAsset>();
+  const sidecarByName = new Map<string, GithubReleaseAsset>();
+
+  for (const installer of installers) {
+    if (installerByName.has(installer.name)) {
+      problems.push(`duplicate public installer asset: ${installer.name}`);
+    }
+    installerByName.set(installer.name, installer);
+  }
+  for (const sidecar of sidecars) {
+    if (sidecarByName.has(sidecar.name)) {
+      problems.push(`duplicate SHA-256 sidecar asset: ${sidecar.name}`);
+    }
+    sidecarByName.set(sidecar.name, sidecar);
+  }
+
+  for (const installer of installers) {
+    const expectedSidecarName = `${installer.name}.sha256`;
+    const sidecar = sidecarByName.get(expectedSidecarName);
+    if (!sidecar) {
+      problems.push(`missing SHA-256 sidecar for published asset: ${installer.name}`);
+      continue;
+    }
+    const parsed = parseSha256Sidecar(sidecarContents.get(sidecar.id) ?? "");
+    if (!parsed) {
+      problems.push(`malformed SHA-256 sidecar: ${sidecar.name}`);
+      continue;
+    }
+    if (parsed.filename !== installer.name) {
+      problems.push(
+        `SHA-256 sidecar filename mismatch: ${sidecar.name} names ${parsed.filename}, published asset is ${installer.name}`,
+      );
+    }
+    const githubDigest = installer.digest;
+    if (!githubDigest || githubDigest !== `sha256:${parsed.digest}`) {
+      problems.push(
+        `SHA-256 sidecar digest mismatch: ${sidecar.name} has sha256:${parsed.digest}, GitHub reports ${githubDigest ?? "none"} for ${installer.name}`,
+      );
+    }
+  }
+
+  for (const sidecar of sidecars) {
+    const installerName = sidecar.name.endsWith(".sha256")
+      ? sidecar.name.slice(0, -".sha256".length)
+      : "";
+    if (!installerByName.has(installerName)) {
+      problems.push(`orphan SHA-256 sidecar on public release: ${sidecar.name}`);
+    }
+  }
+  return problems;
+}

--- a/scripts/lib/release-inventory.test.ts
+++ b/scripts/lib/release-inventory.test.ts
@@ -5,6 +5,7 @@ import {
   expectedPublicBundleCounts,
   expectedMsiInstallerLocaleCounts,
   msiLocaleInventoryProblems,
+  publicInstallerInventoryProblems,
   expectedUpdaterSignatureCount,
 } from "./release-inventory.ts";
 
@@ -58,4 +59,29 @@ test("release inventory rejects a cosmetic or imbalanced MSI language suffix", (
       "release inventory MSI zh-CN count 1 != expected 2",
     ],
   );
+});
+
+test("public installer inventory rejects an incomplete remote release matrix", () => {
+  const complete = [
+    "DSH.Desktop_0.2.15_x64-setup.exe",
+    "DSH.Desktop_0.2.15_arm64-setup.exe",
+    "DSH.Desktop_0.2.15_x64_en-US.msi",
+    "DSH.Desktop_0.2.15_x64_zh-CN.msi",
+    "DSH.Desktop_0.2.15_arm64_en-US.msi",
+    "DSH.Desktop_0.2.15_arm64_zh-CN.msi",
+    "DSH.Desktop_0.2.15_x64.dmg",
+    "DSH.Desktop_0.2.15_aarch64.dmg",
+    "DSH.Desktop_0.2.15_amd64.AppImage",
+    "DSH.Desktop_0.2.15_aarch64.AppImage",
+    "DSH.Desktop_0.2.15_amd64.deb",
+    "DSH.Desktop_0.2.15_arm64.deb",
+    "DSH.Desktop-0.2.15-1.x86_64.rpm",
+    "DSH.Desktop-0.2.15-1.aarch64.rpm",
+    "DSH.Desktop_0.2.15_x86_64.flatpak",
+    "DSH.Desktop_0.2.15_aarch64.flatpak",
+  ];
+  assert.deepEqual(publicInstallerInventoryProblems(complete), []);
+  assert.deepEqual(publicInstallerInventoryProblems(complete.slice(0, -1)), [
+    "release inventory flatpak count 1 != expected 2",
+  ]);
 });

--- a/scripts/lib/release-inventory.ts
+++ b/scripts/lib/release-inventory.ts
@@ -63,6 +63,38 @@ export function msiLocaleInventoryProblems(msiNames: readonly string[]): string[
   return problems;
 }
 
+/**
+ * Require the complete reviewed public installer matrix. This is shared by
+ * the local artifact check and the draft-release API audit so an upload that
+ * silently drops a package cannot be published with an otherwise valid subset.
+ */
+export function publicInstallerInventoryProblems(names: readonly string[]): string[] {
+  const expected = expectedPublicBundleCounts();
+  const counts = Object.fromEntries(
+    (Object.keys(expected) as PublicBundle[]).map((bundle) => [bundle, 0]),
+  ) as Record<PublicBundle, number>;
+  const problems: string[] = [];
+  for (const name of names) {
+    const bundle = classifyPublicInstaller(name);
+    if (!bundle) {
+      problems.push(`unrecognized public installer asset: ${name}`);
+      continue;
+    }
+    counts[bundle] += 1;
+  }
+  for (const [bundle, count] of Object.entries(counts) as [PublicBundle, number][]) {
+    if (count !== expected[bundle]) {
+      problems.push(`release inventory ${bundle} count ${count} != expected ${expected[bundle]}`);
+    }
+  }
+  problems.push(
+    ...msiLocaleInventoryProblems(
+      names.filter((name) => classifyPublicInstaller(name) === "msi"),
+    ),
+  );
+  return problems;
+}
+
 export function expectedUpdaterSignatureCount(): number {
   return NATIVE_RELEASE_TARGETS.reduce(
     (count, target) =>

--- a/scripts/verify-release-checksums.ts
+++ b/scripts/verify-release-checksums.ts
@@ -1,0 +1,114 @@
+// Validate SHA-256 sidecars against the assets GitHub actually accepted on a
+// draft Release. This is intentionally after upload: local paths cannot see
+// upload-time filename normalization.
+
+import { spawnSync } from "node:child_process";
+import { fail, info, ok } from "./lib/common.ts";
+import {
+  releaseChecksumProblems,
+  type GithubReleaseAsset,
+} from "./lib/release-checksums.ts";
+import { classifyPublicInstaller, publicInstallerInventoryProblems } from "./lib/release-inventory.ts";
+
+interface ReleaseInfo {
+  tag_name: string;
+  assets: GithubReleaseAsset[];
+}
+
+function parseJson<T>(text: string, context: string): T {
+  try {
+    return JSON.parse(text) as T;
+  } catch (error) {
+    fail(`${context} returned invalid JSON: ${(error as Error).message}`);
+  }
+}
+
+function argument(name: string): string | undefined {
+  const index = process.argv.indexOf(name);
+  return index >= 0 ? process.argv[index + 1] : undefined;
+}
+
+function isRepositoryName(value: string): boolean {
+  return /^[^/\s]+\/[^/\s]+$/.test(value);
+}
+
+function resolveRepo(): string {
+  if (process.env.GITHUB_REPOSITORY) {
+    if (!isRepositoryName(process.env.GITHUB_REPOSITORY)) {
+      fail("GITHUB_REPOSITORY must be an owner/name repository identity");
+    }
+    return process.env.GITHUB_REPOSITORY;
+  }
+  const result = spawnSync("gh", ["repo", "view", "--json", "nameWithOwner"], {
+    encoding: "utf8",
+  });
+  if (result.status !== 0) {
+    fail(`could not determine repository: ${result.stderr || result.error?.message || "gh repo view failed"}`);
+  }
+  const name = parseJson<{ nameWithOwner?: unknown }>(
+    result.stdout || "{}",
+    "gh repo view",
+  ).nameWithOwner;
+  if (typeof name !== "string" || !isRepositoryName(name)) {
+    fail("could not determine repository (set GITHUB_REPOSITORY)");
+  }
+  return name;
+}
+
+function ghJson<T>(path: string): T {
+  const result = spawnSync("gh", ["api", path], { encoding: "utf8" });
+  if (result.status !== 0) {
+    fail(`gh api ${path} failed: ${result.stderr || result.error?.message || "unknown error"}`);
+  }
+  return parseJson<T>(result.stdout ?? "", `gh api ${path}`);
+}
+
+function ghAssetText(repo: string, asset: GithubReleaseAsset): string {
+  const result = spawnSync(
+    "gh",
+    ["api", `repos/${repo}/releases/assets/${asset.id}`, "-H", "Accept: application/octet-stream"],
+    { encoding: "utf8" },
+  );
+  if (result.status !== 0) {
+    fail(`could not download SHA-256 sidecar ${asset.name}: ${result.stderr}`);
+  }
+  return result.stdout ?? "";
+}
+
+const tag = argument("--tag");
+if (!tag || !/^v(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*)$/.test(tag)) {
+  fail("usage: node scripts/verify-release-checksums.ts --tag vMAJOR.MINOR.PATCH");
+}
+
+const repo = resolveRepo();
+// Draft releases cannot reliably be fetched through releases/tags/<tag>.
+const releases = ghJson<ReleaseInfo[]>(`repos/${repo}/releases?per_page=100`);
+if (!Array.isArray(releases)) fail("GitHub releases API returned a non-array response");
+const release = releases.find((candidate) => candidate.tag_name === tag);
+if (!release) fail(`release ${tag} not found (${releases.length} releases listed)`);
+if (!Array.isArray(release.assets)) fail(`release ${tag} has an invalid asset list`);
+for (const [index, asset] of release.assets.entries()) {
+  if (
+    !Number.isSafeInteger(asset.id) ||
+    asset.id <= 0 ||
+    typeof asset.name !== "string" ||
+    (asset.digest !== undefined && asset.digest !== null && typeof asset.digest !== "string")
+  ) {
+    fail(`release ${tag} has an invalid asset at index ${index}`);
+  }
+}
+
+const installers = release.assets.filter((asset) => classifyPublicInstaller(asset.name) !== null);
+const sidecars = release.assets.filter((asset) => asset.name.endsWith(".sha256"));
+const sidecarContents = new Map(
+  sidecars.map((sidecar) => [sidecar.id, ghAssetText(repo, sidecar)]),
+);
+const problems = [
+  ...publicInstallerInventoryProblems(installers.map((installer) => installer.name)),
+  ...releaseChecksumProblems(installers, sidecars, sidecarContents),
+];
+if (problems.length > 0) {
+  fail(`draft Release checksum contract failed:\n- ${problems.join("\n- ")}`);
+}
+for (const installer of installers) info(`draft checksum verified: ${installer.name}`);
+ok(`draft Release ${tag} checksum sidecars match ${installers.length} published installers`);

--- a/scripts/verify-release-inventory.ts
+++ b/scripts/verify-release-inventory.ts
@@ -8,10 +8,10 @@ import { basename, join } from "node:path";
 import { fail, ok, info } from "./lib/common.ts";
 import {
   classifyPublicInstaller,
-  expectedPublicBundleCounts,
-  msiLocaleInventoryProblems,
+  publicInstallerInventoryProblems,
   expectedUpdaterSignatureCount,
 } from "./lib/release-inventory.ts";
+import { githubReleaseAssetName, parseSha256Sidecar } from "./lib/release-checksums.ts";
 import type { PublicBundle } from "./lib/release-artifacts.ts";
 
 function argument(name: string): string | undefined {
@@ -57,25 +57,10 @@ if ([...byBasename.keys()].some((name) => name.toLowerCase().endsWith(".msix")))
 const installers = files
   .map((path) => ({ path, bundle: classifyPublicInstaller(basename(path)) }))
   .filter((entry): entry is { path: string; bundle: PublicBundle } => entry.bundle !== null);
-const counts = Object.fromEntries(
-  Object.keys(expectedPublicBundleCounts()).map((bundle) => [bundle, 0]),
-) as Record<PublicBundle, number>;
-for (const installer of installers) counts[installer.bundle] += 1;
-for (const [bundle, expected] of Object.entries(expectedPublicBundleCounts()) as [
-  PublicBundle,
-  number,
-][]) {
-  if (counts[bundle] !== expected) {
-    fail(`release inventory ${bundle} count ${counts[bundle]} != expected ${expected}`);
-  }
-}
-
-const msiProblems = msiLocaleInventoryProblems(
-  installers
-    .filter((installer) => installer.bundle === "msi")
-    .map((installer) => basename(installer.path)),
+const inventoryProblems = publicInstallerInventoryProblems(
+  installers.map((installer) => basename(installer.path)),
 );
-if (msiProblems.length > 0) fail(msiProblems.join("\n"));
+if (inventoryProblems.length > 0) fail(inventoryProblems.join("\n"));
 
 for (const installer of installers) {
   const name = basename(installer.path);
@@ -83,10 +68,13 @@ for (const installer of installers) {
   const sidecar = byBasename.get(sidecarName);
   if (!sidecar) fail(`missing SHA-256 sidecar for ${name}`);
   const content = readFileSync(sidecar, "utf8");
-  const match = /^([a-f0-9]{64})  ([^\r\n]+)\r?\n$/.exec(content);
-  if (!match || match[2] !== name) fail(`malformed SHA-256 sidecar: ${sidecarName}`);
+  const parsed = parseSha256Sidecar(content);
+  const publishedName = githubReleaseAssetName(name);
+  if (!parsed || parsed.filename !== publishedName) {
+    fail(`malformed SHA-256 sidecar: ${sidecarName}`);
+  }
   const actual = await sha256(installer.path);
-  if (actual !== match[1]) fail(`SHA-256 mismatch for ${name}: ${match[1]} != ${actual}`);
+  if (actual !== parsed.digest) fail(`SHA-256 mismatch for ${name}: ${parsed.digest} != ${actual}`);
   ok(`release checksum verified: ${name}`);
 }
 

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deepseek-harness-desktop"
-version = "0.2.14"
+version = "0.2.15"
 description = "DSH Desktop — community desktop packaging of DeepSeek Harness"
 edition = "2021"
 license = "MIT"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "DSH Desktop",
-  "version": "0.2.14",
+  "version": "0.2.15",
   "identifier": "com.yeagoo.dsh-desktop",
   "build": {
     "beforeDevCommand": "pnpm dev",


### PR DESCRIPTION
## Summary

- generate SHA-256 sidecars using the reviewed GitHub-published asset name
- fail closed by auditing the draft Release against GitHub asset identities, server SHA-256 digests, and the complete installer matrix
- bump Desktop to v0.2.15; v0.2.14 remains immutable and will be marked superseded after the corrective release

## Verification

- `pnpm check`, build, `pnpm test:frontend`, `pnpm check:scripts`, `pnpm test:scripts`
- `cargo check --locked`, fmt, clippy, nextest (42 sidecar + 229 Desktop)
- runtime + heartbeat smoke, bundle/signing self-tests, `cargo deny`, `cargo vet --locked`, npm audits, actionlint, release preflight bound to v0.2.15
- new remote audit intentionally rejects all 16 malformed v0.2.14 sidecars

The workflow keeps the release as a draft if any remote checksum check fails.