### PR TITLE
ci: upgrade CodeQL action to v4

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -29,16 +29,16 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1 (SHA-pinned)
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@f3712979fa5f215279b101dd0a2e3bdfb4353324  # v3 (SHA-pinned, peeled commit)
+        uses: github/codeql-action/init@cdf488f595d80d6e07e03d4674febd5ab45fa938  # v4.37.9 (SHA-pinned)
         with:
           languages: ${{ matrix.language }}
           queries: security-extended,security-and-quality
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@f3712979fa5f215279b101dd0a2e3bdfb4353324  # v3 (SHA-pinned, peeled commit)
+        uses: github/codeql-action/autobuild@cdf488f595d80d6e07e03d4674febd5ab45fa938  # v4.37.9 (SHA-pinned)
 
       - name: Perform CodeQL analysis
-        uses: github/codeql-action/analyze@f3712979fa5f215279b101dd0a2e3bdfb4353324  # v3 (SHA-pinned, peeled commit)
+        uses: github/codeql-action/analyze@cdf488f595d80d6e07e03d4674febd5ab45fa938  # v4.37.9 (SHA-pinned)
 
   analyze-rust:
     name: Analyze (Rust)
@@ -48,7 +48,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1 (SHA-pinned)
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@f3712979fa5f215279b101dd0a2e3bdfb4353324  # v3 (SHA-pinned, peeled commit)
+        uses: github/codeql-action/init@cdf488f595d80d6e07e03d4674febd5ab45fa938  # v4.37.9 (SHA-pinned)
         with:
           languages: rust
 
@@ -91,4 +91,4 @@ jobs:
           cargo build --locked --manifest-path src-tauri/Cargo.toml
 
       - name: Perform CodeQL analysis
-        uses: github/codeql-action/analyze@f3712979fa5f215279b101dd0a2e3bdfb4353324  # v3 (SHA-pinned, peeled commit)
+        uses: github/codeql-action/analyze@cdf488f595d80d6e07e03d4674febd5ab45fa938  # v4.37.9 (SHA-pinned)

--- a/scripts/lib/workflow-safety.test.ts
+++ b/scripts/lib/workflow-safety.test.ts
@@ -25,6 +25,16 @@ test("Rust CodeQL compiles both the sidecar and the Tauri security boundary", ()
   assert.match(codeqlWorkflow, /mkdir -p src-tauri\/resources\/runtime/);
 });
 
+test("CodeQL actions use one SHA-pinned v4 release", () => {
+  const actions = [...codeqlWorkflow.matchAll(
+    /uses: github\/codeql-action\/(?:init|autobuild|analyze)@([0-9a-f]{40})\s+# v(4\.[0-9]+\.[0-9]+) \(SHA-pinned\)/g,
+  )];
+  assert.equal(actions.length, 5);
+  assert.equal(new Set(actions.map((match) => match[1])).size, 1);
+  assert.equal(new Set(actions.map((match) => match[2])).size, 1);
+  assert.doesNotMatch(codeqlWorkflow, /github\/codeql-action\/[^@\s]+@v[0-9]/);
+});
+
 test("macOS shell path gate validates event SHAs and fails closed", () => {
   const start = workflow.indexOf("      - name: Detect macOS shell changes");
   const end = workflow.indexOf("      # The exact P0 acceptance chain", start);


### PR DESCRIPTION
## Review finding
The final main-branch review surfaced GitHub annotations that CodeQL Action v3 will be deprecated in December 2026 and still targets the deprecated Node 20 action runtime.

## Fix
- upgrade all CodeQL init/autobuild/analyze steps to official v4.37.9
- pin the verified upstream commit cdf488f595d80d6e07e03d4674febd5ab45fa938
- add a workflow contract test requiring all five CodeQL steps to use one SHA-pinned v4 release

## Verification
- upstream commit signature verified through the GitHub API
- upstream init action declares node24 and retains the languages/queries inputs used here
- pnpm check:scripts
- pnpm test:scripts (127 passed)
- git diff --check