### PR TITLE
fix: restore strict Snap Harness portal access

### DIFF
--- a/.github/workflows/snap.yml
+++ b/.github/workflows/snap.yml
@@ -164,6 +164,11 @@ jobs:
           sudo snap connect "$instance:icon-themes" gtk-common-themes:icon-themes
           sudo snap connect "$instance:sound-themes" gtk-common-themes:sound-themes
           sudo snap connect "$instance:gnome-46-2404" gnome-46-2404:gnome-46-2404
+          # `network-status` must auto-connect: WebKitGTK/GLib uses the
+          # NetworkMonitor portal for connectivity/proxy state when
+          # GTK_USE_PORTAL=1. A missing connection otherwise leaves the
+          # embedded Harness window displaying a portal denial.
+          assert_connection network-status :network-status
           assert_connection gpu-2404 mesa-2404:gpu-2404
           assert_connection gtk-3-themes gtk-common-themes:gtk-3-themes
           assert_connection icon-themes gtk-common-themes:icon-themes
@@ -288,6 +293,9 @@ jobs:
               exit 1
             fi
           }
+          # Check the Store-installed package too; a local `--dangerous`
+          # install cannot prove the Store's automatic interface policy.
+          assert_connection network-status :network-status
           assert_connection gpu-2404 mesa-2404:gpu-2404
           assert_connection gtk-3-themes gtk-common-themes:gtk-3-themes
           assert_connection icon-themes gtk-common-themes:icon-themes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -698,7 +698,7 @@ dependencies = [
 
 [[package]]
 name = "deepseek-harness-desktop"
-version = "0.2.16"
+version = "0.2.17"
 dependencies = [
  "dsh-sidecar",
  "flate2",
@@ -909,7 +909,7 @@ dependencies = [
 
 [[package]]
 name = "dsh-sidecar"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "libc",
  "proptest",

--- a/README.en.md
+++ b/README.en.md
@@ -13,7 +13,7 @@ intact; the desktop layer only handles lifecycle and the security boundary.
 | Website | [dsharness.app](https://dsharness.app) |
 | Plugin marketplace | [cordis.run](https://cordis.run) |
 | Docs | [SECURITY](SECURITY.md) · [FORKING](FORKING.md) · [RELEASING](RELEASING.md) · [AGENTS](AGENTS.md) |
-| Current version | v0.2.16 · Windows x64/ARM64 EXE/MSI · macOS x64/arm64 DMG · Linux x64/arm64 AppImage/DEB/RPM/Flatpak · Snap Store delivery is ready but not public yet · signed/notarized macOS · [中文](README.md) |
+| Current version | v0.2.17 · Windows x64/ARM64 EXE/MSI · macOS x64/arm64 DMG · Linux x64/arm64 AppImage/DEB/RPM/Flatpak · Snap Store delivery is ready but not public yet · signed/notarized macOS · [中文](README.md) |
 
 > **macOS users**: starting with v0.2.9, DMGs are signed with Developer ID
 > Application, notarized by Apple, stapled, and rechecked with Gatekeeper.
@@ -207,7 +207,7 @@ deny.toml + supply-chain/   policy & audits   .github/workflows/   CI
   Partner Center upload, not GitHub Release assets.
 - Harness upgrades follow the startup-contract checklist in
   [AGENTS.md](AGENTS.md); the release flow lives in [RELEASING.md](RELEASING.md).
-- Current release: v0.2.16, including six native build targets, Windows
+- Current release: v0.2.17, including six native build targets, Windows
   x64/ARM64 installers and English/Simplified-Chinese MSI packages, macOS
   Developer ID signing/notarization, the Cordis v4 marketplace contract,
   diagnostic resilience, safe plugin recovery, and the strict Snap x64/arm64

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 | 官网 | [dsharness.app](https://dsharness.app) |
 | 插件市场 | [cordis.run](https://cordis.run) |
 | 文档 | [SECURITY](SECURITY.md) · [FORKING](FORKING.md) · [RELEASING](RELEASING.md) · [AGENTS](AGENTS.md) |
-| 当前版本 | v0.2.16 · Windows x64/ARM64 EXE/MSI · macOS x64/arm64 DMG · Linux x64/arm64 AppImage/DEB/RPM/Flatpak · Snap Store 上架链路已就绪（尚未公开）· macOS 已签名/公证 · [English](README.en.md) |
+| 当前版本 | v0.2.17 · Windows x64/ARM64 EXE/MSI · macOS x64/arm64 DMG · Linux x64/arm64 AppImage/DEB/RPM/Flatpak · Snap Store 上架链路已就绪（尚未公开）· macOS 已签名/公证 · [English](README.en.md) |
 
 > **macOS 用户**：v0.2.9 起，DMG 使用 Developer ID Application 签名并经
 > Apple 公证、staple 与 Gatekeeper 复验。请只从本仓库 Releases 下载；若官方
@@ -182,6 +182,6 @@ deny.toml + supply-chain/   供应链策略与审计     .github/workflows/   CI
 - CI：push/PR 跑质量门 + 三平台冒烟；打 `v*` tag 触发六个**原生**构建目标（Windows x64/ARM64、macOS x64/arm64、Linux x64/arm64）及 Store MSIX x64/arm64，再经完整资产清单门禁创建 draft release、生成并校验 `latest.json`，最后才自动公开 Release。独立 Snap 工作流也从同一源码原生构建 x64/arm64 严格沙箱包：先验证本地 DEB，再验证重新封装的 Snap、其深链与持久化启动器，候选上传仍须受保护环境显式授权。每一 lane 都会同时核对 Node、Rust host triple 与目标架构；Windows on ARM 另加 x64 兼容性安装 smoke，不把它误称为原生构建。
 - Microsoft Store：`v*` tag 同时构建 x64/arm64 MSIX（`build-msix` job，Store 模式关闭应用内更新并限制插件为 cordis.run 审核列表）。MSIX 产物作为 workflow artifact 下载后上传 Partner Center，不发布到 GitHub Release。
 - Harness 升级走 [AGENTS.md](AGENTS.md)「启动契约」清单；发布流程见 [RELEASING.md](RELEASING.md)。
-- 当前发布版本：v0.2.16；包含六个原生构建目标、Windows x64/ARM64 安装包与中英文 MSI、macOS Developer ID 签名/公证、Cordis v4 市场契约、诊断韧性与安全插件恢复，以及严格 Snap x64/arm64 的候选上架链路。历史 v0.2.13 文件名中的 `_en-US` 只表示其安装向导为英文。
+- 当前发布版本：v0.2.17；包含六个原生构建目标、Windows x64/ARM64 安装包与中英文 MSI、macOS Developer ID 签名/公证、Cordis v4 市场契约、诊断韧性与安全插件恢复，以及严格 Snap x64/arm64 的候选上架链路。历史 v0.2.13 文件名中的 `_en-US` 只表示其安装向导为英文。
 - 已知边界：Windows GitHub 安装包尚未配置 Authenticode，可能触发 SmartScreen；应用内更新只接受与当前 CPU 架构及 NSIS 安装方式完全匹配的 payload，MSI 不会自动切换到 NSIS；macOS 仍待“公证后 updater archive + 原生升级 smoke”闭环；Linux 包当前以 SHA-256 保护，尚无独立软件仓库签名。
 - 许可：MIT；内置 Harness 及全部依赖的 LICENSE 随包附于 `runtime/harness/licenses/`。

--- a/crates/dsh-sidecar/Cargo.toml
+++ b/crates/dsh-sidecar/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dsh-sidecar"
-version = "0.2.5"
+version = "0.2.6"
 description = "Minimal process supervisor for the DSH Desktop runtime"
 edition = "2021"
 license = "MIT"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "deepseek-harness-desktop",
   "private": true,
-  "version": "0.2.16",
+  "version": "0.2.17",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/runtime/runtime-manifest.json
+++ b/runtime/runtime-manifest.json
@@ -1,8 +1,8 @@
 {
-  "desktopVersion": "0.2.16",
+  "desktopVersion": "0.2.17",
   "harnessVersion": "0.1.1-rc.2",
   "nodeVersion": "24.19.0",
-  "sidecarVersion": "0.2.5",
+  "sidecarVersion": "0.2.6",
   "nodeSha256": {
     "win32-x64": "57f71ab3652e797d84acddc79c81cc9ff1c6ddb2a1974cdb83f00fee9bff4c73",
     "darwin-arm64": "8294b7aa9b03997481c06babf1e8b270c859358f27da57a11509afe537ac381d",

--- a/scripts/lib/snap-package.test.ts
+++ b/scripts/lib/snap-package.test.ts
@@ -26,6 +26,7 @@ apps:
     plugs:
     - network
     - network-bind
+    - network-status
     - desktop
     - desktop-legacy
     - gsettings
@@ -94,6 +95,12 @@ test("Snap metadata requires the reviewed strict native contract", () => {
       version: "0.2.16",
       architecture: "arm64",
     }).some((problem) => problem.includes("assumes")),
+  );
+  assert.ok(
+    snapMetadataProblems(metadata.replace("    - network-status\n", ""), {
+      version: "0.2.16",
+      architecture: "arm64",
+    }).some((problem) => problem.includes("network-status for the GTK/XDG portal runtime")),
   );
   assert.ok(
     snapMetadataProblems(

--- a/scripts/lib/snap-package.test.ts
+++ b/scripts/lib/snap-package.test.ts
@@ -9,7 +9,7 @@ import {
 
 const metadata = `name: dsh-desktop-community
 title: DSH Desktop (Community)
-version: 0.2.16
+version: 0.2.17
 summary: DSH Desktop
 base: core24
 grade: stable
@@ -70,48 +70,48 @@ environment:
 `;
 
 test("Snap metadata requires the reviewed strict native contract", () => {
-  assert.equal(snapArtifactName("0.2.16", "arm64"), "dsh-desktop-community_0.2.16_arm64.snap");
-  assert.deepEqual(snapMetadataProblems(metadata, { version: "0.2.16", architecture: "arm64" }), []);
+  assert.equal(snapArtifactName("0.2.17", "arm64"), "dsh-desktop-community_0.2.17_arm64.snap");
+  assert.deepEqual(snapMetadataProblems(metadata, { version: "0.2.17", architecture: "arm64" }), []);
   assert.ok(
     snapMetadataProblems(metadata.replace("confinement: strict", "confinement: classic"), {
-      version: "0.2.16",
+      version: "0.2.17",
       architecture: "arm64",
     }).some((problem) => problem.includes("classic")),
   );
   assert.ok(
     snapMetadataProblems(metadata.replace("- arm64", "- home"), {
-      version: "0.2.16",
+      version: "0.2.17",
       architecture: "arm64",
     }).some((problem) => problem.includes("forbidden")),
   );
   assert.ok(
     snapMetadataProblems(metadata.replace("gpu-2404-wrapper", "unexpected-wrapper"), {
-      version: "0.2.16",
+      version: "0.2.17",
       architecture: "arm64",
     }).some((problem) => problem.includes("command chain")),
   );
   assert.ok(
     snapMetadataProblems(metadata.replace("- command-chain\n", ""), {
-      version: "0.2.16",
+      version: "0.2.17",
       architecture: "arm64",
     }).some((problem) => problem.includes("assumes")),
   );
   assert.ok(
     snapMetadataProblems(metadata.replace("    - network-status\n", ""), {
-      version: "0.2.16",
+      version: "0.2.17",
       architecture: "arm64",
     }).some((problem) => problem.includes("network-status for the GTK/XDG portal runtime")),
   );
   assert.ok(
     snapMetadataProblems(
       metadata.replaceAll("aarch64-linux-gnu", "x86_64-linux-gnu"),
-      { version: "0.2.16", architecture: "arm64" },
+      { version: "0.2.17", architecture: "arm64" },
     ).some((problem) => problem.includes("WebKit layout")),
   );
   const amd64Metadata = metadata
     .replace("- arm64", "- amd64")
     .replaceAll("aarch64-linux-gnu", "x86_64-linux-gnu");
-  assert.deepEqual(snapMetadataProblems(amd64Metadata, { version: "0.2.16", architecture: "amd64" }), []);
+  assert.deepEqual(snapMetadataProblems(amd64Metadata, { version: "0.2.17", architecture: "amd64" }), []);
 });
 
 test("Snap provenance binds architecture, version, hash, and source commit", () => {
@@ -119,7 +119,7 @@ test("Snap provenance binds architecture, version, hash, and source commit", () 
   const provenance = {
     schema: SNAP_PROVENANCE_SCHEMA,
     name: "dsh-desktop-community",
-    version: "0.2.16",
+    version: "0.2.17",
     arch: "arm64",
     snapArchitecture: "arm64",
     sourceCommit: "b".repeat(40),
@@ -129,7 +129,7 @@ test("Snap provenance binds architecture, version, hash, and source commit", () 
   };
   assert.deepEqual(
     snapProvenanceProblems(provenance, {
-      version: "0.2.16",
+      version: "0.2.17",
       arch: "arm64",
       snapArchitecture: "arm64",
       snapSha256: digest,
@@ -141,7 +141,7 @@ test("Snap provenance binds architecture, version, hash, and source commit", () 
     snapProvenanceProblems(
       { ...provenance, snap: { sha256: "d".repeat(64) } },
       {
-        version: "0.2.16",
+        version: "0.2.17",
         arch: "arm64",
         snapArchitecture: "arm64",
         snapSha256: digest,

--- a/scripts/lib/snap-package.ts
+++ b/scripts/lib/snap-package.ts
@@ -10,6 +10,7 @@ import {
   SNAP_COMMAND_CHAIN,
   SNAP_DECLARED_PLUGS,
   SNAP_NAME,
+  SNAP_PORTAL_REQUIRED_APP_PLUGS,
   SNAP_TITLE,
   type SnapArchitecture,
 } from "./snap.ts";
@@ -155,6 +156,11 @@ export function snapMetadataProblems(
     const appPlugs = listField(app, "plugs");
     if (appPlugs.join(",") !== SNAP_APP_PLUGS.join(",")) {
       problems.push(`Snap metadata app plugs must be ${SNAP_APP_PLUGS.join(",")}`);
+    }
+    for (const plug of SNAP_PORTAL_REQUIRED_APP_PLUGS) {
+      if (!appPlugs.includes(plug)) {
+        problems.push(`Snap metadata must enable ${plug} for the GTK/XDG portal runtime`);
+      }
     }
   }
 

--- a/scripts/lib/snap-workflow.test.ts
+++ b/scripts/lib/snap-workflow.test.ts
@@ -35,6 +35,11 @@ test("Snap CI builds source DEBs natively and validates an enforced strict insta
   assert.match(buildWorkflow, /sudo snap connect "\$instance:gnome-46-2404" gnome-46-2404:gnome-46-2404/);
   assert.match(buildWorkflow, /assert_connection gpu-2404 mesa-2404:gpu-2404/);
   assert.match(buildWorkflow, /assert_connection gnome-46-2404 gnome-46-2404:gnome-46-2404/);
+  assert.equal(
+    (buildWorkflow.match(/assert_connection network-status :network-status/g) ?? []).length,
+    2,
+    "both local strict-install and Store-candidate checks must require the portal NetworkMonitor interface",
+  );
   assert.match(snapDependencies, /amd64\) snapcraft_revision=18514/);
   assert.match(snapDependencies, /arm64\) snapcraft_revision=18519/);
   assert.match(snapDependencies, /snapcraft 9\.0\.1/);

--- a/scripts/lib/snap.test.ts
+++ b/scripts/lib/snap.test.ts
@@ -33,7 +33,7 @@ const commandChainRunner = readFileSync(new URL("../../snap/command-chain/run", 
 const buildInfo = readFileSync(new URL("../../src-tauri/src/build_info.rs", import.meta.url), "utf8");
 
 test("reviewed Snap definition is strict, native, and version-aligned", () => {
-  assert.equal(snapRecipeVersion(recipe), "0.2.16");
+  assert.equal(snapRecipeVersion(recipe), "0.2.17");
   assert.deepEqual(
     snapDefinitionProblems({
       recipe,
@@ -42,7 +42,7 @@ test("reviewed Snap definition is strict, native, and version-aligned", () => {
       gpuWrapper,
       desktopLauncher,
       commandChainRunner,
-      expectedVersion: "0.2.16",
+      expectedVersion: "0.2.17",
     }),
     [],
   );
@@ -62,7 +62,7 @@ test("Snap definition rejects weakened confinement, broad filesystem access, and
       gpuWrapper,
       desktopLauncher,
       commandChainRunner,
-      expectedVersion: "0.2.16",
+      expectedVersion: "0.2.17",
     }).some((problem) => problem.includes("classic or devmode")),
   );
   assert.ok(
@@ -73,7 +73,7 @@ test("Snap definition rejects weakened confinement, broad filesystem access, and
       gpuWrapper,
       desktopLauncher,
       commandChainRunner,
-      expectedVersion: "0.2.16",
+      expectedVersion: "0.2.17",
     }).some((problem) => problem.includes("launcher diverges")),
   );
   assert.ok(
@@ -84,7 +84,7 @@ test("Snap definition rejects weakened confinement, broad filesystem access, and
       gpuWrapper,
       desktopLauncher,
       commandChainRunner,
-      expectedVersion: "0.2.16",
+      expectedVersion: "0.2.17",
     }).some((problem) => problem.includes("desktop entry diverges")),
   );
   assert.ok(
@@ -95,7 +95,7 @@ test("Snap definition rejects weakened confinement, broad filesystem access, and
       gpuWrapper: gpuWrapper.replace("gpu-2404-provider-wrapper", "untrusted-wrapper"),
       desktopLauncher,
       commandChainRunner,
-      expectedVersion: "0.2.16",
+      expectedVersion: "0.2.17",
     }).some((problem) => problem.includes("GPU command-chain")),
   );
   assert.ok(
@@ -106,7 +106,7 @@ test("Snap definition rejects weakened confinement, broad filesystem access, and
       gpuWrapper,
       desktopLauncher,
       commandChainRunner,
-      expectedVersion: "0.2.16",
+      expectedVersion: "0.2.17",
     }).some((problem) => problem.includes("must not download mutable")),
   );
   assert.ok(
@@ -117,7 +117,7 @@ test("Snap definition rejects weakened confinement, broad filesystem access, and
       gpuWrapper,
       desktopLauncher,
       commandChainRunner,
-      expectedVersion: "0.2.16",
+      expectedVersion: "0.2.17",
     }).some((problem) => problem.includes("network-status for the GTK/XDG portal runtime")),
   );
 });

--- a/scripts/lib/snap.test.ts
+++ b/scripts/lib/snap.test.ts
@@ -12,6 +12,8 @@ import {
   SNAP_ICON,
   SNAP_LAUNCHER,
   SNAP_NAME,
+  SNAP_APP_PLUGS,
+  SNAP_PORTAL_REQUIRED_APP_PLUGS,
   SNAP_TITLE,
   SNAP_RELEASE_TARGETS,
   githubSnapMatrix,
@@ -107,12 +109,35 @@ test("Snap definition rejects weakened confinement, broad filesystem access, and
       expectedVersion: "0.2.16",
     }).some((problem) => problem.includes("must not download mutable")),
   );
+  assert.ok(
+    snapDefinitionProblems({
+      recipe: recipe.replace("      - network-status\n", ""),
+      launcher,
+      desktopEntry,
+      gpuWrapper,
+      desktopLauncher,
+      commandChainRunner,
+      expectedVersion: "0.2.16",
+    }).some((problem) => problem.includes("network-status for the GTK/XDG portal runtime")),
+  );
 });
 
 test("Snap matrix is exactly native amd64 and arm64", () => {
   assert.equal(SNAP_NAME, "dsh-desktop-community");
   assert.equal(SNAP_TITLE, "DSH Desktop (Community)");
   assert.equal(SNAP_ICON, "snap/gui/dsh-desktop-community.png");
+  assert.deepEqual(SNAP_PORTAL_REQUIRED_APP_PLUGS, ["desktop", "network-status"]);
+  assert.deepEqual(SNAP_APP_PLUGS, [
+    "network",
+    "network-bind",
+    "network-status",
+    "desktop",
+    "desktop-legacy",
+    "gsettings",
+    "opengl",
+    "wayland",
+    "x11",
+  ]);
   assert.deepEqual(SNAPCRAFT_REVISIONS, { amd64: "18514", arm64: "18519" });
   assert.deepEqual(SNAP_SOURCE_ASSUMES, ["snapd2.43", "common-data-dir"]);
   assert.deepEqual(SNAP_ASSUMES, ["snapd2.43", "common-data-dir", "command-chain"]);

--- a/scripts/lib/snap.ts
+++ b/scripts/lib/snap.ts
@@ -25,9 +25,17 @@ export const SNAP_COMMAND_CHAIN = [
   "snap/command-chain/gpu-2404-wrapper",
   "snap/command-chain/desktop-launch",
 ] as const;
+// `GTK_USE_PORTAL=1` is intentional: it keeps file pickers and URI opening
+// inside the host's reviewed XDG portal boundary. WebKitGTK/GLib also asks
+// the NetworkMonitor portal for connectivity/proxy state; Snap gates that
+// read-only request behind `network-status`, separately from network I/O.
+// Keep this minimum explicit so a future packaging cleanup cannot reintroduce
+// a white/error-only Harness window under strict confinement.
+export const SNAP_PORTAL_REQUIRED_APP_PLUGS = ["desktop", "network-status"] as const;
 export const SNAP_APP_PLUGS = [
   "network",
   "network-bind",
+  "network-status",
   "desktop",
   "desktop-legacy",
   "gsettings",
@@ -378,6 +386,11 @@ export function snapDefinitionProblems(input: SnapDefinitionInput): string[] {
   }
   if (/^\s*-\s*(?:home|removable-media)\s*$/m.test(recipe)) {
     problems.push("snap recipe must not request home or removable-media access");
+  }
+  for (const plug of SNAP_PORTAL_REQUIRED_APP_PLUGS) {
+    if (!hasExactLine(recipe, `      - ${plug}`)) {
+      problems.push(`snap recipe must enable ${plug} for the GTK/XDG portal runtime`);
+    }
   }
 
   if (/^\s*extensions:/m.test(recipe)) {

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -87,6 +87,7 @@ apps:
     plugs:
       - network
       - network-bind
+      - network-status
       - desktop
       - desktop-legacy
       - gsettings

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,6 +1,6 @@
 name: dsh-desktop-community
 base: core24
-version: "0.2.16"
+version: "0.2.17"
 title: DSH Desktop (Community)
 summary: Community desktop packaging of DeepSeek Harness
 description: |

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deepseek-harness-desktop"
-version = "0.2.16"
+version = "0.2.17"
 description = "DSH Desktop — community desktop packaging of DeepSeek Harness"
 edition = "2021"
 license = "MIT"
@@ -39,7 +39,7 @@ getrandom = "0.4"
 # SAME process-tree guarantees (unix process group / Windows Job Object).
 # The version must stay in lockstep with crates/dsh-sidecar/Cargo.toml —
 # cargo-deny treats a version-less path dep as a wildcard, so it is pinned.
-dsh-sidecar = { path = "../crates/dsh-sidecar", version = "0.2.5" }
+dsh-sidecar = { path = "../crates/dsh-sidecar", version = "0.2.6" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 semver = "1"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "DSH Desktop",
-  "version": "0.2.16",
+  "version": "0.2.17",
   "identifier": "com.yeagoo.dsh-desktop",
   "build": {
     "beforeDevCommand": "pnpm dev",

--- a/src/app.css
+++ b/src/app.css
@@ -1,4 +1,8 @@
 :root {
+  /* The controller is intentionally dark. Tell native WebKitGTK form
+   * controls too; otherwise a light GTK select surface can combine with our
+   * light text token and make its selected value unreadable. */
+  color-scheme: dark;
   --bg: #0d1117;
   --panel: #141a23;
   --panel-2: #1a212d;
@@ -15,6 +19,20 @@
 
 * {
   box-sizing: border-box;
+}
+
+/* WebKitGTK renders select popovers through native controls. Keep their
+ * color-scheme and fallback option colors aligned with the controller rather
+ * than relying on CSS inheritance that varies by Linux desktop theme. */
+select {
+  color-scheme: dark;
+  color: var(--text);
+  background-color: var(--panel-2);
+}
+
+select option {
+  color: var(--text);
+  background-color: var(--panel-2);
 }
 
 html,

--- a/tests/frontend/native-control-theme.test.ts
+++ b/tests/frontend/native-control-theme.test.ts
@@ -1,0 +1,28 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+const css = readFileSync(new URL("../../src/app.css", import.meta.url), "utf8");
+const controller = readFileSync(new URL("../../src/App.svelte", import.meta.url), "utf8");
+
+test("controller native selects preserve readable dark contrast on WebKitGTK", () => {
+  assert.match(css, /^:root\s*\{[^}]*color-scheme:\s*dark;/m);
+  assert.match(
+    css,
+    /^select\s*\{[^}]*color-scheme:\s*dark;[^}]*color:\s*var\(--text\);[^}]*background-color:\s*var\(--panel-2\);/m,
+  );
+  assert.match(
+    css,
+    /^select option\s*\{[^}]*color:\s*var\(--text\);[^}]*background-color:\s*var\(--panel-2\);/m,
+  );
+  assert.match(
+    controller,
+    /<select\b[^>]*value=\{localePreference\}[^>]*aria-label=\{t\("locale\.label"\)\}[^>]*>/,
+    "the language selector must inherit the native-select contract",
+  );
+  assert.match(
+    controller,
+    /<select\b[^>]*class="plugin-input"[^>]*bind:value=\{marketCategory\}[^>]*aria-label=\{t\("market\.categoryLabel"\)\}[^>]*>/,
+    "the marketplace category selector must inherit the native-select contract",
+  );
+});


### PR DESCRIPTION
## Summary
- declare the read-only `network-status` interface required by WebKitGTK/GLib when `GTK_USE_PORTAL=1`
- make source recipe, generated package metadata, and both native Snap CI checks fail closed if the interface is absent
- set the controller native form-control color scheme to dark so the language and marketplace selectors remain readable under WebKitGTK

## Validation
- `pnpm check`
- `pnpm check:scripts`
- `pnpm test:scripts` (119 passed)
- `pnpm test:frontend` (18 passed)
- `pnpm build`
- `pnpm snap:definition`
- `pnpm release:preflight`
- `pnpm verify:command-contract`
- `actionlint .github/workflows/snap.yml`