### PR TITLE
docs: announce Snap Store stable release

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -13,7 +13,7 @@ intact; the desktop layer only handles lifecycle and the security boundary.
 | Website | [dsharness.app](https://dsharness.app) |
 | Plugin marketplace | [cordis.run](https://cordis.run) |
 | Docs | [SECURITY](SECURITY.md) · [FORKING](FORKING.md) · [RELEASING](RELEASING.md) · [AGENTS](AGENTS.md) |
-| Current version | v0.2.18 · Windows x64/ARM64 EXE/MSI · macOS x64/arm64 DMG · Linux x64/arm64 AppImage/DEB/RPM/Flatpak · Snap Store delivery is ready but not public yet · signed/notarized macOS · [中文](README.md) |
+| Current version | v0.2.18 · Windows x64/ARM64 EXE/MSI · macOS x64/arm64 DMG · Linux x64/arm64 AppImage/DEB/RPM/Flatpak · [now on the Snap Store](https://snapcraft.io/dsh-desktop-community) · signed/notarized macOS · [中文](README.md) |
 
 > **macOS users**: starting with v0.2.9, DMGs are signed with Developer ID
 > Application, notarized by Apple, stapled, and rechecked with Gatekeeper.
@@ -51,11 +51,18 @@ intact; the desktop layer only handles lifecycle and the security boundary.
 > If v0.2.18 still has a problem, cross-check its `.deb`, `.rpm`, or `.flatpak`, and attach your desktop environment,
 > GPU/driver details, and redacted stderr. Do not delete `~/.dsh`.
 
-The future Snap Store package is named `dsh-desktop-community` and titled
-**DSH Desktop (Community)**. It will be a strictly confined, native x64/arm64
-Snap. Account ownership and Store onboarding are still being completed, so
-there is no public install command yet. Once released, Snap Store/`snapd` —
-not the in-app updater — will manage updates.
+The Snap Store package **`dsh-desktop-community`**, titled **DSH Desktop
+(Community)**, is publicly available as a strictly confined, native x64/arm64
+Snap:
+
+```bash
+sudo snap install dsh-desktop-community
+```
+
+The stable Snap channel may lag behind the GitHub Release; check the
+[Snap Store page](https://snapcraft.io/dsh-desktop-community) for its current
+version before installing. Snap Store/`snapd` — not the in-app updater —
+manages updates for this edition.
 
 Every public installer has a same-name `.sha256` sidecar. The x64/arm64
 Microsoft Store MSIX packages remain separate, unsigned Partner Center
@@ -229,8 +236,8 @@ deny.toml + supply-chain/   policy & audits   .github/workflows/   CI
 - Current release: v0.2.18, including six native build targets, Windows
   x64/ARM64 installers and English/Simplified-Chinese MSI packages, macOS
   Developer ID signing/notarization, the AppImage Wayland/GLib/GIO compatibility repair, the Cordis v4 marketplace contract,
-  diagnostic resilience, safe plugin recovery, and the strict Snap x64/arm64
-  candidate-delivery path. The historical v0.2.13 `_en-US` suffix means only
+  diagnostic resilience, safe plugin recovery, and a released strict Snap
+  Store channel for native x64/arm64. The historical v0.2.13 `_en-US` suffix means only
   that its installer UI was English.
 - Known limits: Windows GitHub installers do not yet have Authenticode and may
   trigger SmartScreen; in-app updating accepts only a payload exactly matching

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 | 官网 | [dsharness.app](https://dsharness.app) |
 | 插件市场 | [cordis.run](https://cordis.run) |
 | 文档 | [SECURITY](SECURITY.md) · [FORKING](FORKING.md) · [RELEASING](RELEASING.md) · [AGENTS](AGENTS.md) |
-| 当前版本 | v0.2.18 · Windows x64/ARM64 EXE/MSI · macOS x64/arm64 DMG · Linux x64/arm64 AppImage/DEB/RPM/Flatpak · Snap Store 上架链路已就绪（尚未公开）· macOS 已签名/公证 · [English](README.en.md) |
+| 当前版本 | v0.2.18 · Windows x64/ARM64 EXE/MSI · macOS x64/arm64 DMG · Linux x64/arm64 AppImage/DEB/RPM/Flatpak · [Snap Store 已正式发布](https://snapcraft.io/dsh-desktop-community) · macOS 已签名/公证 · [English](README.en.md) |
 
 > **macOS 用户**：v0.2.9 起，DMG 使用 Developer ID Application 签名并经
 > Apple 公证、staple 与 Gatekeeper 复验。请只从本仓库 Releases 下载；若官方
@@ -43,10 +43,16 @@
 > 该命令对 v0.2.17 无效，因为它会强制 X11；请升级至 v0.2.18。若 v0.2.18 仍有问题，请用同版本 `.deb`、`.rpm` 或 `.flatpak`
 > 交叉验证，并附上桌面环境、GPU/驱动信息和脱敏后的 stderr。请不要删除 `~/.dsh`。
 
-Snap Store 包将使用名称 `dsh-desktop-community`（标题 **DSH Desktop
-(Community)**），并只提供严格沙箱的 x64/arm64 原生构建。当前上架和账户归属
-配置仍在完成中，尚未有可安装的公开 Snap；正式候选/稳定通道上线后会在此处更新
-安装命令。Snap 版由 Snap Store 与 `snapd` 更新，不启用应用内更新。
+Snap Store 包 **`dsh-desktop-community`**（标题 **DSH Desktop
+(Community)**）已正式发布，提供严格沙箱的 x64/arm64 原生构建：
+
+```bash
+sudo snap install dsh-desktop-community
+```
+
+Snap 稳定通道的版本可能晚于 GitHub Release；可在安装前查看
+[Snap Store 页面](https://snapcraft.io/dsh-desktop-community)确认当前版本。Snap 版由
+Snap Store 与 `snapd` 更新，不启用应用内更新。
 
 每个公开安装包旁均有同名 `.sha256`。Microsoft Store 的 x64/arm64 MSIX
 保持为独立、未签名的 Partner Center workflow artifact，不会混入公开 Release；
@@ -196,6 +202,6 @@ deny.toml + supply-chain/   供应链策略与审计     .github/workflows/   CI
 - CI：push/PR 跑质量门 + 三平台冒烟；打 `v*` tag 触发六个**原生**构建目标（Windows x64/ARM64、macOS x64/arm64、Linux x64/arm64）及 Store MSIX x64/arm64，再经完整资产清单门禁创建 draft release、生成并校验 `latest.json`，最后才自动公开 Release。独立 Snap 工作流也从同一源码原生构建 x64/arm64 严格沙箱包：先验证本地 DEB，再验证重新封装的 Snap、其深链与持久化启动器，候选上传仍须受保护环境显式授权。每一 lane 都会同时核对 Node、Rust host triple 与目标架构；Windows on ARM 另加 x64 兼容性安装 smoke，不把它误称为原生构建。
 - Microsoft Store：`v*` tag 同时构建 x64/arm64 MSIX（`build-msix` job，Store 模式关闭应用内更新并限制插件为 cordis.run 审核列表）。MSIX 产物作为 workflow artifact 下载后上传 Partner Center，不发布到 GitHub Release。
 - Harness 升级走 [AGENTS.md](AGENTS.md)「启动契约」清单；发布流程见 [RELEASING.md](RELEASING.md)。
-- 当前发布版本：v0.2.18；包含六个原生构建目标、Windows x64/ARM64 安装包与中英文 MSI、macOS Developer ID 签名/公证、AppImage Wayland/GLib/GIO 兼容性修复、Cordis v4 市场契约、诊断韧性与安全插件恢复，以及严格 Snap x64/arm64 的候选上架链路。历史 v0.2.13 文件名中的 `_en-US` 只表示其安装向导为英文。
+- 当前发布版本：v0.2.18；包含六个原生构建目标、Windows x64/ARM64 安装包与中英文 MSI、macOS Developer ID 签名/公证、AppImage Wayland/GLib/GIO 兼容性修复、Cordis v4 市场契约、诊断韧性与安全插件恢复，以及已正式发布的严格 Snap x64/arm64 Store 通道。历史 v0.2.13 文件名中的 `_en-US` 只表示其安装向导为英文。
 - 已知边界：Windows GitHub 安装包尚未配置 Authenticode，可能触发 SmartScreen；应用内更新只接受与当前 CPU 架构及 NSIS 安装方式完全匹配的 payload，MSI 不会自动切换到 NSIS；macOS 仍待“公证后 updater archive + 原生升级 smoke”闭环；Linux 包当前以 SHA-256 保护，尚无独立软件仓库签名。
 - 许可：MIT；内置 Harness 及全部依赖的 LICENSE 随包附于 `runtime/harness/licenses/`。


### PR DESCRIPTION
## Summary
- replace the obsolete “not public yet” Snap status in both READMEs
- document the stable `snap install dsh-desktop-community` command
- align the v0.2.16 release summary with the released native amd64/arm64 Snap channel

## Verification
- `pnpm release:preflight`
- `git diff --check`
- public Store API confirms stable amd64 revision 2 and arm64 revision 1 for v0.2.16