### PR TITLE
docs: add bilingual changelog through v0.2.18

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,104 @@
+# Changelog
+
+This file records user-facing DSH Desktop changes. For immutable release
+assets, checksums, and the full technical record, use the linked GitHub
+Release for each version.
+
+Chinese edition: [CHANGELOG.zh-CN.md](CHANGELOG.zh-CN.md).
+
+## [0.2.18] — 2026-08-27
+
+### AppImage desktop runtime compatibility
+
+- Stops bundling build-host Wayland, GLib, GIO, and nghttp2 ABI libraries in
+  AppImages, allowing the application to use the compatible desktop libraries
+  supplied by the target Linux system.
+- Bundles the GStreamer plugins required by the embedded WebView.
+- Preserves an explicitly selected GTK backend while retaining X11 as the
+  default fallback for broader AppImage compatibility.
+- Packages official, unmodified DeepSeek Harness `0.1.1-rc.2`, Node.js
+  `24.19.0`, and `dsh-sidecar` `0.2.7`.
+
+**Release:** [v0.2.18](https://github.com/web-casa/DeepSeek-Harness-Desktop/releases/tag/v0.2.18)
+
+## [0.2.17] — 2026-08-24
+
+### Strict Snap access restored
+
+- Restores the desktop-portal access required by the embedded Harness inside a
+  strictly confined Snap, so it can interact with the desktop session without
+  weakening confinement.
+- Fixes native select contrast in the controller, including language choices.
+- Packages official, unmodified DeepSeek Harness `0.1.1-rc.2`, Node.js
+  `24.19.0`, and `dsh-sidecar` `0.2.6`.
+
+**Release:** [v0.2.17](https://github.com/web-casa/DeepSeek-Harness-Desktop/releases/tag/v0.2.17)
+
+## [0.2.16] — 2026-08-24
+
+### Strict Snap Store distribution
+
+- Introduces the strict Snap package definition and its reviewed desktop
+  interface policy.
+- Adds package, runner, and artifact verification for the Snap release path.
+- Adds Windows runtime prerequisite guidance and refreshed product screenshots.
+
+**Release:** [v0.2.16](https://github.com/web-casa/DeepSeek-Harness-Desktop/releases/tag/v0.2.16)
+
+## [0.2.15] — 2026-08-23
+
+### Published checksum audit
+
+- Makes release publication fail closed when a public GitHub asset name or its
+  reported SHA-256 digest differs from the reviewed artifact.
+- Prevents a checksum sidecar from being published under a filename that cannot
+  verify the downloaded asset.
+
+> v0.2.15 supersedes v0.2.14 for downloads. Use this version or a newer release
+> when verifying checksums.
+
+**Release:** [v0.2.15](https://github.com/web-casa/DeepSeek-Harness-Desktop/releases/tag/v0.2.15)
+
+## [0.2.14] — 2026-08-23
+
+### Native multi-architecture release line
+
+- Adds native Windows x64/arm64, macOS x64/arm64, and Linux x64/arm64 release
+  targets, with architecture checks for bundled Node.js and `node-pty`.
+- Repairs Windows installer runtime and deep-link smoke coverage.
+- Updates the bundled official Harness to `0.1.1-rc.2` and hardens install
+  arbitration and CodeQL coverage.
+
+> The package bytes and digests are valid, but GitHub-normalized filenames made
+> the v0.2.14 checksum sidecars impractical to use. Download v0.2.15 or later
+> instead.
+
+**Release:** [v0.2.14](https://github.com/web-casa/DeepSeek-Harness-Desktop/releases/tag/v0.2.14)
+
+## [0.2.13] — 2026-08-22
+
+### Localized controller and safer tray shortcuts
+
+- Adds Simplified Chinese and English dictionaries, system-language detection,
+  manual selection, and a persisted language preference.
+- Keeps the controller title, tray, and native macOS menu synchronized with the
+  selected language.
+- Adds state-gated tray shortcuts to open the controller or Harness, start or
+  restart, stop, and quit.
+- Updates audited `pnpm`, `getrandom`, `zip`, and `reqwest` dependencies while
+  retaining the Rust `ring` TLS provider.
+
+**Release:** [v0.2.13](https://github.com/web-casa/DeepSeek-Harness-Desktop/releases/tag/v0.2.13)
+
+## [0.2.12] — 2026-08-22
+
+### Safer plugin lifecycle recovery
+
+- Fixes Windows PATH handling so every path segment is preserved when the
+  bundled `pnpm` shim is placed first.
+- Hardens plugin installation, activation, removal, process cleanup, and
+  recovery behavior.
+- Normalizes verbatim Node launch paths so the bundled runtime starts reliably
+  from Windows installation paths.
+
+**Release:** [v0.2.12](https://github.com/web-casa/DeepSeek-Harness-Desktop/releases/tag/v0.2.12)

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -1,0 +1,89 @@
+# 更新日志
+
+本文记录 DSH Desktop 面向用户的变更。每个版本的不可变安装包、校验和和完整
+技术记录，请查看对应的 GitHub Release。
+
+English edition: [CHANGELOG.md](CHANGELOG.md).
+
+## [0.2.18] — 2026-08-27
+
+### AppImage 桌面运行时兼容性
+
+- 不再把构建主机的 Wayland、GLib、GIO 和 nghttp2 ABI 库打入 AppImage，改用
+  目标 Linux 系统提供的兼容桌面库。
+- 打包内嵌 WebView 所需的 GStreamer 插件。
+- 保留用户显式选择的 GTK 后端，同时继续以 X11 作为兼容性更广的默认回退。
+- 打包官方、未修改的 DeepSeek Harness `0.1.1-rc.2`、Node.js `24.19.0` 和
+  `dsh-sidecar` `0.2.7`。
+
+**发布：** [v0.2.18](https://github.com/web-casa/DeepSeek-Harness-Desktop/releases/tag/v0.2.18)
+
+## [0.2.17] — 2026-08-24
+
+### 恢复严格 Snap 的桌面门户访问
+
+- 恢复严格受限 Snap 中内置 Harness 所需的桌面门户访问，使其无需削弱沙箱即可
+  与桌面会话协作。
+- 修复控制器的原生下拉选项对比度，包括语言选择项。
+- 打包官方、未修改的 DeepSeek Harness `0.1.1-rc.2`、Node.js `24.19.0` 和
+  `dsh-sidecar` `0.2.6`。
+
+**发布：** [v0.2.17](https://github.com/web-casa/DeepSeek-Harness-Desktop/releases/tag/v0.2.17)
+
+## [0.2.16] — 2026-08-24
+
+### 严格 Snap Store 发行支持
+
+- 引入严格 Snap 包定义及其经审查的桌面接口策略。
+- 为 Snap 发布链路新增包、runner 和产物验证。
+- 补充 Windows 运行时前置条件说明，并更新产品截图。
+
+**发布：** [v0.2.16](https://github.com/web-casa/DeepSeek-Harness-Desktop/releases/tag/v0.2.16)
+
+## [0.2.15] — 2026-08-23
+
+### 公开校验和审计
+
+- 当公开 GitHub 产物名称或其返回的 SHA-256 摘要与已审查产物不一致时，发布
+  流程将失败关闭。
+- 防止校验和侧车文件以无法校验已下载产物的名称发布。
+
+> v0.2.15 已取代 v0.2.14 的下载推荐；校验文件时请使用本版本或更新版本。
+
+**发布：** [v0.2.15](https://github.com/web-casa/DeepSeek-Harness-Desktop/releases/tag/v0.2.15)
+
+## [0.2.14] — 2026-08-23
+
+### 原生多架构发布线
+
+- 新增 Windows x64/arm64、macOS x64/arm64 和 Linux x64/arm64 原生发布目标，
+  并校验内置 Node.js 与 `node-pty` 的架构。
+- 修复 Windows 安装器运行时和 deep-link 冒烟覆盖。
+- 将内置官方 Harness 升级到 `0.1.1-rc.2`，并加强安装仲裁和 CodeQL 覆盖。
+
+> 安装包字节和摘要有效，但 GitHub 规范化文件名使 v0.2.14 校验和侧车文件难以
+> 直接使用；请改用 v0.2.15 或更新版本。
+
+**发布：** [v0.2.14](https://github.com/web-casa/DeepSeek-Harness-Desktop/releases/tag/v0.2.14)
+
+## [0.2.13] — 2026-08-22
+
+### 控制器本地化与更安全的托盘快捷项
+
+- 新增简体中文和英文词典、系统语言检测、手动选择与语言偏好持久化。
+- 让控制器标题、托盘和 macOS 原生菜单与所选语言同步。
+- 新增受状态门禁保护的“打开控制器或 Harness、启动或重启、停止、退出”快捷项。
+- 更新已审计的 `pnpm`、`getrandom`、`zip` 和 `reqwest` 依赖，同时保留 Rust
+  `ring` TLS 提供者。
+
+**发布：** [v0.2.13](https://github.com/web-casa/DeepSeek-Harness-Desktop/releases/tag/v0.2.13)
+
+## [0.2.12] — 2026-08-22
+
+### 更安全的插件生命周期恢复
+
+- 修复 Windows PATH 处理问题：内置 `pnpm` shim 前置后，仍会保留每一个路径段。
+- 加强插件安装、激活、卸载、进程清理和恢复行为。
+- 规范化 Node 的 verbatim 启动路径，使内置运行时能从 Windows 安装路径可靠启动。
+
+**发布：** [v0.2.12](https://github.com/web-casa/DeepSeek-Harness-Desktop/releases/tag/v0.2.12)

--- a/README.en.md
+++ b/README.en.md
@@ -12,7 +12,7 @@ intact; the desktop layer only handles lifecycle and the security boundary.
 | Downloads | [Releases](https://github.com/web-casa/DeepSeek-Harness-Desktop/releases) |
 | Website | [dsharness.app](https://dsharness.app) |
 | Plugin marketplace | [cordis.run](https://cordis.run) |
-| Docs | [SECURITY](SECURITY.md) · [FORKING](FORKING.md) · [RELEASING](RELEASING.md) · [AGENTS](AGENTS.md) |
+| Docs | [Changelog](CHANGELOG.md) · [中文更新日志](CHANGELOG.zh-CN.md) · [SECURITY](SECURITY.md) · [FORKING](FORKING.md) · [RELEASING](RELEASING.md) · [AGENTS](AGENTS.md) |
 | Current version | v0.2.18 · Windows x64/ARM64 EXE/MSI · macOS x64/arm64 DMG · Linux x64/arm64 AppImage/DEB/RPM/Flatpak · [now on the Snap Store](https://snapcraft.io/dsh-desktop-community) · signed/notarized macOS · [中文](README.md) |
 
 > **macOS users**: starting with v0.2.9, DMGs are signed with Developer ID

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 | 下载 | [Releases](https://github.com/web-casa/DeepSeek-Harness-Desktop/releases) |
 | 官网 | [dsharness.app](https://dsharness.app) |
 | 插件市场 | [cordis.run](https://cordis.run) |
-| 文档 | [SECURITY](SECURITY.md) · [FORKING](FORKING.md) · [RELEASING](RELEASING.md) · [AGENTS](AGENTS.md) |
+| 文档 | [更新日志](CHANGELOG.zh-CN.md) · [English changelog](CHANGELOG.md) · [SECURITY](SECURITY.md) · [FORKING](FORKING.md) · [RELEASING](RELEASING.md) · [AGENTS](AGENTS.md) |
 | 当前版本 | v0.2.18 · Windows x64/ARM64 EXE/MSI · macOS x64/arm64 DMG · Linux x64/arm64 AppImage/DEB/RPM/Flatpak · [Snap Store 已正式发布](https://snapcraft.io/dsh-desktop-community) · macOS 已签名/公证 · [English](README.en.md) |
 
 > **macOS 用户**：v0.2.9 起，DMG 使用 Developer ID Application 签名并经


### PR DESCRIPTION
## Summary
- add English and Simplified Chinese root changelogs for v0.2.12-v0.2.18
- link both editions from the repository READMEs without regressing current v0.2.18 or public Snap Store status
- document the v0.2.14 checksum-sidecar supersession and v0.2.18 AppImage runtime repair

## Verification
- `pnpm release:preflight`
- `pnpm check:scripts`
- `pnpm test:scripts` (125 passed)
- Markdown local-link and bilingual-version alignment check
- `git diff --check`