### PR TITLE
fix: use reserved Microsoft Store display name

### DIFF
--- a/STORE.md
+++ b/STORE.md
@@ -9,6 +9,7 @@ committed in `src-tauri/gen/windows/`; do not edit them in Partner Center.
 |---|---|
 | Product type | MSIX or PWA App |
 | Product name | `DSH Desktop (Community)` |
+| MSIX `Properties/DisplayName` | `DSH Desktop (Community)` (exact reserved Store title) |
 | Package Identity Name | `53660AlanM.DSHDesktopCommunity` |
 | Package Identity Publisher | `CN=84AC3716-04E0-4D67-8951-0D3E51674CA0` |
 | PublisherDisplayName | `AlanM.` |
@@ -104,7 +105,10 @@ Microsoft Store 版通过 Microsoft Store 更新；插件安装仅允许 cordis.
 3. Download artifacts:
    - `dsh-desktop-store-msix-x64`
    - `dsh-desktop-store-msix-arm64`
-4. Extract and upload the two `.msix` packages on the Packages page.
+4. Extract and upload the two `.msix` packages on the Packages page. The
+   validated manifest must show `DSH Desktop (Community)` as
+   `Properties/DisplayName`; this is intentionally separate from the direct
+   distribution product name `DSH Desktop`.
 5. Do **not** upload the MSIX files to GitHub Releases; they are Store-only.
 
 ## Post-publish updates

--- a/scripts/lib/msix.test.ts
+++ b/scripts/lib/msix.test.ts
@@ -1,6 +1,9 @@
 import assert from "node:assert/strict";
 import test from "node:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
 import { normalizeMsixEntryName, windowsPeArchitecture } from "./msix.ts";
+import { repoRoot } from "./common.ts";
 
 function peHeader(machine: number): Buffer {
   const header = Buffer.alloc(0x90);
@@ -36,4 +39,15 @@ test("reads only reviewed x64 and arm64 PE machine headers", () => {
   const malformedOffset = peHeader(0x8664);
   malformedOffset.writeUInt32LE(0x200, 0x3c);
   assert.throws(() => windowsPeArchitecture(malformedOffset), /outside the captured/);
+});
+
+test("Store manifest uses the reserved title without renaming direct distributions", () => {
+  const tauriConfig = JSON.parse(readFileSync(join(repoRoot, "src-tauri/tauri.conf.json"), "utf8")) as {
+    productName?: unknown;
+  };
+  const manifest = readFileSync(join(repoRoot, "src-tauri/gen/windows/AppxManifest.xml.template"), "utf8");
+
+  assert.equal(tauriConfig.productName, "DSH Desktop");
+  assert.match(manifest, /<DisplayName>DSH Desktop \(Community\)<\/DisplayName>/);
+  assert.match(manifest, /<uap:VisualElements\s+DisplayName="DSH Desktop \(Community\)"/);
 });

--- a/scripts/verify-msix.ts
+++ b/scripts/verify-msix.ts
@@ -3,7 +3,7 @@
 //
 // Checks:
 //   * x64 and arm64 .msix packages exist
-//   * package identity matches the reserved Partner Center identity
+//   * package identity and Store-facing display name match Partner Center
 //   * the main executable and complete staged runtime are inside the package
 //   * the dsharness:// protocol and runFullTrust capability are declared
 //   * the Store input is intentionally unsigned and architecture-bound
@@ -18,6 +18,10 @@ import { normalizeMsixEntryName, windowsPeArchitecture } from "./lib/msix.ts";
 
 const PACKAGE_NAME = "53660AlanM.DSHDesktopCommunity";
 const PUBLISHER = "CN=84AC3716-04E0-4D67-8951-0D3E51674CA0";
+// This is the Partner Center-reserved Store title. It intentionally differs
+// from the cross-platform Tauri product name, which must stay "DSH Desktop"
+// to preserve direct-installer identity and upgrade paths.
+const STORE_DISPLAY_NAME = "DSH Desktop (Community)";
 const PROTOCOL = "dsharness";
 
 const archIdx = process.argv.indexOf("--arch");
@@ -146,6 +150,12 @@ for (const target of targets) {
   if (!manifest.includes(`ProcessorArchitecture="${target.arch}"`)) {
     fail(`${msix} manifest architecture is not ${target.arch}`);
   }
+  if (!manifest.includes(`<DisplayName>${STORE_DISPLAY_NAME}</DisplayName>`)) {
+    fail(`${msix} manifest Properties/DisplayName is not the reserved Store title`);
+  }
+  if (!manifest.includes(`DisplayName="${STORE_DISPLAY_NAME}"`)) {
+    fail(`${msix} manifest VisualElements DisplayName is not the reserved Store title`);
+  }
   if (!manifest.includes(`Name="${PROTOCOL}"`) || !manifest.includes("windows.protocol")) {
     fail(`${msix} manifest is missing the ${PROTOCOL}:// protocol extension`);
   }
@@ -178,11 +188,12 @@ for (const target of targets) {
       fail(`${msix} ${path} is ${actualArchitecture}, expected ${target.arch}`);
     }
   }
-  ok(`${msix} verified (${names.size} entries, identity/arch/protocol OK, unsigned Store input)`);
+  ok(`${msix} verified (${names.size} entries, identity/display-name/arch/protocol OK, unsigned Store input)`);
 }
 
 if (process.argv.includes("--self-test")) {
   if (PACKAGE_NAME !== "53660AlanM.DSHDesktopCommunity") fail("self-test: package name changed");
+  if (STORE_DISPLAY_NAME !== "DSH Desktop (Community)") fail("self-test: Store display name changed");
   ok("self-test: verify-msix constants");
   process.exit(0);
 }

--- a/src-tauri/gen/windows/AppxManifest.xml.template
+++ b/src-tauri/gen/windows/AppxManifest.xml.template
@@ -14,7 +14,12 @@
     ProcessorArchitecture="{{ARCH}}" />
 
   <Properties>
-    <DisplayName>{{DISPLAY_NAME}}</DisplayName>
+    <!--
+      Partner Center reserved this exact Store-facing title. Keep it separate
+      from Tauri's cross-platform productName ("DSH Desktop"), so direct
+      installers retain their established product identity and upgrade path.
+    -->
+    <DisplayName>DSH Desktop (Community)</DisplayName>
     <PublisherDisplayName>{{PUBLISHER_DISPLAY_NAME}}</PublisherDisplayName>
     <Logo>Assets\StoreLogo.png</Logo>
   </Properties>
@@ -34,7 +39,7 @@
       Executable="{{EXECUTABLE}}"
       EntryPoint="Windows.FullTrustApplication">
       <uap:VisualElements
-        DisplayName="{{DISPLAY_NAME}}"
+        DisplayName="DSH Desktop (Community)"
         Description="{{DESCRIPTION}}"
         BackgroundColor="transparent"
         Square150x150Logo="Assets\Square150x150Logo.png"


### PR DESCRIPTION
## Summary
- set the Store-only MSIX display name to the exact Partner Center-reserved `DSH Desktop (Community)` value
- preserve the existing cross-platform `DSH Desktop` identity for direct installers and their upgrade path
- verify the reserved display name in both source tests and built MSIX artifacts

## Validation
- `pnpm check:scripts`
- `pnpm test:scripts` (112 passing)
- `git diff --check`